### PR TITLE
[WIP] Add apirequest package to common; Fix socket leaks

### DIFF
--- a/common/apirequest/apirequest.go
+++ b/common/apirequest/apirequest.go
@@ -11,6 +11,8 @@ const (
 	Timeout int64 = 10
 )
 
+var Identity = ""
+
 /*
 	Executes an API request and populates the data with the response
 */
@@ -73,9 +75,19 @@ func doRequest(method string, url string, payload *interface{}, data *interface{
 
 	req, err := http.NewRequest(method, url, body)
 
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("HackIllinois-Identity", Identity)
+
 	if err != nil {
 		return -1, err
 	}
 
 	return Do(req, data)
+}
+
+/*
+	Set the identity to place into HackIllinois-Identity when making requests
+*/
+func SetIdentity(identity string) {
+	Identity = identity
 }

--- a/common/apirequest/apirequest.go
+++ b/common/apirequest/apirequest.go
@@ -68,21 +68,25 @@ func Delete(url string, data interface{}) (int, error) {
 	Builds a request, executes it, and then decodes the response into data
 */
 func doRequest(method string, url string, payload interface{}, data interface{}) (int, error) {
-	var body *bytes.Buffer
+	var req *http.Request
+	var err error
 
 	if payload != nil {
-		body = &bytes.Buffer{}
-		json.NewEncoder(body).Encode(payload)
+		var body bytes.Buffer
+		json.NewEncoder(&body).Encode(payload)
+
+		req, err = http.NewRequest(method, url, &body)
+	} else {
+		req, err = http.NewRequest(method, url, nil)
 	}
-
-	req, err := http.NewRequest(method, url, body)
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("HackIllinois-Identity", Identity)
 
 	if err != nil {
 		return -1, err
 	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("HackIllinois-Identity", Identity)
+
 
 	return Do(req, data)
 }

--- a/common/apirequest/apirequest.go
+++ b/common/apirequest/apirequest.go
@@ -16,7 +16,7 @@ var Identity = ""
 /*
 	Executes an API request and populates the data with the response
 */
-func Do(req *http.Request, data *interface{}) (int, error) {
+func Do(req *http.Request, data interface{}) (int, error) {
 	client := http.Client{
 		Timeout: time.Duration(Timeout) * time.Second,
 	}
@@ -39,35 +39,35 @@ func Do(req *http.Request, data *interface{}) (int, error) {
 /*
 	Executes an API GET request and populates the data with the response
 */
-func Get(url string, data *interface{}) (int, error) {
+func Get(url string, data interface{}) (int, error) {
 	return doRequest("GET", url, nil, data)
 }
 
 /*
 	Executes an API POST request and populates the data with the response
 */
-func Post(url string, payload *interface{}, data *interface{}) (int, error) {
+func Post(url string, payload interface{}, data interface{}) (int, error) {
 	return doRequest("POST", url, payload, data)
 }
 
 /*
 	Executes an API PUT request and populates the data with the response
 */
-func Put(url string, payload *interface{}, data *interface{}) (int, error) {
+func Put(url string, payload interface{}, data interface{}) (int, error) {
 	return doRequest("PUT", url, payload, data)
 }
 
 /*
 	Executes an API DELETE request and populates the data with the response
 */
-func Delete(url string, data *interface{}) (int, error) {
+func Delete(url string, data interface{}) (int, error) {
 	return doRequest("DELETE", url, nil, data)
 }
 
 /*
 	Builds a request, executes it, and then decodes the response into data
 */
-func doRequest(method string, url string, payload *interface{}, data *interface{}) (int, error) {
+func doRequest(method string, url string, payload interface{}, data interface{}) (int, error) {
 	var body *bytes.Buffer
 
 	if payload != nil {

--- a/common/apirequest/apirequest.go
+++ b/common/apirequest/apirequest.go
@@ -29,7 +29,9 @@ func Do(req *http.Request, data *interface{}) (int, error) {
 
 	defer resp.Body.Close()
 
-	json.NewDecoder(resp.Body).Decode(data)
+	if data != nil {
+		json.NewDecoder(resp.Body).Decode(data)
+	}
 
 	return resp.StatusCode, nil
 }

--- a/common/apirequest/apirequest.go
+++ b/common/apirequest/apirequest.go
@@ -1,0 +1,81 @@
+package apirequest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+const (
+	Timeout int64 = 10
+)
+
+/*
+	Executes an API request and populates the data with the response
+*/
+func Do(req *http.Request, data *interface{}) (int, error) {
+	client := http.Client{
+		Timeout: time.Duration(Timeout) * time.Second,
+	}
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return -1, err
+	}
+
+	defer resp.Body.Close()
+
+	json.NewDecoder(resp.Body).Decode(data)
+
+	return resp.StatusCode, nil
+}
+
+/*
+	Executes an API GET request and populates the data with the response
+*/
+func Get(url string, data *interface{}) (int, error) {
+	return doRequest("GET", url, nil, data)
+}
+
+/*
+	Executes an API POST request and populates the data with the response
+*/
+func Post(url string, payload *interface{}, data *interface{}) (int, error) {
+	return doRequest("POST", url, payload, data)
+}
+
+/*
+	Executes an API PUT request and populates the data with the response
+*/
+func Put(url string, payload *interface{}, data *interface{}) (int, error) {
+	return doRequest("PUT", url, payload, data)
+}
+
+/*
+	Executes an API DELETE request and populates the data with the response
+*/
+func Delete(url string, data *interface{}) (int, error) {
+	return doRequest("DELETE", url, nil, data)
+}
+
+/*
+	Builds a request, executes it, and then decodes the response into data
+*/
+func doRequest(method string, url string, payload *interface{}, data *interface{}) (int, error) {
+	var body *bytes.Buffer
+
+	if payload != nil {
+		body = &bytes.Buffer{}
+		json.NewEncoder(body).Encode(payload)
+	}
+
+	req, err := http.NewRequest(method, url, body)
+
+	if err != nil {
+		return -1, err
+	}
+
+	return Do(req, data)
+}

--- a/common/apirequest/apirequest.go
+++ b/common/apirequest/apirequest.go
@@ -87,7 +87,6 @@ func doRequest(method string, url string, payload interface{}, data interface{})
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("HackIllinois-Identity", Identity)
 
-
 	return Do(req, data)
 }
 

--- a/services/auth/service/user_service.go
+++ b/services/auth/service/user_service.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/auth/config"
 	"github.com/HackIllinois/api/services/auth/models"
-	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
@@ -26,7 +26,7 @@ func SendUserInfo(id string, username string, first_name string, last_name strin
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_info)
 
-	status, err := apirequest.Post(config.USER_SERVICE + "/user/", &body, nil)
+	status, err := apirequest.Post(config.USER_SERVICE+"/user/", &body, nil)
 
 	if err != nil {
 		return err
@@ -44,7 +44,7 @@ func SendUserInfo(id string, username string, first_name string, last_name strin
 */
 func GetUserInfo(id string) (*models.UserInfo, error) {
 	var user_info models.UserInfo
-	status, err := apirequest.Get(config.USER_SERVICE + "/user/" + id + "/", &user_info)
+	status, err := apirequest.Get(config.USER_SERVICE+"/user/"+id+"/", &user_info)
 
 	if err != nil {
 		return nil, err

--- a/services/auth/service/user_service.go
+++ b/services/auth/service/user_service.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/HackIllinois/api/services/auth/config"
 	"github.com/HackIllinois/api/services/auth/models"
+	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
@@ -26,13 +26,13 @@ func SendUserInfo(id string, username string, first_name string, last_name strin
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_info)
 
-	resp, err := http.Post(config.USER_SERVICE+"/user/", "application/json", &body)
+	status, err := apirequest.Post(config.USER_SERVICE + "/user/", &body, nil)
 
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("User service failed to update")
 	}
 
@@ -43,28 +43,16 @@ func SendUserInfo(id string, username string, first_name string, last_name strin
 	Given a user ID, fetch the user info corresponding to the ID.
 */
 func GetUserInfo(id string) (*models.UserInfo, error) {
-	api_user_url := fmt.Sprintf("%s/user/%s/", config.USER_SERVICE, id)
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", api_user_url, nil)
-
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(fmt.Sprintf("GET request to api-user(%s) resulted in a response with a non-200 status code.", api_user_url))
-	}
-
-	defer resp.Body.Close()
-
 	var user_info models.UserInfo
-	json.NewDecoder(resp.Body).Decode(&user_info)
+	status, err := apirequest.Get(config.USER_SERVICE + "/user/" + id + "/", &user_info)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, errors.New("Failed to retrieve info from user service")
+	}
+
 	return &user_info, err
 }

--- a/services/checkin/service/registration_service.go
+++ b/services/checkin/service/registration_service.go
@@ -3,15 +3,15 @@ package service
 import (
 	"net/http"
 
-	"github.com/HackIllinois/api/services/checkin/config"
 	"github.com/HackIllinois/api/common/apirequest"
+	"github.com/HackIllinois/api/services/checkin/config"
 )
 
 /*
 	Returns true if the user with specified id is registered, and false if not.
 */
 func IsUserRegistered(id string) (bool, error) {
-	status, err := apirequest.Get(config.REGISTRATION_SERVICE + "/registration/attendee/" + id + "/", nil)
+	status, err := apirequest.Get(config.REGISTRATION_SERVICE+"/registration/attendee/"+id+"/", nil)
 
 	if err != nil {
 		return false, err

--- a/services/checkin/service/registration_service.go
+++ b/services/checkin/service/registration_service.go
@@ -1,25 +1,21 @@
 package service
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/HackIllinois/api/services/checkin/config"
+	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
 	Returns true if the user with specified id is registered, and false if not.
 */
 func IsUserRegistered(id string) (bool, error) {
-	api_registration_url := fmt.Sprintf("%s/registration/attendee/%s/", config.REGISTRATION_SERVICE, id)
-
-	resp, err := http.Get(api_registration_url)
+	status, err := apirequest.Get(config.REGISTRATION_SERVICE + "/registration/attendee/" + id + "/", nil)
 
 	if err != nil {
 		return false, err
 	}
 
-	defer resp.Body.Close()
-
-	return resp.StatusCode == http.StatusOK, nil
+	return status == http.StatusOK, nil
 }

--- a/services/checkin/service/rsvp_service.go
+++ b/services/checkin/service/rsvp_service.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/checkin/config"
 	"github.com/HackIllinois/api/services/checkin/models"
-	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -13,7 +13,7 @@ import (
 */
 func IsAttendeeRsvped(id string) (bool, error) {
 	var rsvp models.UserRsvp
-	status, err := apirequest.Get(config.RSVP_SERVICE + "/rsvp/" + id + "/", &rsvp)
+	status, err := apirequest.Get(config.RSVP_SERVICE+"/rsvp/"+id+"/", &rsvp)
 
 	if err != nil {
 		return false, err

--- a/services/checkin/service/rsvp_service.go
+++ b/services/checkin/service/rsvp_service.go
@@ -1,10 +1,10 @@
 package service
 
 import (
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/services/checkin/config"
 	"github.com/HackIllinois/api/services/checkin/models"
+	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -12,18 +12,16 @@ import (
 	Checks if the user has been rsvped in the decision service
 */
 func IsAttendeeRsvped(id string) (bool, error) {
-	resp, err := http.Get(config.RSVP_SERVICE + "/rsvp/" + id + "/")
+	var rsvp models.UserRsvp
+	status, err := apirequest.Get(config.RSVP_SERVICE + "/rsvp/" + id + "/", &rsvp)
 
 	if err != nil {
 		return false, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return false, errors.New("Rsvp service failed to return status")
 	}
-
-	var rsvp models.UserRsvp
-	json.NewDecoder(resp.Body).Decode(&rsvp)
 
 	return rsvp.IsAttending, nil
 }

--- a/services/decision/service/mail_service.go
+++ b/services/decision/service/mail_service.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/decision/config"
 	"github.com/HackIllinois/api/services/decision/models"
-	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
@@ -38,7 +38,7 @@ func AddUserToMailList(id string, decision *models.DecisionHistory) error {
 	request_body := bytes.Buffer{}
 	json.NewEncoder(&request_body).Encode(&mail_list)
 
-	status, err_update := apirequest.Post(config.MAIL_SERVICE + "/mail/list/add/", &request_body, nil)
+	status, err_update := apirequest.Post(config.MAIL_SERVICE+"/mail/list/add/", &request_body, nil)
 
 	if err_update == nil && status != http.StatusOK {
 		// The mail list with given id does not exist.
@@ -47,7 +47,7 @@ func AddUserToMailList(id string, decision *models.DecisionHistory) error {
 		// Since the buffer gets consumed after the preceding POST request
 		json.NewEncoder(&request_body).Encode(&mail_list)
 
-		status, err_create := apirequest.Post(config.MAIL_SERVICE + "/mail/list/create/", &request_body, nil)
+		status, err_create := apirequest.Post(config.MAIL_SERVICE+"/mail/list/create/", &request_body, nil)
 
 		if err_create == nil && status != http.StatusOK {
 

--- a/services/decision/service/mail_service.go
+++ b/services/decision/service/mail_service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/HackIllinois/api/services/decision/config"
 	"github.com/HackIllinois/api/services/decision/models"
+	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
@@ -37,24 +38,18 @@ func AddUserToMailList(id string, decision *models.DecisionHistory) error {
 	request_body := bytes.Buffer{}
 	json.NewEncoder(&request_body).Encode(&mail_list)
 
-	// URL to update the MailList with new IDs
-	api_mail_update_url := fmt.Sprintf("%s/mail/list/add/", config.MAIL_SERVICE)
+	status, err_update := apirequest.Post(config.MAIL_SERVICE + "/mail/list/add/", &request_body, nil)
 
-	content_type := "application/json"
-
-	resp, err_update := http.Post(api_mail_update_url, content_type, &request_body)
-
-	if err_update == nil && resp.StatusCode != http.StatusOK {
+	if err_update == nil && status != http.StatusOK {
 		// The mail list with given id does not exist.
 		// A new one will be created with the current user in it.
-		api_mail_create_url := fmt.Sprintf("%s/mail/list/create/", config.MAIL_SERVICE)
 
 		// Since the buffer gets consumed after the preceding POST request
 		json.NewEncoder(&request_body).Encode(&mail_list)
 
-		resp, err_create := http.Post(api_mail_create_url, content_type, &request_body)
+		status, err_create := apirequest.Post(config.MAIL_SERVICE + "/mail/list/create/", &request_body, nil)
 
-		if err_create == nil && resp.StatusCode != http.StatusOK {
+		if err_create == nil && status != http.StatusOK {
 
 			return errors.New(fmt.Sprintf("Failed to create new MailList with id %s.", mail_list_name))
 

--- a/services/event/service/checkin_service.go
+++ b/services/event/service/checkin_service.go
@@ -1,8 +1,8 @@
 package service
 
 import (
-	"github.com/HackIllinois/api/services/event/config"
 	"github.com/HackIllinois/api/common/apirequest"
+	"github.com/HackIllinois/api/services/event/config"
 	"net/http"
 )
 
@@ -10,7 +10,7 @@ import (
 	Checks if the user has been checked in with the checkin service
 */
 func IsUserCheckedIn(id string) (bool, error) {
-	status, err := apirequest.Get(config.CHECKIN_SERVICE + "/checkin/" + id + "/", nil)
+	status, err := apirequest.Get(config.CHECKIN_SERVICE+"/checkin/"+id+"/", nil)
 
 	if err != nil {
 		return false, err

--- a/services/event/service/checkin_service.go
+++ b/services/event/service/checkin_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/HackIllinois/api/services/event/config"
+	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -9,11 +10,11 @@ import (
 	Checks if the user has been checked in with the checkin service
 */
 func IsUserCheckedIn(id string) (bool, error) {
-	resp, err := http.Get(config.CHECKIN_SERVICE + "/checkin/" + id + "/")
+	status, err := apirequest.Get(config.CHECKIN_SERVICE + "/checkin/" + id + "/", nil)
 
 	if err != nil {
 		return false, err
 	}
 
-	return resp.StatusCode == http.StatusOK, nil
+	return status == http.StatusOK, nil
 }

--- a/services/mail/service/mail_service.go
+++ b/services/mail/service/mail_service.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/common/apirequest"
+	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/services/mail/config"
 	"github.com/HackIllinois/api/services/mail/models"
 	"gopkg.in/mgo.v2"
@@ -88,7 +88,7 @@ func SendMail(mail_info models.MailInfo) (*models.MailStatus, error) {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&mail_info)
 
-	req, err := http.NewRequest("POST", config.SPARKPOST_API + "/transmissions/", &body)
+	req, err := http.NewRequest("POST", config.SPARKPOST_API+"/transmissions/", &body)
 
 	if err != nil {
 		return nil, err

--- a/services/mail/service/mail_service.go
+++ b/services/mail/service/mail_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/mail/config"
 	"github.com/HackIllinois/api/services/mail/models"
 	"gopkg.in/mgo.v2"
@@ -87,8 +88,7 @@ func SendMail(mail_info models.MailInfo) (*models.MailStatus, error) {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&mail_info)
 
-	client := http.Client{}
-	req, err := http.NewRequest("POST", config.SPARKPOST_API+"/transmissions/", &body)
+	req, err := http.NewRequest("POST", config.SPARKPOST_API + "/transmissions/", &body)
 
 	if err != nil {
 		return nil, err
@@ -97,18 +97,16 @@ func SendMail(mail_info models.MailInfo) (*models.MailStatus, error) {
 	req.Header.Set("Authorization", config.SPARKPOST_APIKEY)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := client.Do(req)
+	var mail_status models.MailStatus
+	status, err := apirequest.Do(req, &mail_status)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return nil, errors.New("Failed to send mail")
 	}
-
-	var mail_status models.MailStatus
-	json.NewDecoder(resp.Body).Decode(&mail_status)
 
 	return &mail_status, nil
 }

--- a/services/mail/service/user_service.go
+++ b/services/mail/service/user_service.go
@@ -1,10 +1,10 @@
 package service
 
 import (
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/services/mail/config"
 	"github.com/HackIllinois/api/services/mail/models"
+	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -12,18 +12,16 @@ import (
 	Get basic user info from user serivce
 */
 func GetUserInfo(id string) (*models.UserInfo, error) {
-	resp, err := http.Get(config.USER_SERVICE + "/user/" + id + "/")
+	var user_info models.UserInfo
+	status, err := apirequest.Get(config.USER_SERVICE + "/user/" + id + "/", &user_info)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return nil, errors.New("User service failed to return information")
 	}
-
-	var user_info models.UserInfo
-	json.NewDecoder(resp.Body).Decode(&user_info)
 
 	return &user_info, nil
 }

--- a/services/mail/service/user_service.go
+++ b/services/mail/service/user_service.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/mail/config"
 	"github.com/HackIllinois/api/services/mail/models"
-	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -13,7 +13,7 @@ import (
 */
 func GetUserInfo(id string) (*models.UserInfo, error) {
 	var user_info models.UserInfo
-	status, err := apirequest.Get(config.USER_SERVICE + "/user/" + id + "/", &user_info)
+	status, err := apirequest.Get(config.USER_SERVICE+"/user/"+id+"/", &user_info)
 
 	if err != nil {
 		return nil, err

--- a/services/registration/service/auth-service.go
+++ b/services/registration/service/auth-service.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
-	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -29,7 +29,7 @@ func AddMentorRole(id string) error {
 */
 func AddRole(id string, role string) error {
 	var user_roles models.UserRoles
-	status, err := apirequest.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/", &user_roles)
+	status, err := apirequest.Get(config.AUTH_SERVICE+"/auth/roles/"+id+"/", &user_roles)
 
 	if err != nil {
 		return err
@@ -44,7 +44,7 @@ func AddRole(id string, role string) error {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_roles)
 
-	status, err = apirequest.Put(config.AUTH_SERVICE + "/auth/roles/", &body, nil)
+	status, err = apirequest.Put(config.AUTH_SERVICE+"/auth/roles/", &body, nil)
 
 	if err != nil {
 		return err

--- a/services/registration/service/auth-service.go
+++ b/services/registration/service/auth-service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
+	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -27,40 +28,29 @@ func AddMentorRole(id string) error {
 	Add role to user with auth service
 */
 func AddRole(id string, role string) error {
-	resp, err := http.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/")
+	var user_roles models.UserRoles
+	status, err := apirequest.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/", &user_roles)
 
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Auth service failed to update roles")
 	}
-
-	var user_roles models.UserRoles
-	json.NewDecoder(resp.Body).Decode(&user_roles)
 
 	user_roles.Roles = append(user_roles.Roles, role)
 
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_roles)
 
-	client := http.Client{}
-	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/", &body)
+	status, err = apirequest.Put(config.AUTH_SERVICE + "/auth/roles/", &body, nil)
 
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err = client.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Auth service failed to update roles")
 	}
 

--- a/services/registration/service/decision_service.go
+++ b/services/registration/service/decision_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
+	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -21,23 +22,13 @@ func AddInitialDecision(id string) error {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&decision)
 
-	client := http.Client{}
-	req, err := http.NewRequest("POST", config.DECISION_SERVICE+"/decision/", &body)
+	status, err := apirequest.Post(config.DECISION_SERVICE + "/decision/", &body, nil)
 
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("HackIllinois-Identity", "registrationservice")
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Decision service failed to create decision")
 	}
 

--- a/services/registration/service/decision_service.go
+++ b/services/registration/service/decision_service.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
-	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -22,7 +22,7 @@ func AddInitialDecision(id string) error {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&decision)
 
-	status, err := apirequest.Post(config.DECISION_SERVICE + "/decision/", &body, nil)
+	status, err := apirequest.Post(config.DECISION_SERVICE+"/decision/", &body, nil)
 
 	if err != nil {
 		return err

--- a/services/registration/service/mail_service.go
+++ b/services/registration/service/mail_service.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
-	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
@@ -21,7 +21,7 @@ func SendUserMail(id string, template string) error {
 	request_body := bytes.Buffer{}
 	json.NewEncoder(&request_body).Encode(&mail_order)
 
-	_, err := apirequest.Post(config.MAIL_SERVICE + "/mail/send/", &request_body, nil)
+	_, err := apirequest.Post(config.MAIL_SERVICE+"/mail/send/", &request_body, nil)
 
 	return err
 }

--- a/services/registration/service/mail_service.go
+++ b/services/registration/service/mail_service.go
@@ -3,19 +3,16 @@ package service
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"net/http"
 
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
+	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
 	Send user with specified id a confirmation email, with template as specified.
 */
 func SendUserMail(id string, template string) error {
-	api_mail_url := fmt.Sprintf("%s/mail/send/", config.MAIL_SERVICE)
-
 	mail_order := models.MailOrder{
 		IDs:      []string{id},
 		Template: template,
@@ -24,9 +21,7 @@ func SendUserMail(id string, template string) error {
 	request_body := bytes.Buffer{}
 	json.NewEncoder(&request_body).Encode(&mail_order)
 
-	content_type := "application/json"
-
-	_, err := http.Post(api_mail_url, content_type, &request_body)
+	_, err := apirequest.Post(config.MAIL_SERVICE + "/mail/send/", &request_body, nil)
 
 	return err
 }

--- a/services/registration/service/user_service.go
+++ b/services/registration/service/user_service.go
@@ -1,10 +1,10 @@
 package service
 
 import (
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
+	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -12,18 +12,16 @@ import (
 	Get basic user info from user serivce
 */
 func GetUserInfo(id string) (*models.UserInfo, error) {
-	resp, err := http.Get(config.USER_SERVICE + "/user/" + id + "/")
+	var user_info models.UserInfo
+	status, err := apirequest.Get(config.USER_SERVICE + "/user/" + id + "/", &user_info)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return nil, errors.New("User service failed to return information")
 	}
-
-	var user_info models.UserInfo
-	json.NewDecoder(resp.Body).Decode(&user_info)
 
 	return &user_info, nil
 }

--- a/services/registration/service/user_service.go
+++ b/services/registration/service/user_service.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
-	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -13,7 +13,7 @@ import (
 */
 func GetUserInfo(id string) (*models.UserInfo, error) {
 	var user_info models.UserInfo
-	status, err := apirequest.Get(config.USER_SERVICE + "/user/" + id + "/", &user_info)
+	status, err := apirequest.Get(config.USER_SERVICE+"/user/"+id+"/", &user_info)
 
 	if err != nil {
 		return nil, err

--- a/services/rsvp/service/auth_service.go
+++ b/services/rsvp/service/auth_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
+	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -13,40 +14,29 @@ import (
 	Add Attendee role to user with auth service
 */
 func AddAttendeeRole(id string) error {
-	resp, err := http.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/")
+	var user_roles models.UserRoles
+	status, err := apirequest.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/", &user_roles)
 
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Auth service failed to update roles")
 	}
-
-	var user_roles models.UserRoles
-	json.NewDecoder(resp.Body).Decode(&user_roles)
 
 	user_roles.Roles = append(user_roles.Roles, "Attendee")
 
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_roles)
 
-	client := http.Client{}
-	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/", &body)
+	status, err = apirequest.Put(config.AUTH_SERVICE + "/auth/roles/", &body, nil)
 
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err = client.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Auth service failed to update roles")
 	}
 
@@ -57,18 +47,16 @@ func AddAttendeeRole(id string) error {
 	Remove Attendee role from user with auth service
 */
 func RemoveAttendeeRole(id string) error {
-	resp, err := http.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/")
+	var user_roles models.UserRoles
+	status, err := apirequest.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/", &user_roles)
 
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Auth service failed to update roles")
 	}
-
-	var user_roles models.UserRoles
-	json.NewDecoder(resp.Body).Decode(&user_roles)
 
 	for index, role := range user_roles.Roles {
 		if role == "Attendee" {
@@ -79,22 +67,13 @@ func RemoveAttendeeRole(id string) error {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_roles)
 
-	client := http.Client{}
-	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/", &body)
+	status, err = apirequest.Put(config.AUTH_SERVICE + "/auth/roles/", &body, nil)
 
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err = client.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Auth service failed to update roles")
 	}
 

--- a/services/rsvp/service/auth_service.go
+++ b/services/rsvp/service/auth_service.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
-	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -15,7 +15,7 @@ import (
 */
 func AddAttendeeRole(id string) error {
 	var user_roles models.UserRoles
-	status, err := apirequest.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/", &user_roles)
+	status, err := apirequest.Get(config.AUTH_SERVICE+"/auth/roles/"+id+"/", &user_roles)
 
 	if err != nil {
 		return err
@@ -30,7 +30,7 @@ func AddAttendeeRole(id string) error {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_roles)
 
-	status, err = apirequest.Put(config.AUTH_SERVICE + "/auth/roles/", &body, nil)
+	status, err = apirequest.Put(config.AUTH_SERVICE+"/auth/roles/", &body, nil)
 
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func AddAttendeeRole(id string) error {
 */
 func RemoveAttendeeRole(id string) error {
 	var user_roles models.UserRoles
-	status, err := apirequest.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/", &user_roles)
+	status, err := apirequest.Get(config.AUTH_SERVICE+"/auth/roles/"+id+"/", &user_roles)
 
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func RemoveAttendeeRole(id string) error {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_roles)
 
-	status, err = apirequest.Put(config.AUTH_SERVICE + "/auth/roles/", &body, nil)
+	status, err = apirequest.Put(config.AUTH_SERVICE+"/auth/roles/", &body, nil)
 
 	if err != nil {
 		return err

--- a/services/rsvp/service/decision_service.go
+++ b/services/rsvp/service/decision_service.go
@@ -1,10 +1,10 @@
 package service
 
 import (
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
+	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -12,18 +12,16 @@ import (
 	Checks if the user has been accepted in the decision service
 */
 func IsApplicantAccepted(id string) (bool, error) {
-	resp, err := http.Get(config.DECISION_SERVICE + "/decision/" + id + "/")
+	var decision models.UserDecision
+	status, err := apirequest.Get(config.DECISION_SERVICE + "/decision/" + id + "/", &decision)
 
 	if err != nil {
 		return false, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return false, errors.New("Decision service failed to return status")
 	}
-
-	var decision models.UserDecision
-	json.NewDecoder(resp.Body).Decode(&decision)
 
 	return decision.Status == "ACCEPTED", nil
 }

--- a/services/rsvp/service/decision_service.go
+++ b/services/rsvp/service/decision_service.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
-	"github.com/HackIllinois/api/common/apirequest"
 	"net/http"
 )
 
@@ -13,7 +13,7 @@ import (
 */
 func IsApplicantAccepted(id string) (bool, error) {
 	var decision models.UserDecision
-	status, err := apirequest.Get(config.DECISION_SERVICE + "/decision/" + id + "/", &decision)
+	status, err := apirequest.Get(config.DECISION_SERVICE+"/decision/"+id+"/", &decision)
 
 	if err != nil {
 		return false, err

--- a/services/rsvp/service/mail_service.go
+++ b/services/rsvp/service/mail_service.go
@@ -3,19 +3,16 @@ package service
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"net/http"
 
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
+	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
 	Send user with specified id a confirmation email, with template as specified.
 */
 func SendUserMail(id string, template string) error {
-	api_mail_url := fmt.Sprintf("%s/mail/send/", config.MAIL_SERVICE)
-
 	mail_order := models.MailOrder{
 		IDs:      []string{id},
 		Template: template,
@@ -24,9 +21,7 @@ func SendUserMail(id string, template string) error {
 	request_body := bytes.Buffer{}
 	json.NewEncoder(&request_body).Encode(&mail_order)
 
-	content_type := "application/json"
-
-	_, err := http.Post(api_mail_url, content_type, &request_body)
+	_, err := apirequest.Post(config.MAIL_SERVICE + "/mail/send/", &request_body, nil)
 
 	return err
 }

--- a/services/rsvp/service/mail_service.go
+++ b/services/rsvp/service/mail_service.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
-	"github.com/HackIllinois/api/common/apirequest"
 )
 
 /*
@@ -21,7 +21,7 @@ func SendUserMail(id string, template string) error {
 	request_body := bytes.Buffer{}
 	json.NewEncoder(&request_body).Encode(&mail_order)
 
-	_, err := apirequest.Post(config.MAIL_SERVICE + "/mail/send/", &request_body, nil)
+	_, err := apirequest.Post(config.MAIL_SERVICE+"/mail/send/", &request_body, nil)
 
 	return err
 }

--- a/services/stat/service/stat_service.go
+++ b/services/stat/service/stat_service.go
@@ -1,11 +1,11 @@
 package service
 
 import (
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/services/stat/config"
 	"github.com/HackIllinois/api/services/stat/models"
+	"github.com/HackIllinois/api/common/apirequest"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"net/http"
@@ -91,21 +91,18 @@ func GetAggregatedStats(name string) (*models.Stat, error) {
 		return nil, err
 	}
 
-	resp, err := http.Get(service.URL)
+	var stat models.Stat
+	status, err := apirequest.Get(service.URL, &stat)
 
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return nil, errors.New("Could not retreive stats from registed service")
 	}
 
-	var stat models.Stat
-	json.NewDecoder(resp.Body).Decode(&stat)
-
 	return &stat, nil
-
 }
 
 /*

--- a/services/stat/service/stat_service.go
+++ b/services/stat/service/stat_service.go
@@ -2,10 +2,10 @@ package service
 
 import (
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/services/stat/config"
 	"github.com/HackIllinois/api/services/stat/models"
-	"github.com/HackIllinois/api/common/apirequest"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"net/http"


### PR DESCRIPTION
[WIP] Fixes #54

Currently this PR just adds the `apirequest` package to `common`. This package should be used for all inter-service communication. The goal here is to eliminate the issue of leaving a socket open.

- [x] Adds the `apirequest` package to `common`
- [x] Use `apirequest` package to fix socket leaks