### PR TITLE
Modify role-setting endpoints

### DIFF
--- a/common/utils/slice_utils.go
+++ b/common/utils/slice_utils.go
@@ -1,0 +1,23 @@
+package slice_utils
+
+import (
+	"errors"
+)
+
+func ContainsString(slice []string, str string) bool {
+	for _, value := range slice {
+		if value == str {
+			return true
+		}
+	}
+	return false
+}
+
+func RemoveString(slice []string, str string) ([]string, error) {
+	for i, value := range slice {
+		if value == str {
+			return append(slice[:i], slice[i+1:]...), nil
+		}
+	}
+	return nil, errors.New("Value to remove not found")
+}

--- a/gateway/services/auth.go
+++ b/gateway/services/auth.go
@@ -35,13 +35,13 @@ var AuthRoutes = arbor.RouteCollection{
 	arbor.Route{
 		"AddUserRole",
 		"PUT",
-		"/auth/roles/remove/",
+		"/auth/roles/add/",
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(AddUserRole).ServeHTTP,
 	},
 	arbor.Route{
 		"RemoveUserRole",
 		"PUT",
-		"/auth/roles/add/",
+		"/auth/roles/remove/",
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(RemoveUserRole).ServeHTTP,
 	},
 	arbor.Route{

--- a/gateway/services/auth.go
+++ b/gateway/services/auth.go
@@ -33,10 +33,16 @@ var AuthRoutes = arbor.RouteCollection{
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(GetUserRoles).ServeHTTP,
 	},
 	arbor.Route{
-		"SetUserRoles",
+		"AddUserRole",
 		"PUT",
-		"/auth/roles/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(SetUserRoles).ServeHTTP,
+		"/auth/roles/remove/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(AddUserRole).ServeHTTP,
+	},
+	arbor.Route{
+		"RemoveUserRole",
+		"PUT",
+		"/auth/roles/add/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]string{"Admin"})).ThenFunc(RemoveUserRole).ServeHTTP,
 	},
 	arbor.Route{
 		"RefreshToken",
@@ -58,7 +64,11 @@ func GetUserRoles(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, AuthURL+r.URL.String(), AuthFormat, "", r)
 }
 
-func SetUserRoles(w http.ResponseWriter, r *http.Request) {
+func AddUserRole(w http.ResponseWriter, r *http.Request) {
+	arbor.PUT(w, AuthURL+r.URL.String(), AuthFormat, "", r)
+}
+
+func RemoveUserRole(w http.ResponseWriter, r *http.Request) {
 	arbor.PUT(w, AuthURL+r.URL.String(), AuthFormat, "", r)
 }
 

--- a/services/auth/docs/Authorization.md
+++ b/services/auth/docs/Authorization.md
@@ -1,8 +1,6 @@
-Authorization
-=============
+# Authorization
 
-GET /auth/PROVIDER/?redirect_uri=AUTHREDIRECTURI
-------------------------------------------------
+## GET /auth/PROVIDER/?redirect_uri=AUTHREDIRECTURI
 
 Redirects to the `PROVIDER`'s OAuth authorization page. Once the user accepts the OAuth authorization they will be redirected to the client's auth page with an OAuth code. This code should be sent to the API to be exchanged for an API JWT.
 
@@ -10,8 +8,7 @@ Valid `PROVIDER` strings: `github`, `google`
 
 `AUTHREDIRECTURI` can be specified to override the default OAuth redirect URI. This is the URI to which the application is redirected after the Authorization request is approved / rejected.
 
-POST /auth/code/PROVIDER/?redirect_uri=AUTHREDIRECTURI
-------------------------------------------------------
+## POST /auth/code/PROVIDER/?redirect_uri=AUTHREDIRECTURI
 
 Exchanges a valid OAuth code from a JWT from the API. This JWT should be placed in the `Authorization` header for all future API requests.
 
@@ -19,9 +16,10 @@ Valid `PROVIDER` strings: `github`, `google` and `linkedin`.
 
 `AUTHREDIRECTURI` can be specified to override the default OAuth redirect URI. This is the URI to which the application is redirected after the token request is completed.
 
-*Important note:* For Google OAuth requests, the provided `redirect_uri` needs to be the same as the one provided in the GET request above. If the two `redirect_uri`s differ, Google will reject the OAuth token request.
+_Important note:_ For Google OAuth requests, the provided `redirect_uri` needs to be the same as the one provided in the GET request above. If the two `redirect_uri`s differ, Google will reject the OAuth token request.
 
 Request format:
+
 ```
 {
 	"code": "5897dk3j05192c5j2gc8"
@@ -29,17 +27,19 @@ Request format:
 ```
 
 Response format:
+
 ```
 {
 	"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFybmF2c2Fua2FyYW5AZ21haWwuY29tIiwiZXhwIjoxNTI1ODQ1MzA0LCJpZCI6MCwicm9sZXMiOlsiVXNlciJdfQ.lYxFGSNDU9q7FoQHNHGvpKu1fTHf8yHsKPg8FDt9L-s"
 }
 ```
-GET /auth/roles/USERID/
---------------------------
+
+## GET /auth/roles/USERID/
 
 Gets the roles of the user with the id `USERID`.
 
 Response format:
+
 ```
 {
 	"id": "github6892396",
@@ -49,12 +49,21 @@ Response format:
 }
 ```
 
-PUT /auth/roles/
------------------
+## PUT /auth/roles/add/
 
-Sets the roles of the user with the given `id` to `roles`. The updated user's roles will be returned.
+Adds the given `role` to the user with the given `id`. The updated user's roles will be returned.
 
 Request format:
+
+```
+{
+	"id": "github6892396",
+	"role": "User"
+}
+```
+
+Response format:
+
 ```
 {
 	"id": "github6892396",
@@ -64,22 +73,34 @@ Request format:
 }
 ```
 
-Response format:
+## PUT /auth/roles/remove/
+
+Removes the given `role` from the user with the given `id`. The updated user's roles will be returned.
+
+Request format:
+
 ```
 {
 	"id": "github6892396",
-	"roles": [
-		"User"
-	]
+	"role": "User"
 }
 ```
 
-GET /auth/token/refresh/
------------------
+Response format:
 
-Creates a new JWT for the current user. This is useful when the user's roles change, and the updated roles need to be encoded into a new JWT, such as during registration. 
+```
+{
+	"id": "github6892396",
+	"roles": []
+}
+```
+
+## GET /auth/token/refresh/
+
+Creates a new JWT for the current user. This is useful when the user's roles change, and the updated roles need to be encoded into a new JWT, such as during registration.
 
 Response format:
+
 ```
 {
 	"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFybmF2c2Fua2FyYW5AZ21haWwuY29tIiwiZXhwIjoxNTI1ODQ1MzA0LCJpZCI6MCwicm9sZXMiOlsiVXNlciJdfQ.lYxFGSNDU9q7FoQHNHGvpKu1fTHf8yHsKPg8FDt9L-s"

--- a/services/auth/docs/Authorization.md
+++ b/services/auth/docs/Authorization.md
@@ -1,6 +1,8 @@
-# Authorization
+Authorization
+=============
 
-## GET /auth/PROVIDER/?redirect_uri=AUTHREDIRECTURI
+GET /auth/PROVIDER/?redirect_uri=AUTHREDIRECTURI
+------------------------------------------------
 
 Redirects to the `PROVIDER`'s OAuth authorization page. Once the user accepts the OAuth authorization they will be redirected to the client's auth page with an OAuth code. This code should be sent to the API to be exchanged for an API JWT.
 
@@ -8,7 +10,8 @@ Valid `PROVIDER` strings: `github`, `google`
 
 `AUTHREDIRECTURI` can be specified to override the default OAuth redirect URI. This is the URI to which the application is redirected after the Authorization request is approved / rejected.
 
-## POST /auth/code/PROVIDER/?redirect_uri=AUTHREDIRECTURI
+POST /auth/code/PROVIDER/?redirect_uri=AUTHREDIRECTURI
+------------------------------------------------------
 
 Exchanges a valid OAuth code from a JWT from the API. This JWT should be placed in the `Authorization` header for all future API requests.
 
@@ -16,10 +19,9 @@ Valid `PROVIDER` strings: `github`, `google` and `linkedin`.
 
 `AUTHREDIRECTURI` can be specified to override the default OAuth redirect URI. This is the URI to which the application is redirected after the token request is completed.
 
-_Important note:_ For Google OAuth requests, the provided `redirect_uri` needs to be the same as the one provided in the GET request above. If the two `redirect_uri`s differ, Google will reject the OAuth token request.
+*Important note:* For Google OAuth requests, the provided `redirect_uri` needs to be the same as the one provided in the GET request above. If the two `redirect_uri`s differ, Google will reject the OAuth token request.
 
 Request format:
-
 ```
 {
 	"code": "5897dk3j05192c5j2gc8"
@@ -27,19 +29,17 @@ Request format:
 ```
 
 Response format:
-
 ```
 {
 	"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFybmF2c2Fua2FyYW5AZ21haWwuY29tIiwiZXhwIjoxNTI1ODQ1MzA0LCJpZCI6MCwicm9sZXMiOlsiVXNlciJdfQ.lYxFGSNDU9q7FoQHNHGvpKu1fTHf8yHsKPg8FDt9L-s"
 }
 ```
-
-## GET /auth/roles/USERID/
+GET /auth/roles/USERID/
+--------------------------
 
 Gets the roles of the user with the id `USERID`.
 
 Response format:
-
 ```
 {
 	"id": "github6892396",
@@ -49,7 +49,7 @@ Response format:
 }
 ```
 
-## PUT /auth/roles/add/
+PUT /auth/roles/add/
 
 Adds the given `role` to the user with the given `id`. The updated user's roles will be returned.
 
@@ -73,7 +73,7 @@ Response format:
 }
 ```
 
-## PUT /auth/roles/remove/
+PUT /auth/roles/remove/
 
 Removes the given `role` from the user with the given `id`. The updated user's roles will be returned.
 
@@ -95,12 +95,12 @@ Response format:
 }
 ```
 
-## GET /auth/token/refresh/
+GET /auth/token/refresh/
+-----------------
 
 Creates a new JWT for the current user. This is useful when the user's roles change, and the updated roles need to be encoded into a new JWT, such as during registration.
 
 Response format:
-
 ```
 {
 	"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFybmF2c2Fua2FyYW5AZ21haWwuY29tIiwiZXhwIjoxNTI1ODQ1MzA0LCJpZCI6MCwicm9sZXMiOlsiVXNlciJdfQ.lYxFGSNDU9q7FoQHNHGvpKu1fTHf8yHsKPg8FDt9L-s"

--- a/services/auth/models/user_role_modification.go
+++ b/services/auth/models/user_role_modification.go
@@ -1,0 +1,6 @@
+package models
+
+type UserRoleModification struct {
+	ID    string   `bson:"id"    json:"id"`
+	Role  string   `bson:"role"  json:"role"`
+}

--- a/services/auth/models/user_role_modification.go
+++ b/services/auth/models/user_role_modification.go
@@ -1,6 +1,6 @@
 package models
 
 type UserRoleModification struct {
-	ID   string `bson:"id"    json:"id"`
-	Role string `bson:"role"  json:"role"`
+	ID   string `json:"id"`
+	Role string `json:"role"`
 }

--- a/services/auth/models/user_role_modification.go
+++ b/services/auth/models/user_role_modification.go
@@ -1,6 +1,6 @@
 package models
 
 type UserRoleModification struct {
-	ID    string   `bson:"id"    json:"id"`
-	Role  string   `bson:"role"  json:"role"`
+	ID   string `bson:"id"    json:"id"`
+	Role string `bson:"role"  json:"role"`
 }

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"errors"
+	"github.com/HackIllinois/api/common/utils"
+
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/services/auth/config"
 	"github.com/HackIllinois/api/services/auth/models"
@@ -67,7 +70,9 @@ func AddUserRole(id string, role string) error {
 		return err
 	}
 
-	roles = append(roles, role)
+	if !slice_utils.ContainsString(roles, role) {
+		roles = append(roles, role)
+	}
 
 	err = db.Update("roles", selector, &models.UserRoles{
 		ID:    id,
@@ -77,6 +82,9 @@ func AddUserRole(id string, role string) error {
 	return err
 }
 
+/*
+	Removes a role from the user with the specified id
+*/
 func RemoveUserRole(id string, role string) error {
 	selector := bson.M{
 		"id": id,
@@ -88,7 +96,11 @@ func RemoveUserRole(id string, role string) error {
 		return err
 	}
 
-	roles = append(roles, role)
+	roles, err = slice_utils.RemoveString(roles, role)
+
+	if err != nil {
+		return errors.New("User does not have specified role")
+	}
 
 	err = db.Update("roles", selector, &models.UserRoles{
 		ID:    id,

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -54,14 +54,43 @@ func GetUserRoles(id string, create_user bool) ([]string, error) {
 }
 
 /*
-	Sets the roles for the user with the specified id
+	Adds a role to the user with the specified id
 */
-func SetUserRoles(id string, roles []string) error {
+func AddUserRole(id string, role string) error {
 	selector := bson.M{
 		"id": id,
 	}
 
-	err := db.Update("roles", selector, &models.UserRoles{
+	roles, err := GetUserRoles(id, false)
+
+	if err != nil {
+		return err
+	}
+
+	roles = append(roles, role)
+
+	err = db.Update("roles", selector, &models.UserRoles{
+		ID:    id,
+		Roles: roles,
+	})
+
+	return err
+}
+
+func RemoveUserRole(id string, role string) error {
+	selector := bson.M{
+		"id": id,
+	}
+
+	roles, err := GetUserRoles(id, false)
+
+	if err != nil {
+		return err
+	}
+
+	roles = append(roles, role)
+
+	err = db.Update("roles", selector, &models.UserRoles{
 		ID:    id,
 		Roles: roles,
 	})

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -60,7 +60,7 @@ func GetUserRoles(id string, create_user bool) ([]string, error) {
 	Adds a role to the user with the specified id
 */
 func AddUserRole(id string, role string) error {
-	selector := bson.M{
+	selector := database.QuerySelector{
 		"id": id,
 	}
 
@@ -86,7 +86,7 @@ func AddUserRole(id string, role string) error {
 	Removes a role from the user with the specified id
 */
 func RemoveUserRole(id string, role string) error {
-	selector := bson.M{
+	selector := database.QuerySelector{
 		"id": id,
 	}
 

--- a/services/auth/tests/roles_test.go
+++ b/services/auth/tests/roles_test.go
@@ -80,13 +80,13 @@ func TestGetRolesService(t *testing.T) {
 }
 
 /*
-	Service level test for setting a user's roles in the db
+	Service level test for adding a role to a user in the DB
 */
-func TestPutRolesService(t *testing.T) {
+func TestAddRoleService(t *testing.T) {
 	SetupTestDB(t)
 
-	updated_roles := []string{"User", "Admin"}
-	err := service.SetUserRoles("testid", updated_roles)
+	expected_roles := []string{"User", "Admin"}
+	err := service.AddUserRole("testid", "Admin")
 
 	if err != nil {
 		t.Fatal(err)
@@ -98,8 +98,58 @@ func TestPutRolesService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(roles, updated_roles) {
-		t.Errorf("Wrong user roles. Expected %v, got %v", updated_roles, roles)
+	if !reflect.DeepEqual(roles, expected_roles) {
+		t.Errorf("Wrong user roles. Expected %v, got %v", expected_roles, roles)
+	}
+
+	// Test adding duplicate role
+	err = service.AddUserRole("testid", "Admin")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	roles, err = service.GetUserRoles("testid", false)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(roles, expected_roles) {
+		t.Errorf("Wrong user roles. Expected %v, got %v", expected_roles, roles)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for removing a role from a user in the DB
+*/
+func TestRemoveRoleService(t *testing.T) {
+	SetupTestDB(t)
+
+	expected_roles := []string{}
+	err := service.RemoveUserRole("testid", "User")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	roles, err := service.GetUserRoles("testid", false)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(roles, expected_roles) {
+		t.Errorf("Wrong user roles. Expected %v, got %v", expected_roles, roles)
+	}
+
+	// Ensure removing a user's role fails if they do not have that role
+	err = service.RemoveUserRole("testid", "User")
+
+	if err == nil {
+		t.Errorf("Able to remove role \"User\" from a user that does not have the \"User\" role")
 	}
 
 	CleanupTestDB(t)

--- a/services/decision/service/decision_service.go
+++ b/services/decision/service/decision_service.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/common/utils"
 	"github.com/HackIllinois/api/services/decision/config"
 	"github.com/HackIllinois/api/services/decision/models"
 	"gopkg.in/go-playground/validator.v9"
@@ -110,18 +111,9 @@ func HasDecision(id string) (bool, error) {
 	}
 }
 
-func Contains(slice []string, str string) bool {
-	for _, value := range slice {
-		if value == str {
-			return true
-		}
-	}
-	return false
-}
-
 func AssignValueType(key, value string) (interface{}, error) {
 	int_keys := []string{"wave", "timestamp"}
-	if Contains(int_keys, key) {
+	if slice_utils.ContainsString(int_keys, key) {
 		return strconv.Atoi(value)
 	}
 	return value, nil

--- a/services/registration/models/user_role_modification.go
+++ b/services/registration/models/user_role_modification.go
@@ -1,0 +1,6 @@
+package models
+
+type UserRoleModification struct {
+	ID   string `json:"id"`
+	Role string `json:"role"`
+}

--- a/services/registration/service/auth-service.go
+++ b/services/registration/service/auth-service.go
@@ -27,26 +27,13 @@ func AddMentorRole(id string) error {
 	Add role to user with auth service
 */
 func AddRole(id string, role string) error {
-	resp, err := http.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/")
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("Auth service failed to update roles")
-	}
-
-	var user_roles models.UserRoles
-	json.NewDecoder(resp.Body).Decode(&user_roles)
-
-	user_roles.Roles = append(user_roles.Roles, role)
+	user_role_modification := models.UserRoleModification{ID: id, Role: role}
 
 	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_roles)
+	json.NewEncoder(&body).Encode(&user_role_modification)
 
 	client := http.Client{}
-	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/", &body)
+	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/add/", &body)
 
 	if err != nil {
 		return err
@@ -54,7 +41,7 @@ func AddRole(id string, role string) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err = client.Do(req)
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return err

--- a/services/rsvp/models/user_role_modification.go
+++ b/services/rsvp/models/user_role_modification.go
@@ -1,0 +1,6 @@
+package models
+
+type UserRoleModification struct {
+	ID   string `json:"id"`
+	Role string `json:"role"`
+}

--- a/services/rsvp/service/auth_service.go
+++ b/services/rsvp/service/auth_service.go
@@ -13,26 +13,13 @@ import (
 	Add Attendee role to user with auth service
 */
 func AddAttendeeRole(id string) error {
-	resp, err := http.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/")
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("Auth service failed to update roles")
-	}
-
-	var user_roles models.UserRoles
-	json.NewDecoder(resp.Body).Decode(&user_roles)
-
-	user_roles.Roles = append(user_roles.Roles, "Attendee")
+	user_role_modification := models.UserRoleModification{ID: id, Role: "Attendee"}
 
 	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_roles)
+	json.NewEncoder(&body).Encode(&user_role_modification)
 
 	client := http.Client{}
-	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/", &body)
+	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/add/", &body)
 
 	if err != nil {
 		return err
@@ -40,7 +27,7 @@ func AddAttendeeRole(id string) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err = client.Do(req)
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return err
@@ -57,30 +44,13 @@ func AddAttendeeRole(id string) error {
 	Remove Attendee role from user with auth service
 */
 func RemoveAttendeeRole(id string) error {
-	resp, err := http.Get(config.AUTH_SERVICE + "/auth/roles/" + id + "/")
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("Auth service failed to update roles")
-	}
-
-	var user_roles models.UserRoles
-	json.NewDecoder(resp.Body).Decode(&user_roles)
-
-	for index, role := range user_roles.Roles {
-		if role == "Attendee" {
-			user_roles.Roles = append(user_roles.Roles[:index], user_roles.Roles[index+1:]...)
-		}
-	}
+	user_role_modification := models.UserRoleModification{ID: id, Role: "Attendee"}
 
 	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_roles)
+	json.NewEncoder(&body).Encode(&user_role_modification)
 
 	client := http.Client{}
-	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/", &body)
+	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/remove/", &body)
 
 	if err != nil {
 		return err
@@ -88,7 +58,7 @@ func RemoveAttendeeRole(id string) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err = client.Do(req)
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Resolves #28.

Removes the `PUT /auth/roles/` endpoint and replaces it with `PUT /auth/roles/add/` and `PUT /auth/roles/remove/`. Requires Admin permissions.

Adds relevant documentation and tests.

Request format:

```
{
	"id": "github6892396",
	"role": "User"
}
```

Response format:

```
{
	"id": "github6892396",
	"roles": [
		"User"
	]
}
```

`/roles/remove/` will throw a `400` response if the user does not have the specified role.

References to the old endpoint were updated.

In addition, two slice utility functions were created and added to `common/utils/slice_utils.go`, `ContainsString` and `RemoveString`, which check if a slice contains a string and remove a string from a given slice, respectively.
