### PR TITLE
Fix/apirequests

### DIFF
--- a/services/auth/service/user_service.go
+++ b/services/auth/service/user_service.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -23,10 +21,7 @@ func SendUserInfo(id string, username string, first_name string, last_name strin
 		Email:     email,
 	}
 
-	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_info)
-
-	status, err := apirequest.Post(config.USER_SERVICE+"/user/", &body, nil)
+	status, err := apirequest.Post(config.USER_SERVICE+"/user/", &user_info, nil)
 
 	if err != nil {
 		return err

--- a/services/checkin/service/auth_service.go
+++ b/services/checkin/service/auth_service.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/rsvp/config"
@@ -16,10 +14,7 @@ import (
 func AddAttendeeRole(id string) error {
 	user_role_modification := models.UserRoleModification{ID: id, Role: "Attendee"}
 
-	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_role_modification)
-
-	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/add/", &body, nil)
+	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/add/", &user_role_modification, nil)
 
 	if err != nil {
 		return err

--- a/services/registration/service/auth-service.go
+++ b/services/registration/service/auth-service.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/registration/config"
@@ -30,10 +28,7 @@ func AddMentorRole(id string) error {
 func AddRole(id string, role string) error {
 	user_role_modification := models.UserRoleModification{ID: id, Role: role}
 
-	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_role_modification)
-
-	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/add/", &body, nil)
+	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/add/", &user_role_modification, nil)
 
 	if err != nil {
 		return err

--- a/services/registration/service/decision_service.go
+++ b/services/registration/service/decision_service.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/registration/config"
@@ -19,10 +17,7 @@ func AddInitialDecision(id string) error {
 		Status: "PENDING",
 	}
 
-	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&decision)
-
-	status, err := apirequest.Post(config.DECISION_SERVICE+"/decision/", &body, nil)
+	status, err := apirequest.Post(config.DECISION_SERVICE+"/decision/", &decision, nil)
 
 	if err != nil {
 		return err

--- a/services/rsvp/service/auth_service.go
+++ b/services/rsvp/service/auth_service.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/rsvp/config"
@@ -16,10 +14,7 @@ import (
 func AddAttendeeRole(id string) error {
 	user_role_modification := models.UserRoleModification{ID: id, Role: "Attendee"}
 
-	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_role_modification)
-
-	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/add/", &body, nil)
+	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/add/", &user_role_modification, nil)
 
 	if err != nil {
 		return err
@@ -38,10 +33,7 @@ func AddAttendeeRole(id string) error {
 func RemoveAttendeeRole(id string) error {
 	user_role_modification := models.UserRoleModification{ID: id, Role: "Attendee"}
 
-	body := bytes.Buffer{}
-	json.NewEncoder(&body).Encode(&user_role_modification)
-
-	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/remove/", &body, nil)
+	status, err := apirequest.Put(config.AUTH_SERVICE+"/auth/roles/remove/", &user_role_modification, nil)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes interservice POST requests. The `apirequests` package handles the json encoding on inputs. We should not be encoding the structs before passing them into the `apirequests` package.