### PR TITLE
Add endpoint to get all mailing lists

### DIFF
--- a/gateway/services/mail.go
+++ b/gateway/services/mail.go
@@ -26,6 +26,12 @@ var MailRoutes = arbor.RouteCollection{
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(SendMailList).ServeHTTP,
 	},
 	arbor.Route{
+		"GetAllMailLists",
+		"GET",
+		"/mail/list/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetAllMailLists).ServeHTTP,
+	},
+	arbor.Route{
 		"CreateMailList",
 		"POST",
 		"/mail/list/create/",
@@ -72,5 +78,9 @@ func RemoveFromMailList(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetMailList(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, MailURL+r.URL.String(), MailFormat, "", r)
+}
+
+func GetAllMailLists(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, MailURL+r.URL.String(), MailFormat, "", r)
 }

--- a/services/mail/controller/controller.go
+++ b/services/mail/controller/controller.go
@@ -15,6 +15,7 @@ func SetupController(route *mux.Route) {
 
 	router.Handle("/send/", alice.New().ThenFunc(SendMail)).Methods("POST")
 	router.Handle("/send/list/", alice.New().ThenFunc(SendMailList)).Methods("POST")
+	router.Handle("/list/", alice.New().ThenFunc(GetAllMailLists)).Methods("GET")
 	router.Handle("/list/create/", alice.New().ThenFunc(CreateMailList)).Methods("POST")
 	router.Handle("/list/add/", alice.New().ThenFunc(AddToMailList)).Methods("POST")
 	router.Handle("/list/remove/", alice.New().ThenFunc(RemoveFromMailList)).Methods("POST")
@@ -134,4 +135,17 @@ func GetMailList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(mail_list)
+}
+
+/*
+	Endpoint to get all mailing lists
+*/
+func GetAllMailLists(w http.ResponseWriter, r *http.Request) {
+	mail_lists, err := service.GetAllMailLists()
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(mail_lists)
 }

--- a/services/mail/docs/Mail.md
+++ b/services/mail/docs/Mail.md
@@ -52,7 +52,7 @@ Response format:
 GET /mail/list/
 ---------------------
 
-Returns a list of all events.
+Returns a list of all created mailing lists.
 
 Response format:
 ```

--- a/services/mail/docs/Mail.md
+++ b/services/mail/docs/Mail.md
@@ -49,6 +49,32 @@ Response format:
 }
 ```
 
+GET /mail/list/
+---------------------
+
+Returns a list of all events.
+
+Response format:
+```
+{
+	"mailLists": [
+		{
+			"id": "test",
+			"userIds": [
+				"testuser1"
+			]
+		},
+		{
+			"id": "test2",
+			"userIds": [
+				"testuser2",
+				"testuser3"
+			]
+		}
+	]
+}
+```
+
 POST /mail/list/create/
 ------------------
 

--- a/services/mail/models/mail_list_list.go
+++ b/services/mail/models/mail_list_list.go
@@ -1,0 +1,5 @@
+package models
+
+type MailListList struct {
+	MailLists []MailList `json:"mailLists"`
+}

--- a/services/mail/service/mail_service.go
+++ b/services/mail/service/mail_service.go
@@ -202,3 +202,23 @@ func GetMailList(id string) (*models.MailList, error) {
 
 	return &mail_list, nil
 }
+
+/*
+	Gets all created mailing lists
+*/
+func GetAllMailLists() (*models.MailListList, error) {
+	var mail_lists []models.MailList
+
+	// nil in this case means that we return everything in the lists collection
+	err := db.FindAll("lists", nil, &mail_lists)
+
+	if err != nil {
+		return nil, err
+	}
+
+	mail_list_list := models.MailListList{
+		MailLists: mail_lists,
+	}
+
+	return &mail_list_list, nil
+}

--- a/services/mail/tests/mail_test.go
+++ b/services/mail/tests/mail_test.go
@@ -172,3 +172,46 @@ func TestRemoveFromMailList(t *testing.T) {
 
 	CleanupTestDB(t)
 }
+
+/*
+	Tests getting a list of all mailing lists
+*/
+func TestGetAllMailLists(t *testing.T) {
+	SetupTestDB(t)
+
+	mail_list := models.MailList{
+		ID:      "testlist2",
+		UserIDs: []string{"userid1", "userid2"},
+	}
+
+	err := service.CreateMailList(mail_list)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mail_lists, err := service.GetAllMailLists()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &models.MailListList{
+		MailLists: []models.MailList{
+			models.MailList{
+				ID:      "testlist",
+				UserIDs: []string{"userid1", "userid2"},
+			},
+			models.MailList{
+				ID:      "testlist2",
+				UserIDs: []string{"userid1", "userid2"},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(mail_lists, expected) {
+		t.Errorf("Wrong set of mailing lists. Expected %v, got %v", expected, mail_lists)
+	}
+
+	CleanupTestDB(t)
+}


### PR DESCRIPTION
Resolves #64.

Adds an endpoint `/mail/list` that returns a list of all mailing lists, and their users. Requires Admin permissions.

Adds information about the endpoint to the mail service documentation, and adds a test.

Result looks like the following:
```
{
    "mailLists": [
        {
            "id": "testlist1",
            "userIds": [
                "testuser1",
                "testuser2"
            ]
        },
        {
            "id": "testlist2",
            "userIds": [
                "testuser3"
            ]
        }
    ]
}
```

Right now, all of the mailing list's information is returned. Could also scope this down to just a list of `id`s like what was specified in the issue.

In order to match other services, a new model `MailListList` was created. Not thrilled with the name, but wanted to match the standard set by `EventList`. Alternatively, could go with something like `FilteredMailLists` to match what registration/user services do.