### PR TITLE
Use sudo for Deployment Scripts

### DIFF
--- a/scripts/install/deps.sh
+++ b/scripts/install/deps.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-pip3 install sparkpost
+sudo pip3 install sparkpost


### PR DESCRIPTION
According to past builds, we need to use `sudo` when we `pip install` in our deploy scripts.
- [x] Adds sudo to deployment scripts

It's difficult to tell if this will work, so later related PRs may follow.