### PR TITLE
Make user an Attendee on check-in override

### DIFF
--- a/services/checkin/controller/controller.go
+++ b/services/checkin/controller/controller.go
@@ -80,6 +80,14 @@ func CreateUserCheckin(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
+	if updated_checkin.Override {
+		err = service.AddAttendeeRole(updated_checkin.ID)
+
+		if err != nil {
+			panic(errors.UnprocessableError(err.Error()))
+		}
+	}
+
 	json.NewEncoder(w).Encode(updated_checkin)
 }
 
@@ -100,6 +108,14 @@ func UpdateUserCheckin(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	if updated_checkin.Override {
+		err = service.AddAttendeeRole(updated_checkin.ID)
+
+		if err != nil {
+			panic(errors.UnprocessableError(err.Error()))
+		}
 	}
 
 	json.NewEncoder(w).Encode(updated_checkin)

--- a/services/checkin/service/auth_service.go
+++ b/services/checkin/service/auth_service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
 	"net/http"
@@ -18,22 +19,13 @@ func AddAttendeeRole(id string) error {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_role_modification)
 
-	client := http.Client{}
-	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/add/", &body)
+	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/add/", &body, nil)
 
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Auth service failed to update roles")
 	}
 
@@ -49,22 +41,13 @@ func RemoveAttendeeRole(id string) error {
 	body := bytes.Buffer{}
 	json.NewEncoder(&body).Encode(&user_role_modification)
 
-	client := http.Client{}
-	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/remove/", &body)
+	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/remove/", &body, nil)
 
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		return errors.New("Auth service failed to update roles")
 	}
 

--- a/services/checkin/service/auth_service.go
+++ b/services/checkin/service/auth_service.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"github.com/HackIllinois/api/services/rsvp/config"
+	"github.com/HackIllinois/api/services/rsvp/models"
+	"net/http"
+)
+
+/*
+	Add Attendee role to user with auth service
+*/
+func AddAttendeeRole(id string) error {
+	user_role_modification := models.UserRoleModification{ID: id, Role: "Attendee"}
+
+	body := bytes.Buffer{}
+	json.NewEncoder(&body).Encode(&user_role_modification)
+
+	client := http.Client{}
+	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/add/", &body)
+
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("Auth service failed to update roles")
+	}
+
+	return nil
+}
+
+/*
+	Remove Attendee role from user with auth service
+*/
+func RemoveAttendeeRole(id string) error {
+	user_role_modification := models.UserRoleModification{ID: id, Role: "Attendee"}
+
+	body := bytes.Buffer{}
+	json.NewEncoder(&body).Encode(&user_role_modification)
+
+	client := http.Client{}
+	req, err := http.NewRequest("PUT", config.AUTH_SERVICE+"/auth/roles/remove/", &body)
+
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("Auth service failed to update roles")
+	}
+
+	return nil
+}

--- a/services/checkin/service/auth_service.go
+++ b/services/checkin/service/auth_service.go
@@ -31,25 +31,3 @@ func AddAttendeeRole(id string) error {
 
 	return nil
 }
-
-/*
-	Remove Attendee role from user with auth service
-*/
-func RemoveAttendeeRole(id string) error {
-	user_role_modification := models.UserRoleModification{ID: id, Role: "Attendee"}
-
-	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_role_modification)
-
-	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/remove/", &body, nil)
-
-	if err != nil {
-		return err
-	}
-
-	if status != http.StatusOK {
-		return errors.New("Auth service failed to update roles")
-	}
-
-	return nil
-}


### PR DESCRIPTION
Depends on #84, resolves #11.

Adds the "Attendee" role to a user if they at any point receive a check-in override (via `POST /checkin/` or `PUT /checkin/`) so that they have the same status as an RSVP-ed attendee.

Tested manually by hitting both relevant endpoints.