### PR TITLE
Handle all CORS Preflight requests

### DIFF
--- a/gateway/services/services.go
+++ b/gateway/services/services.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"github.com/arbor-dev/arbor"
+	"github.com/justinas/alice"
 	"net/http"
 )
 
@@ -20,6 +21,16 @@ func Gateway(w http.ResponseWriter, r *http.Request) {
 }
 
 func RegisterAPIs() arbor.RouteCollection {
+
+	// arbor does not currently handle preflight requests
+	// so for now we handle them here
+	Routes = append(Routes, arbor.Route{
+		"Preflight",
+		"OPTIONS",
+		"/{name:.*}",
+		alice.New().ThenFunc(AllowCorsPreflight).ServeHTTP,
+	})
+
 	Routes = append(Routes, AuthRoutes...)
 	Routes = append(Routes, UserRoutes...)
 	Routes = append(Routes, RegistrationRoutes...)
@@ -31,4 +42,11 @@ func RegisterAPIs() arbor.RouteCollection {
 	Routes = append(Routes, EventRoutes...)
 	Routes = append(Routes, StatRoutes...)
 	return Routes
+}
+
+func AllowCorsPreflight(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS, CONNECT")
+	w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, Origin, Content-Disposition")
+	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
This is a temporary patch to handle all cors requests until arbor-dev/arbor#59 is finished and merged.