### PR TITLE
Fix build-essential installation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We highly reccommend that you use Ubuntu 16.04 or Ubuntu 18.04 when working on A
 Both `make` and `git` can be installed from the default ubuntu package repositories. Run the following commands to install both tools. You may need to run the commands under `sudo`.
 ```
 apt-get update
-apt-get install build-essentials git
+apt-get install build-essential git
 ```
 
 #### Installing Go


### PR DESCRIPTION
Changed "build-essentials" to "build-essential".