### PR TITLE
Mark users as attending only once event has started

### DIFF
--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -44,7 +44,7 @@ func CanCheckInEvent(name string) (bool, error) {
 	startTime := event.StartTime
 	t := time.Now().Unix()
 
-	if int(t)  < (int(startTime) - startCheckInTime) {
+	if int(t) < (int(startTime) - startCheckInTime) {
 		return false, nil
 	}
 

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -46,7 +46,7 @@ func CanCheckInEvent(name string) (bool, error) {
 	startTime := event.StartTime
 	t := time.Now().Unix()
 
-	if int(math.Abs(startTime - t)) > startCheckInTime {
+	if int(math.Abs(float64(startTime - t))) > startCheckInTime {
 		return false, nil
 	}
 

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -43,10 +43,10 @@ func CanCheckInEvent(name string) (bool, error) {
 		return false, err
 	}
 
-	var startTime = event.StartTime
-	t := time.Now()
+	startTime := time.Unix(event.StartTime)
+	t := time.Now.Unix()
 
-	if math.Abs(startTime - int64(t)) > startCheckInTime {
+	if math.Abs(startTime - t) > startCheckInTime {
 		return false, nil
 	}
 

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -43,10 +43,10 @@ func CanCheckInEvent(name string) (bool, error) {
 		return false, err
 	}
 
-	startTime := time.Unix(event.StartTime)
+	startTime := time.Unix(event.StartTime, 0)
 	t := time.Now.Unix()
 
-	if math.Abs(startTime - t) > startCheckInTime {
+	if int(math.Abs(startTime - t)) > startCheckInTime {
 		return false, nil
 	}
 

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -43,7 +43,7 @@ func CanCheckInEvent(name string) (bool, error) {
 		return false, err
 	}
 
-	startTime := time.Unix(event.StartTime, 0)
+	startTime := event.StartTime
 	t := time.Now().Unix()
 
 	if int(math.Abs(startTime - t)) > startCheckInTime {

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 	"time"
-	"math"
+	//"math"
 )
 
 var startCheckInTime = 600 // Start check in 600 seconds before and go till 600 seconds after Event StartTime
@@ -38,15 +38,13 @@ func init() {
 */
 func CanCheckInEvent(name string) (bool, error) {
 	event, err := GetEvent(name)
-
 	if err != nil {
 		return false, err
 	}
-
 	startTime := event.StartTime
 	t := time.Now().Unix()
 
-	if int(math.Abs(float64(startTime - t))) > startCheckInTime {
+	if int(t)  < (int(startTime) - startCheckInTime) {
 		return false, nil
 	}
 

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -44,7 +44,7 @@ func CanCheckInEvent(name string) (bool, error) {
 	}
 
 	startTime := time.Unix(event.StartTime, 0)
-	t := time.Now.Unix()
+	t := time.Now().Unix()
 
 	if int(math.Abs(startTime - t)) > startCheckInTime {
 		return false, nil


### PR DESCRIPTION
[Issue](https://github.com/HackIllinois/api/issues/58)
Added a function for validating the start of an event `CanCheckInEvent(string eventName)` and used that as a precondition in `MarkUserAsAttendingEvent` for only marking attending if event has started.
<img width="493" alt="screen shot 2018-09-26 at 10 09 38 pm" src="https://user-images.githubusercontent.com/30192501/46121330-e42c3800-c1d8-11e8-8963-761a8820eb92.png">