### PR TITLE
[WIP] Datastore

### DIFF
--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -1,0 +1,289 @@
+package datastore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"gopkg.in/go-playground/validator.v9"
+)
+
+type DataStoreDefinition struct {
+	Name        string                `json:"name"`
+	Type        string                `json:"type"`
+	IsArray     bool                  `json:"IsArray"`
+	Validations string                `json:"validations"`
+	Fields      []DataStoreDefinition `json:"fields"`
+}
+
+type DataStore struct {
+	Definition DataStoreDefinition
+	rawData    map[string]interface{}
+	Data       map[string]interface{}
+}
+
+func NewDataStore(definition DataStoreDefinition) DataStore {
+	return DataStore{
+		Definition: definition,
+	}
+}
+
+func (datastore *DataStore) Validate() error {
+	validate := validator.New()
+
+	return validateField(datastore.Data, datastore.Definition, validate)
+}
+
+func validateField(data interface{}, definition DataStoreDefinition, validate *validator.Validate) error {
+
+	fmt.Printf("%T: %v\n\n", data, data)
+
+	err := validate.Var(data, definition.Validations)
+
+	if err != nil {
+		return err
+	}
+
+	switch definition.Type {
+	case "object":
+		for _, field := range definition.Fields {
+			mappedData, ok := data.(map[string]interface{})
+
+			if !ok {
+				return errors.New("Definition contains field for non-mappable data")
+			}
+
+			err = validateField(mappedData[field.Name], field, validate)
+
+			if err != nil {
+				return err
+			}
+		}
+	case "[]object":
+		dataArray, ok := data.([]map[string]interface{})
+
+		if !ok {
+			return errors.New("Data format does not match definition")
+		}
+
+		for _, mappedData := range dataArray {
+			for _, field := range definition.Fields {
+				err = validateField(mappedData[field.Name], field, validate)
+
+				if err != nil {
+					return err
+				}
+			}
+		}
+	default:
+	}
+
+	return nil
+}
+
+func (datastore *DataStore) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&datastore.Data)
+}
+
+func (datastore *DataStore) UnmarshalJSON(b []byte) error {
+	err := json.Unmarshal(b, &datastore.rawData)
+
+	if err != nil {
+		return err
+	}
+
+	data, err := buildDataFromDefinition(datastore.rawData, datastore.Definition)
+
+	if err != nil {
+		return err
+	}
+
+	var ok bool
+	datastore.Data, ok = data.(map[string]interface{})
+
+	if !ok {
+		return errors.New("Invalid data unmarshalled")
+	}
+
+	return nil
+}
+
+func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition) (interface{}, error) {
+	switch definition.Type {
+	case "int":
+		data, ok := rawData.(float64)
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		return int64(data), nil
+	case "float":
+		data, ok := rawData.(float64)
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		return data, nil
+	case "string":
+		data, ok := rawData.(string)
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		return data, nil
+	case "boolean":
+		data, ok := rawData.(bool)
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		return data, nil
+	case "object":
+		unfilteredData, ok := rawData.(map[string]interface{})
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		data := make(map[string]interface{})
+
+		for _, field := range definition.Fields {
+			unfilteredField, exists := unfilteredData[field.Name]
+
+			if !exists {
+				return nil, errors.New("Missing field in data")
+			}
+
+			var err error
+			data[field.Name], err = buildDataFromDefinition(unfilteredField, field)
+
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return data, nil
+	case "[]int":
+		data, ok := rawData.([]interface{})
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		intData := make([]int64, len(data))
+
+		for i := 0; i < len(data); i++ {
+			element, ok := data[i].(float64)
+
+			if !ok {
+				return nil, errors.New("Type mismatch in data and definition")
+			}
+
+			intData[i] = int64(element)
+		}
+
+		return intData, nil
+	case "[]float":
+		data, ok := rawData.([]interface{})
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		floatData := make([]float64, len(data))
+
+		for i := 0; i < len(data); i++ {
+			element, ok := data[i].(float64)
+
+			if !ok {
+				return nil, errors.New("Type mismatch in data and definition")
+			}
+
+			floatData[i] = element
+		}
+
+		return floatData, nil
+	case "[]string":
+		data, ok := rawData.([]interface{})
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		stringData := make([]string, len(data))
+
+		for i := 0; i < len(data); i++ {
+			element, ok := data[i].(string)
+
+			if !ok {
+				return nil, errors.New("Type mismatch in data and definition")
+			}
+
+			stringData[i] = element
+		}
+
+		return stringData, nil
+	case "[]boolean":
+		data, ok := rawData.([]interface{})
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		boolData := make([]bool, len(data))
+
+		for i := 0; i < len(data); i++ {
+			element, ok := data[i].(bool)
+
+			if !ok {
+				return nil, errors.New("Type mismatch in data and definition")
+			}
+
+			boolData[i] = element
+		}
+
+		return boolData, nil
+	case "[]object":
+		unfilteredData, ok := rawData.([]interface{})
+
+		if !ok {
+			return nil, errors.New("Type mismatch in data and definition")
+		}
+
+		data := make([]map[string]interface{}, len(unfilteredData))
+
+		for i := 0; i < len(unfilteredData); i++ {
+			element := make(map[string]interface{})
+
+			for _, field := range definition.Fields {
+				unfilteredDataElement, ok := unfilteredData[i].(map[string]interface{})
+
+				if !ok {
+					return nil, errors.New("Type mismatch in data and definition")
+				}
+
+				unfilteredField, exists := unfilteredDataElement[field.Name]
+
+				if !exists {
+					return nil, errors.New("Missing field in data")
+				}
+
+				var err error
+				element[field.Name], err = buildDataFromDefinition(unfilteredField, field)
+
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			data[i] = element
+		}
+
+		return data, nil
+	default:
+		return nil, errors.New("Invalid type in definition")
+	}
+}

--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -9,7 +9,6 @@ import (
 type DataStoreDefinition struct {
 	Name        string                `json:"name"`
 	Type        string                `json:"type"`
-	IsArray     bool                  `json:"IsArray"`
 	Validations string                `json:"validations"`
 	Fields      []DataStoreDefinition `json:"fields"`
 }

--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"gopkg.in/go-playground/validator.v9"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type DataStoreDefinition struct {
@@ -308,4 +309,12 @@ func defaultValueForType(tpe string) interface{} {
 	default:
 		return nil
 	}
+}
+
+func (datastore *DataStore) GetBSON() (interface{}, error) {
+	return datastore.Data, nil
+}
+
+func (datastore *DataStore) SetBSON(raw bson.Raw) error {
+	return raw.Unmarshal(&datastore.Data)
 }

--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -149,15 +149,15 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 		for _, field := range definition.Fields {
 			unfilteredField, exists := unfilteredData[field.Name]
 
-			if !exists {
-				return nil, errors.New("Missing field in data")
-			}
+			if exists {
+				var err error
+				data[field.Name], err = buildDataFromDefinition(unfilteredField, field)
 
-			var err error
-			data[field.Name], err = buildDataFromDefinition(unfilteredField, field)
-
-			if err != nil {
-				return nil, err
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				data[field.Name] = defaultValueForType(field.Type)
 			}
 		}
 
@@ -263,15 +263,15 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 
 				unfilteredField, exists := unfilteredDataElement[field.Name]
 
-				if !exists {
-					return nil, errors.New("Missing field in data")
-				}
+				if exists {
+					var err error
+					element[field.Name], err = buildDataFromDefinition(unfilteredField, field)
 
-				var err error
-				element[field.Name], err = buildDataFromDefinition(unfilteredField, field)
-
-				if err != nil {
-					return nil, err
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					element[field.Name] = defaultValueForType(field.Type)
 				}
 			}
 
@@ -281,5 +281,32 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 		return data, nil
 	default:
 		return nil, errors.New("Invalid type in definition")
+	}
+}
+
+func defaultValueForType(tpe string) interface{} {
+	switch tpe {
+	case "string":
+		return ""
+	case "int":
+		return 0
+	case "float":
+		return 0.0
+	case "boolean":
+		return false
+	case "object":
+		return nil
+	case "[]string":
+		return nil
+	case "[]int":
+		return nil
+	case "[]float":
+		return nil
+	case "[]boolean":
+		return nil
+	case "[]object":
+		return nil
+	default:
+		return nil
 	}
 }

--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -16,7 +16,7 @@ type DataStoreDefinition struct {
 
 type DataStore struct {
 	Definition DataStoreDefinition
-	rawData    map[string]interface{}
+	raw_data    map[string]interface{}
 	Data       map[string]interface{}
 }
 
@@ -42,28 +42,28 @@ func validateField(data interface{}, definition DataStoreDefinition, validate *v
 	switch definition.Type {
 	case "object":
 		for _, field := range definition.Fields {
-			mappedData, ok := data.(map[string]interface{})
+			mapped_data, ok := data.(map[string]interface{})
 
 			if !ok {
 				return errors.New("Definition contains field for non-mappable data")
 			}
 
-			err = validateField(mappedData[field.Name], field, validate)
+			err = validateField(mapped_data[field.Name], field, validate)
 
 			if err != nil {
 				return err
 			}
 		}
 	case "[]object":
-		dataArray, ok := data.([]map[string]interface{})
+		data_array, ok := data.([]map[string]interface{})
 
 		if !ok {
 			return errors.New("Data format does not match definition")
 		}
 
-		for _, mappedData := range dataArray {
+		for _, mapped_data := range data_array {
 			for _, field := range definition.Fields {
-				err = validateField(mappedData[field.Name], field, validate)
+				err = validateField(mapped_data[field.Name], field, validate)
 
 				if err != nil {
 					return err
@@ -81,13 +81,13 @@ func (datastore *DataStore) MarshalJSON() ([]byte, error) {
 }
 
 func (datastore *DataStore) UnmarshalJSON(b []byte) error {
-	err := json.Unmarshal(b, &datastore.rawData)
+	err := json.Unmarshal(b, &datastore.raw_data)
 
 	if err != nil {
 		return err
 	}
 
-	data, err := buildDataFromDefinition(datastore.rawData, datastore.Definition)
+	data, err := buildDataFromDefinition(datastore.raw_data, datastore.Definition)
 
 	if err != nil {
 		return err
@@ -103,10 +103,10 @@ func (datastore *DataStore) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition) (interface{}, error) {
+func buildDataFromDefinition(raw_data interface{}, definition DataStoreDefinition) (interface{}, error) {
 	switch definition.Type {
 	case "int":
-		data, ok := rawData.(float64)
+		data, ok := raw_data.(float64)
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
@@ -114,7 +114,7 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 
 		return int64(data), nil
 	case "float":
-		data, ok := rawData.(float64)
+		data, ok := raw_data.(float64)
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
@@ -122,7 +122,7 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 
 		return data, nil
 	case "string":
-		data, ok := rawData.(string)
+		data, ok := raw_data.(string)
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
@@ -130,7 +130,7 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 
 		return data, nil
 	case "boolean":
-		data, ok := rawData.(bool)
+		data, ok := raw_data.(bool)
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
@@ -138,7 +138,7 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 
 		return data, nil
 	case "object":
-		unfilteredData, ok := rawData.(map[string]interface{})
+		unfiltered_data, ok := raw_data.(map[string]interface{})
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
@@ -147,11 +147,11 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 		data := make(map[string]interface{})
 
 		for _, field := range definition.Fields {
-			unfilteredField, exists := unfilteredData[field.Name]
+			unfiltered_fields, exists := unfiltered_data[field.Name]
 
 			if exists {
 				var err error
-				data[field.Name], err = buildDataFromDefinition(unfilteredField, field)
+				data[field.Name], err = buildDataFromDefinition(unfiltered_fields, field)
 
 				if err != nil {
 					return nil, err
@@ -163,13 +163,13 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 
 		return data, nil
 	case "[]int":
-		data, ok := rawData.([]interface{})
+		data, ok := raw_data.([]interface{})
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
 		}
 
-		intData := make([]int64, len(data))
+		int_data := make([]int64, len(data))
 
 		for i := 0; i < len(data); i++ {
 			element, ok := data[i].(float64)
@@ -178,18 +178,18 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 				return nil, errors.New("Type mismatch in data and definition")
 			}
 
-			intData[i] = int64(element)
+			int_data[i] = int64(element)
 		}
 
-		return intData, nil
+		return int_data, nil
 	case "[]float":
-		data, ok := rawData.([]interface{})
+		data, ok := raw_data.([]interface{})
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
 		}
 
-		floatData := make([]float64, len(data))
+		float_data := make([]float64, len(data))
 
 		for i := 0; i < len(data); i++ {
 			element, ok := data[i].(float64)
@@ -198,18 +198,18 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 				return nil, errors.New("Type mismatch in data and definition")
 			}
 
-			floatData[i] = element
+			float_data[i] = element
 		}
 
-		return floatData, nil
+		return float_data, nil
 	case "[]string":
-		data, ok := rawData.([]interface{})
+		data, ok := raw_data.([]interface{})
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
 		}
 
-		stringData := make([]string, len(data))
+		string_data := make([]string, len(data))
 
 		for i := 0; i < len(data); i++ {
 			element, ok := data[i].(string)
@@ -218,18 +218,18 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 				return nil, errors.New("Type mismatch in data and definition")
 			}
 
-			stringData[i] = element
+			string_data[i] = element
 		}
 
-		return stringData, nil
+		return string_data, nil
 	case "[]boolean":
-		data, ok := rawData.([]interface{})
+		data, ok := raw_data.([]interface{})
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
 		}
 
-		boolData := make([]bool, len(data))
+		bool_data := make([]bool, len(data))
 
 		for i := 0; i < len(data); i++ {
 			element, ok := data[i].(bool)
@@ -238,34 +238,34 @@ func buildDataFromDefinition(rawData interface{}, definition DataStoreDefinition
 				return nil, errors.New("Type mismatch in data and definition")
 			}
 
-			boolData[i] = element
+			bool_data[i] = element
 		}
 
-		return boolData, nil
+		return bool_data, nil
 	case "[]object":
-		unfilteredData, ok := rawData.([]interface{})
+		unfiltered_data, ok := raw_data.([]interface{})
 
 		if !ok {
 			return nil, errors.New("Type mismatch in data and definition")
 		}
 
-		data := make([]map[string]interface{}, len(unfilteredData))
+		data := make([]map[string]interface{}, len(unfiltered_data))
 
-		for i := 0; i < len(unfilteredData); i++ {
+		for i := 0; i < len(unfiltered_data); i++ {
 			element := make(map[string]interface{})
 
 			for _, field := range definition.Fields {
-				unfilteredDataElement, ok := unfilteredData[i].(map[string]interface{})
+				unfiltered_data_element, ok := unfiltered_data[i].(map[string]interface{})
 
 				if !ok {
 					return nil, errors.New("Type mismatch in data and definition")
 				}
 
-				unfilteredField, exists := unfilteredDataElement[field.Name]
+				unfiltered_fields, exists := unfiltered_data_element[field.Name]
 
 				if exists {
 					var err error
-					element[field.Name], err = buildDataFromDefinition(unfilteredField, field)
+					element[field.Name], err = buildDataFromDefinition(unfiltered_fields, field)
 
 					if err != nil {
 						return nil, err

--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -34,9 +33,6 @@ func (datastore *DataStore) Validate() error {
 }
 
 func validateField(data interface{}, definition DataStoreDefinition, validate *validator.Validate) error {
-
-	fmt.Printf("%T: %v\n\n", data, data)
-
 	err := validate.Var(data, definition.Validations)
 
 	if err != nil {

--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -16,7 +16,6 @@ type DataStoreDefinition struct {
 
 type DataStore struct {
 	Definition DataStoreDefinition
-	raw_data    map[string]interface{}
 	Data       map[string]interface{}
 }
 
@@ -81,13 +80,14 @@ func (datastore *DataStore) MarshalJSON() ([]byte, error) {
 }
 
 func (datastore *DataStore) UnmarshalJSON(b []byte) error {
-	err := json.Unmarshal(b, &datastore.raw_data)
+	var raw_data map[string]interface{}
+	err := json.Unmarshal(b, &raw_data)
 
 	if err != nil {
 		return err
 	}
 
-	data, err := buildDataFromDefinition(datastore.raw_data, datastore.Definition)
+	data, err := buildDataFromDefinition(raw_data, datastore.Definition)
 
 	if err != nil {
 		return err

--- a/common/tests/datastore_test.go
+++ b/common/tests/datastore_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/HackIllinois/api/common/datastore"
 	"testing"
+	"gopkg.in/mgo.v2/bson"
 )
 
 var smallJsonData string = `
@@ -407,5 +408,47 @@ func TestDatastoreComplex(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestBSONConversions(t *testing.T) {
+	var definiton datastore.DataStoreDefinition
+	err := json.Unmarshal([]byte(largeJsonDefiniton), &definiton)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := datastore.NewDataStore(definiton)
+
+	err = json.Unmarshal([]byte(largeJsonData), &store)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bsonMarshalled, err := bson.Marshal(&store)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var unmarshalledStore datastore.DataStore
+	err = bson.Unmarshal(bsonMarshalled, &unmarshalledStore)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if unmarshalledStore.Data["firstName"] != store.Data["firstName"] {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["firstName"], unmarshalledStore.Data["firstName"])
+	}
+
+	if unmarshalledStore.Data["age"] != store.Data["age"] {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["age"], unmarshalledStore.Data["age"])
+	}
+
+	if unmarshalledStore.Data["isNovice"] != store.Data["isNovice"] {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["isNovice"], unmarshalledStore.Data["isNovice"])
 	}
 }

--- a/common/tests/datastore_test.go
+++ b/common/tests/datastore_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/HackIllinois/api/common/datastore"
 	"testing"
 )
@@ -319,38 +318,34 @@ var largeJsonDefiniton = `
 }
 `
 
-// func TestDatastoreBasic(t *testing.T) {
-// 	var definiton datastore.DataStoreDefinition
-// 	err := json.Unmarshal([]byte(smallJsonDefinition), &definiton)
+func TestDatastoreBasic(t *testing.T) {
+	var definiton datastore.DataStoreDefinition
+	err := json.Unmarshal([]byte(smallJsonDefinition), &definiton)
 
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	store := datastore.NewDataStore(definiton)
+	store := datastore.NewDataStore(definiton)
 
-// 	err = json.Unmarshal([]byte(smallJsonData), &store)
+	err = json.Unmarshal([]byte(smallJsonData), &store)
 
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	fmt.Printf("%v\n", store)
+	_, err = json.Marshal(&store)
 
-// 	marshalledData, err := json.Marshal(&store)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	err = store.Validate()
 
-// 	fmt.Printf("%v\n", string(marshalledData))
-
-// 	err = store.Validate()
-
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// }
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestDatastoreComplex(t *testing.T) {
 	var definiton datastore.DataStoreDefinition
@@ -368,7 +363,17 @@ func TestDatastoreComplex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Printf("%v\n", store)
+	if store.Data["firstName"] != "test" {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", "test", store.Data["firstName"])
+	}
+
+	if store.Data["age"] != int64(19) {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", int64(19), store.Data["age"])
+	}
+
+	if store.Data["isNovice"] != false {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", false, store.Data["isNovice"])
+	}
 
 	marshalledData, err := json.Marshal(&store)
 
@@ -376,7 +381,24 @@ func TestDatastoreComplex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Printf("%v\n", string(marshalledData))
+	var rawData map[string]interface{}
+	err = json.Unmarshal(marshalledData, &rawData)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rawData["firstName"] != "test" {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", "test", rawData["firstName"])
+	}
+
+	if rawData["age"] != float64(19) {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", float64(19), rawData["age"])
+	}
+
+	if rawData["isNovice"] != false {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", false, rawData["isNovice"])
+	}
 
 	store.Data["createdAt"] = 1536178263
 	store.Data["updatedAt"] = 1543011468

--- a/common/tests/datastore_test.go
+++ b/common/tests/datastore_test.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-var smallJsonData string = `
+var small_json_data string = `
 {
 	"intKey": 100,
 	"stringKey": "value",
@@ -26,7 +26,7 @@ var smallJsonData string = `
 }
 `
 
-var smallJsonDefinition string = `
+var small_json_definition string = `
 {
 	"name": "topLevel",
 	"type": "object",
@@ -80,7 +80,7 @@ var smallJsonDefinition string = `
 }
 `
 
-var largeJsonData = `
+var large_json_data = `
 {
     "id": "google000000000000000000001",
     "firstName": "test",
@@ -125,7 +125,7 @@ var largeJsonData = `
 }
 `
 
-var largeJsonDefiniton = `
+var large_json_definition = `
 {
     "name": "user_registration",
     "type": "object",
@@ -320,16 +320,16 @@ var largeJsonDefiniton = `
 `
 
 func TestDatastoreBasic(t *testing.T) {
-	var definiton datastore.DataStoreDefinition
-	err := json.Unmarshal([]byte(smallJsonDefinition), &definiton)
+	var definition datastore.DataStoreDefinition
+	err := json.Unmarshal([]byte(small_json_definition), &definition)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	store := datastore.NewDataStore(definiton)
+	store := datastore.NewDataStore(definition)
 
-	err = json.Unmarshal([]byte(smallJsonData), &store)
+	err = json.Unmarshal([]byte(small_json_data), &store)
 
 	if err != nil {
 		t.Fatal(err)
@@ -349,16 +349,16 @@ func TestDatastoreBasic(t *testing.T) {
 }
 
 func TestDatastoreComplex(t *testing.T) {
-	var definiton datastore.DataStoreDefinition
-	err := json.Unmarshal([]byte(largeJsonDefiniton), &definiton)
+	var definition datastore.DataStoreDefinition
+	err := json.Unmarshal([]byte(large_json_definition), &definition)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	store := datastore.NewDataStore(definiton)
+	store := datastore.NewDataStore(definition)
 
-	err = json.Unmarshal([]byte(largeJsonData), &store)
+	err = json.Unmarshal([]byte(large_json_data), &store)
 
 	if err != nil {
 		t.Fatal(err)
@@ -376,29 +376,29 @@ func TestDatastoreComplex(t *testing.T) {
 		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", false, store.Data["isNovice"])
 	}
 
-	marshalledData, err := json.Marshal(&store)
+	marshalled_data, err := json.Marshal(&store)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var rawData map[string]interface{}
-	err = json.Unmarshal(marshalledData, &rawData)
+	var raw_data map[string]interface{}
+	err = json.Unmarshal(marshalled_data, &raw_data)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if rawData["firstName"] != "test" {
-		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", "test", rawData["firstName"])
+	if raw_data["firstName"] != "test" {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", "test", raw_data["firstName"])
 	}
 
-	if rawData["age"] != float64(19) {
-		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", float64(19), rawData["age"])
+	if raw_data["age"] != float64(19) {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", float64(19), raw_data["age"])
 	}
 
-	if rawData["isNovice"] != false {
-		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", false, rawData["isNovice"])
+	if raw_data["isNovice"] != false {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", false, raw_data["isNovice"])
 	}
 
 	store.Data["createdAt"] = 1536178263
@@ -412,43 +412,43 @@ func TestDatastoreComplex(t *testing.T) {
 }
 
 func TestBSONConversions(t *testing.T) {
-	var definiton datastore.DataStoreDefinition
-	err := json.Unmarshal([]byte(largeJsonDefiniton), &definiton)
+	var definition datastore.DataStoreDefinition
+	err := json.Unmarshal([]byte(large_json_definition), &definition)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	store := datastore.NewDataStore(definiton)
+	store := datastore.NewDataStore(definition)
 
-	err = json.Unmarshal([]byte(largeJsonData), &store)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	bsonMarshalled, err := bson.Marshal(&store)
+	err = json.Unmarshal([]byte(large_json_data), &store)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var unmarshalledStore datastore.DataStore
-	err = bson.Unmarshal(bsonMarshalled, &unmarshalledStore)
+	bson_marshalled, err := bson.Marshal(&store)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if unmarshalledStore.Data["firstName"] != store.Data["firstName"] {
-		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["firstName"], unmarshalledStore.Data["firstName"])
+	var unmarshalled_store datastore.DataStore
+	err = bson.Unmarshal(bson_marshalled, &unmarshalled_store)
+
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	if unmarshalledStore.Data["age"] != store.Data["age"] {
-		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["age"], unmarshalledStore.Data["age"])
+	if unmarshalled_store.Data["firstName"] != store.Data["firstName"] {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["firstName"], unmarshalled_store.Data["firstName"])
 	}
 
-	if unmarshalledStore.Data["isNovice"] != store.Data["isNovice"] {
-		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["isNovice"], unmarshalledStore.Data["isNovice"])
+	if unmarshalled_store.Data["age"] != store.Data["age"] {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["age"], unmarshalled_store.Data["age"])
+	}
+
+	if unmarshalled_store.Data["isNovice"] != store.Data["isNovice"] {
+		t.Errorf("Wrong info.\nExpected %v\ngot %v\n", store.Data["isNovice"], unmarshalled_store.Data["isNovice"])
 	}
 }

--- a/common/tests/datastore_test.go
+++ b/common/tests/datastore_test.go
@@ -1,0 +1,114 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/HackIllinois/api/common/datastore"
+	"testing"
+)
+
+var jsonData string = `
+{
+	"intKey": 100,
+	"stringKey": "value",
+	"objectKey": {
+		"stringKeys": [
+			"value2",
+			"value3"
+		],
+		"objectKeys": [
+			{
+				"thing1": 2,
+				"thing2": "a"
+			}
+		]
+	}
+}
+`
+
+var jsonDefinition string = `
+{
+	"name": "topLevel",
+	"type": "object",
+	"validations": "required",
+	"fields": [
+		{
+			"name": "intKey",
+			"type": "int",
+			"validations": "required",
+			"fields": []
+		},
+		{
+			"name": "stringKey",
+			"type": "string",
+			"validations": "required",
+			"fields": []
+		},
+		{
+			"name": "objectKey",
+			"type": "object",
+			"validations": "required",
+			"fields": [
+				{
+					"name": "stringKeys",
+					"type": "[]string",
+					"validations": "required,dive,required,oneof=value2 value3",
+					"fields": []
+				},
+				{
+					"name": "objectKeys",
+					"type": "[]object",
+					"validations": "required",
+					"fields": [
+						{
+							"name": "thing1",
+							"type": "int",
+							"validations": "required",
+							"fields": []
+						},
+						{
+							"name": "thing2",
+							"type": "string",
+							"validations": "required",
+							"fields": []
+						}
+					]
+				}
+			]
+		}
+	]
+}
+`
+
+func TestDatastore(t *testing.T) {
+	var definiton datastore.DataStoreDefinition
+	err := json.Unmarshal([]byte(jsonDefinition), &definiton)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := datastore.NewDataStore(definiton)
+
+	err = json.Unmarshal([]byte(jsonData), &store)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("%v\n", store)
+
+	marshalledData, err := json.Marshal(&store)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("%v\n", string(marshalledData))
+
+	err = store.Validate()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/common/tests/datastore_test.go
+++ b/common/tests/datastore_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-var jsonData string = `
+var smallJsonData string = `
 {
 	"intKey": 100,
 	"stringKey": "value",
@@ -26,7 +26,7 @@ var jsonData string = `
 }
 `
 
-var jsonDefinition string = `
+var smallJsonDefinition string = `
 {
 	"name": "topLevel",
 	"type": "object",
@@ -80,9 +80,283 @@ var jsonDefinition string = `
 }
 `
 
-func TestDatastore(t *testing.T) {
+var largeJsonData = `
+{
+    "id": "google000000000000000000001",
+    "firstName": "test",
+    "lastName": "user",
+    "email": "testemail@gmail.com",
+    "shirtSize": "M",
+    "diet": "NONE",
+    "age": 19,
+    "graduationYear": 2020,
+    "transportation": "NONE",
+    "school": "University of Illinois at Urbana-Champaign",
+    "major": "Computer Science",
+    "gender": "MALE",
+    "professionalInterest": "INTERNSHIP",
+    "github": "test gihubusername",
+    "linkedin": "some-account",
+    "interests": "Software",
+    "isNovice": false,
+    "isPrivate": false,
+    "phoneNumber": "555-555-5555",
+    "longforms": [
+        {
+            "response": "This is a longform."
+        }
+    ],
+    "extraInfos": [
+        {
+            "response": "This is an extra info."
+        }
+    ],
+    "osContributors": [
+        {
+            "contactInfo": "person@gmail.com",
+            "name": "Person"
+        }
+    ],
+    "collaborators": [
+        {
+            "github": "persongithub"
+        }
+    ],
+    "createdAt": 1536178263,
+    "updatedAt": 1543011468
+}
+`
+
+var largeJsonDefiniton = `
+{
+    "name": "user_registration",
+    "type": "object",
+    "validations": "required",
+    "fields": [
+        {
+            "name": "id",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "firstName",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "lastName",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "email",
+            "type": "string",
+            "validations": "required,email",
+            "fields": []
+        },
+        {
+            "name": "shirtSize",
+            "type": "string",
+            "validations": "required,oneof=S M L XL",
+            "fields": []
+        },
+        {
+            "name": "diet",
+            "type": "string",
+            "validations": "required,oneof=NONE VEGAN VEGETARIAN",
+            "fields": []
+        },
+        {
+            "name": "age",
+            "type": "int",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "graduationYear",
+            "type": "int",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "transportation",
+            "type": "string",
+            "validations": "required,oneof=NONE BUS",
+            "fields": []
+        },
+        {
+            "name": "school",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "major",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "gender",
+            "type": "string",
+            "validations": "required,oneof=MALE FEMALE NONBINARY OTHER",
+            "fields": []
+        },
+        {
+            "name": "professionalInterest",
+            "type": "string",
+            "validations": "required,oneof=INTERNSHIP FULLTIME BOTH NONE",
+            "fields": []
+        },
+        {
+            "name": "github",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "linkedin",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "interests",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "isNovice",
+            "type": "boolean",
+            "validations": "required|isdefault",
+            "fields": []
+        },
+        {
+            "name": "isPrivate",
+            "type": "boolean",
+            "validations": "required|isdefault",
+            "fields": []
+        },
+        {
+            "name": "phoneNumber",
+            "type": "string",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "longforms",
+            "type": "[]object",
+            "validations": "required",
+            "fields": [
+                {
+                    "name": "response",
+                    "type": "string",
+                    "validations": "required",
+                    "fields": []
+                }
+            ]
+        },
+        {
+            "name": "extraInfos",
+            "type": "[]object",
+            "validations": "required",
+            "fields": [
+                {
+                    "name": "response",
+                    "type": "string",
+                    "validations": "required",
+                    "fields": []
+                }
+            ]
+        },
+        {
+            "name": "osContributors",
+            "type": "[]object",
+            "validations": "required",
+            "fields": [
+                {
+                    "name": "contactInfo",
+                    "type": "string",
+                    "validations": "required",
+                    "fields": []
+                },
+                {
+                    "name": "name",
+                    "type": "string",
+                    "validations": "required",
+                    "fields": []
+                }
+            ]
+        },
+        {
+            "name": "collaborators",
+            "type": "[]object",
+            "validations": "required",
+            "fields": [
+                {
+                    "name": "github",
+                    "type": "string",
+                    "validations": "required",
+                    "fields": []
+                }
+            ]
+        },
+        {
+            "name": "createdAt",
+            "type": "int",
+            "validations": "required",
+            "fields": []
+        },
+        {
+            "name": "updatedAt",
+            "type": "int",
+            "validations": "required",
+            "fields": []
+        }
+    ]
+}
+`
+
+// func TestDatastoreBasic(t *testing.T) {
+// 	var definiton datastore.DataStoreDefinition
+// 	err := json.Unmarshal([]byte(smallJsonDefinition), &definiton)
+
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	store := datastore.NewDataStore(definiton)
+
+// 	err = json.Unmarshal([]byte(smallJsonData), &store)
+
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	fmt.Printf("%v\n", store)
+
+// 	marshalledData, err := json.Marshal(&store)
+
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	fmt.Printf("%v\n", string(marshalledData))
+
+// 	err = store.Validate()
+
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// }
+
+func TestDatastoreComplex(t *testing.T) {
 	var definiton datastore.DataStoreDefinition
-	err := json.Unmarshal([]byte(jsonDefinition), &definiton)
+	err := json.Unmarshal([]byte(largeJsonDefiniton), &definiton)
 
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +364,7 @@ func TestDatastore(t *testing.T) {
 
 	store := datastore.NewDataStore(definiton)
 
-	err = json.Unmarshal([]byte(jsonData), &store)
+	err = json.Unmarshal([]byte(largeJsonData), &store)
 
 	if err != nil {
 		t.Fatal(err)

--- a/common/tests/datastore_test.go
+++ b/common/tests/datastore_test.go
@@ -121,9 +121,7 @@ var largeJsonData = `
         {
             "github": "persongithub"
         }
-    ],
-    "createdAt": 1536178263,
-    "updatedAt": 1543011468
+    ]
 }
 `
 
@@ -379,6 +377,9 @@ func TestDatastoreComplex(t *testing.T) {
 	}
 
 	fmt.Printf("%v\n", string(marshalledData))
+
+	store.Data["createdAt"] = 1536178263
+	store.Data["updatedAt"] = 1543011468
 
 	err = store.Validate()
 

--- a/common/tests/datastore_test.go
+++ b/common/tests/datastore_test.go
@@ -3,8 +3,8 @@ package tests
 import (
 	"encoding/json"
 	"github.com/HackIllinois/api/common/datastore"
-	"testing"
 	"gopkg.in/mgo.v2/bson"
+	"testing"
 )
 
 var small_json_data string = `


### PR DESCRIPTION
One of the long term goals for the API is to make is sufficiently generic such that R|P can deploy the same binaries are HackIllinois and only alter the configuration. The biggest issue with this goal has been the structs which define registration. We need a way to define all fields that should be in an attendee's registration via the configuration. This PR adds the concept of a datastore which reads in a json configuration that describes the json structure of the attendee registration along with the validations which need to be applied to the incoming data.

For example if we want the following json to be the structure of the attendee's registration:
```
{
    "id": "google000000000000000000001",
    "firstName": "test",
    "lastName": "user",
    "email": "testemail@gmail.com",
    "shirtSize": "M",
    "diet": "NONE",
    "age": 19,
    "graduationYear": 2020,
    "transportation": "NONE",
    "school": "University of Illinois at Urbana-Champaign",
    "major": "Computer Science",
    "gender": "MALE",
    "professionalInterest": "INTERNSHIP",
    "github": "test gihubusername",
    "linkedin": "some-account",
    "interests": "Software",
    "isNovice": false,
    "isPrivate": false,
    "phoneNumber": "555-555-5555",
    "longforms": [
        {
            "response": "This is a longform."
        }
    ],
    "extraInfos": [
        {
            "response": "This is an extra info."
        }
    ],
    "osContributors": [
        {
            "contactInfo": "person@gmail.com",
            "name": "Person"
        }
    ],
    "collaborators": [
        {
            "github": "persongithub"
        }
    ]
}
```
then we input the following to be the definition of that format:
```
{
    "name": "user_registration",
    "type": "object",
    "validations": "required",
    "fields": [
        {
            "name": "id",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "firstName",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "lastName",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "email",
            "type": "string",
            "validations": "required,email",
            "fields": []
        },
        {
            "name": "shirtSize",
            "type": "string",
            "validations": "required,oneof=S M L XL",
            "fields": []
        },
        {
            "name": "diet",
            "type": "string",
            "validations": "required,oneof=NONE VEGAN VEGETARIAN",
            "fields": []
        },
        {
            "name": "age",
            "type": "int",
            "validations": "required",
            "fields": []
        },
        {
            "name": "graduationYear",
            "type": "int",
            "validations": "required",
            "fields": []
        },
        {
            "name": "transportation",
            "type": "string",
            "validations": "required,oneof=NONE BUS",
            "fields": []
        },
        {
            "name": "school",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "major",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "gender",
            "type": "string",
            "validations": "required,oneof=MALE FEMALE NONBINARY OTHER",
            "fields": []
        },
        {
            "name": "professionalInterest",
            "type": "string",
            "validations": "required,oneof=INTERNSHIP FULLTIME BOTH NONE",
            "fields": []
        },
        {
            "name": "github",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "linkedin",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "interests",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "isNovice",
            "type": "boolean",
            "validations": "required|isdefault",
            "fields": []
        },
        {
            "name": "isPrivate",
            "type": "boolean",
            "validations": "required|isdefault",
            "fields": []
        },
        {
            "name": "phoneNumber",
            "type": "string",
            "validations": "required",
            "fields": []
        },
        {
            "name": "longforms",
            "type": "[]object",
            "validations": "required",
            "fields": [
                {
                    "name": "response",
                    "type": "string",
                    "validations": "required",
                    "fields": []
                }
            ]
        },
        {
            "name": "extraInfos",
            "type": "[]object",
            "validations": "required",
            "fields": [
                {
                    "name": "response",
                    "type": "string",
                    "validations": "required",
                    "fields": []
                }
            ]
        },
        {
            "name": "osContributors",
            "type": "[]object",
            "validations": "required",
            "fields": [
                {
                    "name": "contactInfo",
                    "type": "string",
                    "validations": "required",
                    "fields": []
                },
                {
                    "name": "name",
                    "type": "string",
                    "validations": "required",
                    "fields": []
                }
            ]
        },
        {
            "name": "collaborators",
            "type": "[]object",
            "validations": "required",
            "fields": [
                {
                    "name": "github",
                    "type": "string",
                    "validations": "required",
                    "fields": []
                }
            ]
        },
        {
            "name": "createdAt",
            "type": "int",
            "validations": "required",
            "fields": []
        },
        {
            "name": "updatedAt",
            "type": "int",
            "validations": "required",
            "fields": []
        }
    ]
}
```

Currently the datastore has the ability to marshal to and from both json and bson, so it has all the functionality required to be used. However the code quality is very poor at the moment. A lot of work needs to be done to eliminate duplicate code in regards to type assertions and conversions. (We might not be able to completely remove the duplication due to the lack of templating).

At the moment I'd like some feedback on the concept of the datastore rather than the exact code used in the implementation. If we need to tweak the public interface for the datastore I'd rather do that first before going in to clean everything up.