### PR TITLE
Allow Contact Info Change for OAuth Users

### DIFF
--- a/api.js
+++ b/api.js
@@ -2,7 +2,7 @@ const express = require('express');
 const requid = require('cuid');
 const helmet = require('helmet');
 
-const ctx = require("ctx");
+const ctx = require('ctx');
 const config = ctx.config();
 const logger = ctx.logger();
 

--- a/api/v1/controllers/UserController.js
+++ b/api/v1/controllers/UserController.js
@@ -86,6 +86,16 @@ function requestPasswordReset(req, res, next) {
     .catch((error) => next(error));
 }
 
+function updateContactInfo(req, res, next) {
+  req.user.updateContactInfo(req.body.newEmail)
+  .then((result) => {
+    res.body = result.toJSON();
+
+    return next();
+  })
+  .catch((error) => next(error));
+}
+
 router.use(bodyParser.json());
 router.use(middleware.auth);
 
@@ -96,6 +106,8 @@ router.post('/accredited', middleware.request(requests.AccreditedUserCreationReq
 router.post('/reset', middleware.request(requests.ResetTokenRequest), requestPasswordReset);
 router.get('/:id(\\d+)', middleware.permission(roles.HOSTS, isRequester), getUser);
 router.get('/email/:email', middleware.permission(roles.HOSTS), getUserByEmail);
+router.put('/contactinfo', middleware.permission(roles.NONE),
+  middleware.request(requests.UserContactInfoRequest), updateContactInfo);
 
 router.use(middleware.response);
 router.use(middleware.errors);

--- a/api/v1/controllers/UserController.js
+++ b/api/v1/controllers/UserController.js
@@ -20,6 +20,10 @@ function isRequester(req) {
   return req.user.get('id') == req.params.id;
 }
 
+function isAuthenticated(req) {
+  return req.auth && (req.user !== undefined);
+}
+
 function createUser(req, res, next) {
   services.UserService
     .createUser(req.body.email, req.body.password)
@@ -106,7 +110,8 @@ router.post('/accredited', middleware.request(requests.AccreditedUserCreationReq
 router.post('/reset', middleware.request(requests.ResetTokenRequest), requestPasswordReset);
 router.get('/:id(\\d+)', middleware.permission(roles.HOSTS, isRequester), getUser);
 router.get('/email/:email', middleware.permission(roles.HOSTS), getUserByEmail);
-router.put('/contactinfo', middleware.request(requests.UserContactInfoRequest), updateContactInfo);
+router.put('/contactinfo', middleware.request(requests.UserContactInfoRequest),
+  middleware.permission(roles.NONE, isAuthenticated), updateContactInfo);
 
 router.use(middleware.response);
 router.use(middleware.errors);

--- a/api/v1/controllers/UserController.js
+++ b/api/v1/controllers/UserController.js
@@ -87,7 +87,7 @@ function requestPasswordReset(req, res, next) {
 }
 
 function updateContactInfo(req, res, next) {
-  req.user.updateContactInfo(req.body.newEmail)
+  services.UserService.updateContactInfo(req.user, req.body.newEmail)
   .then((result) => {
     res.body = result.toJSON();
 
@@ -106,8 +106,7 @@ router.post('/accredited', middleware.request(requests.AccreditedUserCreationReq
 router.post('/reset', middleware.request(requests.ResetTokenRequest), requestPasswordReset);
 router.get('/:id(\\d+)', middleware.permission(roles.HOSTS, isRequester), getUser);
 router.get('/email/:email', middleware.permission(roles.HOSTS), getUserByEmail);
-router.put('/contactinfo', middleware.permission(roles.NONE),
-  middleware.request(requests.UserContactInfoRequest), updateContactInfo);
+router.put('/contactinfo', middleware.request(requests.UserContactInfoRequest), updateContactInfo);
 
 router.use(middleware.response);
 router.use(middleware.errors);

--- a/api/v1/models/User.js
+++ b/api/v1/models/User.js
@@ -187,7 +187,7 @@ User.prototype.hasPassword = function(password) {
     });
 };
 
-User.prototype.updateContactInfo = function(newEmail) {
+User.prototype.setContactInfo = function(newEmail) {
   this.set({
     email: newEmail
   });

--- a/api/v1/models/User.js
+++ b/api/v1/models/User.js
@@ -3,7 +3,6 @@
 const _Promise = require('bluebird');
 const bcrypt = _Promise.promisifyAll(require('bcrypt'));
 const _ = require('lodash');
-const UnprocessableRequestError = require('../errors/UnprocessableRequestError');
 
 const SALT_ROUNDS = 12;
 

--- a/api/v1/models/User.js
+++ b/api/v1/models/User.js
@@ -3,6 +3,7 @@
 const _Promise = require('bluebird');
 const bcrypt = _Promise.promisifyAll(require('bcrypt'));
 const _ = require('lodash');
+const UnprocessableRequestError = require('../errors/UnprocessableRequestError');
 
 const SALT_ROUNDS = 12;
 
@@ -185,6 +186,17 @@ User.prototype.hasPassword = function(password) {
     .then(function() {
       return bcrypt.compareAsync(password, this.get('password'));
     });
+};
+
+User.prototype.updateContactInfo = function(newEmail) {
+  if(!_.isNull(this.get('password'))) {
+    const message = 'Cannot update the contact info of a Basic user';
+    throw new UnprocessableRequestError(message);
+  }
+
+  return _Promise.resolve(this.set({
+    email: newEmail
+  }));
 };
 
 /**

--- a/api/v1/models/User.js
+++ b/api/v1/models/User.js
@@ -189,14 +189,11 @@ User.prototype.hasPassword = function(password) {
 };
 
 User.prototype.updateContactInfo = function(newEmail) {
-  if(!_.isNull(this.get('password'))) {
-    const message = 'Cannot update the contact info of a Basic user';
-    throw new UnprocessableRequestError(message);
-  }
-
-  return _Promise.resolve(this.set({
+  this.set({
     email: newEmail
-  }));
+  });
+
+  return this.save();
 };
 
 /**

--- a/api/v1/requests/UserContactInfoRequest.js
+++ b/api/v1/requests/UserContactInfoRequest.js
@@ -1,8 +1,8 @@
 const Request = require('./Request');
 
-const bodyRequired = [ 'email' ];
+const bodyRequired = [ 'newEmail' ];
 const bodyValidations = {
-  'email': [ 'email' ]
+  'newEmail': [ 'email' ]
 };
 
 function UserContactInfoRequest(headers, body) {

--- a/api/v1/requests/UserContactInfoRequest.js
+++ b/api/v1/requests/UserContactInfoRequest.js
@@ -1,0 +1,18 @@
+const Request = require('./Request');
+
+const bodyRequired = [ 'email' ];
+const bodyValidations = {
+  'email': [ 'email' ]
+};
+
+function UserContactInfoRequest(headers, body) {
+  Request.call(this, headers, body);
+
+  this.bodyRequired = bodyRequired;
+  this.bodyValidations = bodyValidations;
+}
+
+UserContactInfoRequest.prototype = Object.create(Request.prototype);
+UserContactInfoRequest.prototype.constructor = UserContactInfoRequest;
+
+module.exports = UserContactInfoRequest;

--- a/api/v1/requests/index.js
+++ b/api/v1/requests/index.js
@@ -16,5 +16,6 @@ module.exports = {
   UploadRequest: require('./UploadRequest'),
   CheckInRequest: require('./CheckInRequest'),
   RSVPRequest: require('./RSVPRequest'),
-  UniversalTrackingRequest: require('./UniversalTrackingRequest')
+  UniversalTrackingRequest: require('./UniversalTrackingRequest'),
+  UserContactInfoRequest: require('./UserContactInfoRequest')
 };

--- a/api/v1/services/AuthService.js
+++ b/api/v1/services/AuthService.js
@@ -7,7 +7,7 @@ const StatusCodeError = require('request-promise/errors').StatusCodeError;
 const jwt = require('jsonwebtoken');
 const _ = require('lodash');
 
-const ctx = require("ctx");
+const ctx = require('ctx');
 
 const config = ctx.config();
 const errors = require('../errors');
@@ -72,10 +72,10 @@ module.exports.verify = (token) => _Promise.try(() =>
 module.exports.getGitHubSessionCodeURL = (isMobile) => {
   if (!_.isUndefined(isMobile)) {
     return GITHUB_AUTH_REDIRECT + config.auth.github.id + '&redirect_uri=' + config.auth.github.mobileRedirect;
-  } else {
-    return GITHUB_AUTH_REDIRECT + config.auth.github.id;
-  }
-}
+  } 
+  return GITHUB_AUTH_REDIRECT + config.auth.github.id;
+  
+};
 
 module.exports.requestGitHubAccessToken = (code) => {
   let token;

--- a/api/v1/services/MailService.js
+++ b/api/v1/services/MailService.js
@@ -9,7 +9,7 @@ const _Promise = require('bluebird');
 const SparkPost = require('sparkpost');
 const _ = require('lodash');
 
-const ctx = require("ctx");
+const ctx = require('ctx');
 const config = ctx.config();
 const logger = ctx.logger();
 const files = require('../../files');

--- a/api/v1/services/UserService.js
+++ b/api/v1/services/UserService.js
@@ -125,5 +125,11 @@ module.exports.setContactInfo = (user, newEmail) => {
     throw new errors.InvalidParameterError(message, source);
   }
 
+  if(!_.isNull(user.get('password'))) {
+    const message = 'Cannot update the contact info of a Basic user';
+    const source = 'user';
+    throw new UnprocessableRequestError(message, source);
+  }
+
   return user.setContactInfo(newEmail);
 };

--- a/api/v1/services/UserService.js
+++ b/api/v1/services/UserService.js
@@ -117,3 +117,13 @@ module.exports.verifyPassword = (user, password) => user
 module.exports.resetPassword = (user, password) => user
     .setPassword(password)
     .then((updated) => updated.save());
+
+module.exports.setContactInfo = (user, newEmail) => {
+  if(user.get('email') !== newEmail) {
+    const message = 'A user can only change their own contact info';
+    const source = 'email';
+    throw new errors.InvalidParameterError(message, source);
+  }
+
+  return user.setContactInfo(newEmail);
+};

--- a/api/v1/services/UserService.js
+++ b/api/v1/services/UserService.js
@@ -128,7 +128,7 @@ module.exports.setContactInfo = (user, newEmail) => {
   if(!_.isNull(user.get('password'))) {
     const message = 'Cannot update the contact info of a Basic user';
     const source = 'user';
-    throw new UnprocessableRequestError(message, source);
+    throw new errors.UnprocessableRequestError(message, source);
   }
 
   return user.setContactInfo(newEmail);

--- a/api/v1/services/UserService.js
+++ b/api/v1/services/UserService.js
@@ -118,13 +118,7 @@ module.exports.resetPassword = (user, password) => user
     .setPassword(password)
     .then((updated) => updated.save());
 
-module.exports.setContactInfo = (user, newEmail) => {
-  if(user.get('email') !== newEmail) {
-    const message = 'A user can only change their own contact info';
-    const source = 'email';
-    throw new errors.InvalidParameterError(message, source);
-  }
-
+module.exports.updateContactInfo = (user, newEmail) => {
   if(!_.isNull(user.get('password'))) {
     const message = 'Cannot update the contact info of a Basic user';
     const source = 'user';

--- a/docs/User-Documentation.md
+++ b/docs/User-Documentation.md
@@ -233,7 +233,7 @@ Response
   "meta": null,
   "data": {
 	"id": 1,
-	"email": "new@example.com",
+	"email": "newemail@example.com",
 	"created": "2016-06-19T00:01:00.000Z",
 	"updated": "2016-06-19T00:01:00.000Z",
         "roles": [{
@@ -248,6 +248,6 @@ Errors:
 
 | Error         | Source  | Cause                                           |
 |---------------|---------|-------------------------------------------------|
-| NotFoundError | `email` | A user with the given email could not be found. |
+| UnprocessableRequestError | `user` | Users under a basic authentication scheme can not change their contact info |
 
 ---

--- a/docs/User-Documentation.md
+++ b/docs/User-Documentation.md
@@ -68,8 +68,8 @@ Request Parameters <br />
 
 Role Values <br />
 
-| ROLE | Who are part of the role | 
-| ---------------- | --------------------- | 
+| ROLE | Who are part of the role |
+| ---------------- | --------------------- |
 | `ALL` | `ADMIN, STAFF, SPONSOR, MENTOR, VOLUNTEER, ATTENDEE`|
 | `SUPERUSER ` | `ADMIN` |
 | `ORGANIZERS ` | `ADMIN, STAFF` |
@@ -189,6 +189,58 @@ Response
 {
     "meta":null,
     "data":{}
+}
+```
+
+Errors:
+
+| Error         | Source  | Cause                                           |
+|---------------|---------|-------------------------------------------------|
+| NotFoundError | `email` | A user with the given email could not be found. |
+
+---
+
+**PUT /v1/user/contactinfo**
+
+Allows a user created with the GitHub OAuth authentication scheme to change their contact email if they do not want to use their primary GitHub email as their contact email.
+
+Headers
+
+None
+
+URL Parameters
+
+None
+
+Request Parameters
+
+| Parameters | Description                             | Required |
+|------------|-----------------------------------------|----------|
+| `newEmail` | The new email the user wishes to use as their contact info  | Yes      |
+
+Request
+
+```
+{
+    "email": "newemail@example.com"
+}
+```
+
+Response
+
+```
+{
+  "meta": null,
+  "data": {
+	"id": 1,
+	"email": "new@example.com",
+	"created": "2016-06-19T00:01:00.000Z",
+	"updated": "2016-06-19T00:01:00.000Z",
+        "roles": [{
+          "role": "ATTENDEE",
+          "active": 1
+        }],
+  }
 }
 ```
 


### PR DESCRIPTION
Some attendees may not wish to use their primary github email address as their hackillinois email. This endpoint serves to address this issue

- [x] Contact info change endpoint
- [x] Update Documentation