### PR TITLE
Add filtering route for user service to gateway

### DIFF
--- a/gateway/services/user.go
+++ b/gateway/services/user.go
@@ -17,13 +17,7 @@ var UserRoutes = arbor.RouteCollection{
 		"GetCurrentUserInfo",
 		"GET",
 		"/user/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"User"})).ThenFunc(GetCurrentUserInfo).ServeHTTP,
-	},
-	arbor.Route{
-		"GetUserInfo",
-		"GET",
-		"/user/{id}/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetUserInfo).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"User"})).ThenFunc(GetUserInfo).ServeHTTP,
 	},
 	arbor.Route{
 		"SetUserInfo",
@@ -31,10 +25,18 @@ var UserRoutes = arbor.RouteCollection{
 		"/user/",
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(SetUserInfo).ServeHTTP,
 	},
-}
-
-func GetCurrentUserInfo(w http.ResponseWriter, r *http.Request) {
-	arbor.GET(w, UserURL+r.URL.String(), UserFormat, "", r)
+	arbor.Route{
+		"GetFilteredUserInfo",
+		"GET",
+		"/user/filter/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetUserInfo).ServeHTTP,
+	},
+	arbor.Route{
+		"GetUserInfo",
+		"GET",
+		"/user/{id}/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetUserInfo).ServeHTTP,
+	},
 }
 
 func GetUserInfo(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Resolves #24.

Line-for-line duplicate of HackIllinois/api-gateway#58.

Sent a few GET requests to the filtering endpoint and verified that existing routes continue to function. Documentation is already there.