### PR TITLE
Add endpoint to get all checked in users

### DIFF
--- a/gateway/services/checkin.go
+++ b/gateway/services/checkin.go
@@ -32,6 +32,12 @@ var CheckinRoutes = arbor.RouteCollection{
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(UpdateCurrentCheckinInfo).ServeHTTP,
 	},
 	arbor.Route{
+		"GetAllCheckedInUsers",
+		"GET",
+		"/checkin/list/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetAllCheckedInUsers).ServeHTTP,
+	},
+	arbor.Route{
 		"GetCurrentQrCodeInfo",
 		"GET",
 		"/checkin/qr/",
@@ -72,5 +78,9 @@ func GetCurrentQrCodeInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetQrCodeInfo(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, CheckinURL+r.URL.String(), CheckinFormat, "", r)
+}
+
+func GetAllCheckedInUsers(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, CheckinURL+r.URL.String(), CheckinFormat, "", r)
 }

--- a/services/checkin/controller/controller.go
+++ b/services/checkin/controller/controller.go
@@ -147,7 +147,7 @@ func GetQrCodeInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	Endpoint to get a specified user's checkin
+	Endpoint to get all checked in user IDs
 */
 func GetAllCheckedInUsers(w http.ResponseWriter, r *http.Request) {
 	checked_in_users, err := service.GetAllCheckedInUsers()

--- a/services/checkin/controller/controller.go
+++ b/services/checkin/controller/controller.go
@@ -16,6 +16,7 @@ func SetupController(route *mux.Route) {
 	router.Handle("/", alice.New().ThenFunc(CreateUserCheckin)).Methods("POST")
 	router.Handle("/", alice.New().ThenFunc(UpdateUserCheckin)).Methods("PUT")
 	router.Handle("/", alice.New().ThenFunc(GetCurrentUserCheckin)).Methods("GET")
+	router.Handle("/list/", alice.New().ThenFunc(GetAllCheckedInUsers)).Methods("GET")
 	router.Handle("/qr/", alice.New().ThenFunc(GetCurrentQrCodeInfo)).Methods("GET")
 	router.Handle("/{id}/", alice.New().ThenFunc(GetUserCheckin)).Methods("GET")
 	router.Handle("/qr/{id}/", alice.New().ThenFunc(GetQrCodeInfo)).Methods("GET")
@@ -143,4 +144,17 @@ func GetQrCodeInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(qr_info_container)
+}
+
+/*
+	Endpoint to get a specified user's checkin
+*/
+func GetAllCheckedInUsers(w http.ResponseWriter, r *http.Request) {
+	checked_in_users, err := service.GetAllCheckedInUsers()
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(checked_in_users)
 }

--- a/services/checkin/docs/Checkin.md
+++ b/services/checkin/docs/Checkin.md
@@ -77,10 +77,25 @@ Response format:
 }
 ```
 
+GET /checkin/list/
+----------
+
+Returns a list of all user IDs for users who have checked in
+
+Response format:
+```
+{
+	"checkedInUsers": [
+		"github0000001",
+		"github0000005"
+	]
+}
+```
+
 GET /checkin/qr/
 ----------
 
-Get the string to be embedded in the current user's QR code. 
+Get the string to be embedded in the current user's QR code.
 The QR code string will contain information stored in the form of a URI.
 
 Response format:
@@ -94,7 +109,7 @@ Response format:
 GET /checkin/qr/{id}/
 ----------
 
-Get the string to be embedded in the specified user's QR code. 
+Get the string to be embedded in the specified user's QR code.
 The QR code string will contain information stored in the form of a URI.
 
 Response format:

--- a/services/checkin/models/checkin_list.go
+++ b/services/checkin/models/checkin_list.go
@@ -1,0 +1,5 @@
+package models
+
+type CheckinList struct {
+	CheckedInUsers []string `json:"checkedInUsers"`
+}

--- a/services/checkin/service/checkin_service.go
+++ b/services/checkin/service/checkin_service.go
@@ -132,3 +132,21 @@ func CanUserCheckin(id string, user_has_override bool) (bool, error) {
 
 	return is_user_rsvped, nil
 }
+
+/*
+	Returns the checkin associated with the given user id
+*/
+func GetAllCheckedInUsers() (*[]string, error) {
+	query := bson.M{
+		"hasCheckedIn": true,
+	}
+
+	var checked_in_users []string
+	err := db.FindAll("checkins", query, &checked_in_users)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &checked_in_users, nil
+}

--- a/services/checkin/service/checkin_service.go
+++ b/services/checkin/service/checkin_service.go
@@ -135,7 +135,7 @@ func CanUserCheckin(id string, user_has_override bool) (bool, error) {
 	Returns a list of all checked in user IDs
 */
 func GetAllCheckedInUsers() (*models.CheckinList, error) {
-	query := bson.M{
+	query := database.QuerySelector{
 		"hascheckedin": true,
 	}
 

--- a/services/checkin/service/checkin_service.go
+++ b/services/checkin/service/checkin_service.go
@@ -134,19 +134,24 @@ func CanUserCheckin(id string, user_has_override bool) (bool, error) {
 }
 
 /*
-	Returns the checkin associated with the given user id
+	Returns a list of all checked in user IDs
 */
-func GetAllCheckedInUsers() (*[]string, error) {
+func GetAllCheckedInUsers() (*models.CheckinList, error) {
 	query := bson.M{
-		"hasCheckedIn": true,
+		"hascheckedin": true,
 	}
 
-	var checked_in_users []string
-	err := db.FindAll("checkins", query, &checked_in_users)
+	var check_ins []models.UserCheckin
+	err := db.FindAll("checkins", query, &check_ins)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &checked_in_users, nil
+	var checkin_list models.CheckinList
+	for _, check_in := range check_ins {
+		checkin_list.CheckedInUsers = append(checkin_list.CheckedInUsers, check_in.ID)
+	}
+
+	return &checkin_list, nil
 }

--- a/services/checkin/tests/checkin_test.go
+++ b/services/checkin/tests/checkin_test.go
@@ -153,6 +153,49 @@ func TestUpdateUserCheckinService(t *testing.T) {
 }
 
 /*
+	Service level test for getting list of all checked in users
+*/
+func TestGetAllCheckedInUsersService(t *testing.T) {
+	SetupTestDB(t)
+
+	new_checkin := models.UserCheckin{
+		ID:              "testid2",
+		HasCheckedIn:    false,
+		HasPickedUpSwag: false,
+	}
+
+	err := service.CreateUserCheckin("testid2", new_checkin)
+
+	new_checkin = models.UserCheckin{
+		ID:              "testid3",
+		HasCheckedIn:    true,
+		HasPickedUpSwag: false,
+	}
+
+	err = service.CreateUserCheckin("testid3", new_checkin)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkin_list, err := service.GetAllCheckedInUsers()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_checkin_list := models.CheckinList{
+		CheckedInUsers: []string{"testid", "testid3"},
+	}
+
+	if !reflect.DeepEqual(checkin_list, &expected_checkin_list) {
+		t.Errorf("Wrong user info. Expected %v, got %v", expected_checkin_list, checkin_list)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
 	Service level test for generating QR code URI
 */
 func TestGetQrInfo(t *testing.T) {


### PR DESCRIPTION
Resolves #66.

- [x] Adds an endpoint `/checkin/list/` that returns a list of all checked in user IDs. Requires Admin permissions.
- [x] Adds information about the endpoint to docs
- [x] Adds unit tests
