### PR TITLE
Write resume uploads to /tmp/ when running locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 install:
     - go get -t ./...
 script:
+    - cd $GOPATH/src/github.com/arbor-dev/arbor && git fetch origin dev/v0.3 && git checkout dev/v0.3 && cd
     - "[ $(gofmt -l . | wc -l) == 0 ]"
     - make all
     - make test

--- a/services/upload/config/config.go
+++ b/services/upload/config/config.go
@@ -11,3 +11,4 @@ var UPLOAD_PORT = os.Getenv("UPLOAD_PORT")
 
 var S3_REGION = os.Getenv("S3_REGION")
 var S3_BUCKET = os.Getenv("S3_BUCKET")
+var IS_PRODUCTION = (os.Getenv("IS_PRODUCTION") == "true")

--- a/services/upload/service/upload_service.go
+++ b/services/upload/service/upload_service.go
@@ -9,9 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"net/http"
-	"time"
 	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
 )
 
 var sess *session.Session
@@ -46,7 +47,7 @@ func GetUserResumeLink(id string) (*models.UserResume, error) {
 			return nil, err
 		}
 	} else {
-		signed_url = "/tmp/" + id + ".pdf"
+		signed_url = "/tmp/uploads" + id + ".pdf"
 	}
 
 	resume := models.UserResume{
@@ -67,16 +68,17 @@ func UpdateUserResume(id string, file_buffer []byte) error {
 		return errors.New("Resume upload must be a pdf")
 	}
 
-	var err error;
+	var err error
 	if config.IS_PRODUCTION {
 		_, err = uploader.Upload(&s3manager.UploadInput{
-			Bucket: aws.String(config.S3_BUCKET),
-			Key:    aws.String("resumes/" + id + ".pdf"),
-			Body:   bytes.NewReader(file_buffer),
+			Bucket:      aws.String(config.S3_BUCKET),
+			Key:         aws.String("resumes/" + id + ".pdf"),
+			Body:        bytes.NewReader(file_buffer),
 			ContentType: &content_type,
 		})
 	} else {
-		err = ioutil.WriteFile("/tmp/" + id + ".pdf", file_buffer, 0644)
+		os.Mkdir("/tmp/uploads", os.ModePerm)
+		err = ioutil.WriteFile("/tmp/uploads/"+id+".pdf", file_buffer, 0644)
 	}
 
 	return err

--- a/services/upload/service/upload_service.go
+++ b/services/upload/service/upload_service.go
@@ -15,6 +15,10 @@ import (
 	"time"
 )
 
+// Unix file permissions - R/W for owner, R for group, R for other
+// (corresponds to umask of 022)
+const FILE_PERMISSIONS_RW = 0644;
+
 var sess *session.Session
 var uploader *s3manager.Uploader
 var client *s3.S3
@@ -78,7 +82,7 @@ func UpdateUserResume(id string, file_buffer []byte) error {
 		})
 	} else {
 		os.Mkdir("/tmp/uploads", os.ModePerm)
-		err = ioutil.WriteFile("/tmp/uploads/"+id+".pdf", file_buffer, 0644)
+		err = ioutil.WriteFile("/tmp/uploads/" + id + ".pdf", file_buffer, FILE_PERMISSIONS_RW)
 	}
 
 	return err

--- a/services/upload/service/upload_service.go
+++ b/services/upload/service/upload_service.go
@@ -47,7 +47,7 @@ func GetUserResumeLink(id string) (*models.UserResume, error) {
 			return nil, err
 		}
 	} else {
-		signed_url = "/tmp/uploads" + id + ".pdf"
+		signed_url = "/tmp/uploads/" + id + ".pdf"
 	}
 
 	resume := models.UserResume{

--- a/services/upload/service/upload_service.go
+++ b/services/upload/service/upload_service.go
@@ -17,7 +17,7 @@ import (
 
 // Unix file permissions - R/W for owner, R for group, R for other
 // (corresponds to umask of 022)
-const FILE_PERMISSIONS_RW = 0644;
+const FILE_PERMISSIONS_RW = 0644
 
 var sess *session.Session
 var uploader *s3manager.Uploader
@@ -82,7 +82,7 @@ func UpdateUserResume(id string, file_buffer []byte) error {
 		})
 	} else {
 		os.Mkdir("/tmp/uploads", os.ModePerm)
-		err = ioutil.WriteFile("/tmp/uploads/" + id + ".pdf", file_buffer, FILE_PERMISSIONS_RW)
+		err = ioutil.WriteFile("/tmp/uploads/"+id+".pdf", file_buffer, FILE_PERMISSIONS_RW)
 	}
 
 	return err


### PR DESCRIPTION
Resolves #6.

If the `IS_PRODUCTION` environment variable is not set to `true`, resumes uploaded through the PUT endpoint will be written to `/tmp/uploads/{id}.pdf`. The resume-related GET endpoint will return a local path as well.

Modifies the Travis configuration to force usage of the dev Arbor branch (mimics [similar change on the R|P API](https://github.com/ReflectionsProjections/api/pull/4)). Without this, we can't utilize the RAW format.

Documentation is left unchanged for now since the existing resume docs don't mention s3.