### PR TITLE
Configurable registration

### DIFF
--- a/common/datastore/serialization.go
+++ b/common/datastore/serialization.go
@@ -38,7 +38,15 @@ func (datastore *DataStore) GetBSON() (interface{}, error) {
 }
 
 func (datastore *DataStore) SetBSON(raw bson.Raw) error {
-	return raw.Unmarshal(&datastore.Data)
+	err := raw.Unmarshal(&datastore.Data)
+
+	if err != nil {
+		return err
+	}
+
+	delete(datastore.Data, "_id")
+
+	return nil
 }
 
 func buildDataFromDefinition(raw_data interface{}, definition DataStoreDefinition) (interface{}, error) {

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -252,5 +252,66 @@
 				"fields": []
 			}
 		]
+	},
+	"MENTOR_REGISTRATION_DEFINITION": {
+		"name": "mentor_registration",
+		"type": "object",
+		"validations": "required",
+		"fields": [
+			{
+				"name": "id",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "firstName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "lastName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "email",
+				"type": "string",
+				"validations": "required,email",
+				"fields": []
+			},
+			{
+				"name": "shirtSize",
+				"type": "string",
+				"validations": "required,oneof=S M L XL",
+				"fields": []
+			},
+			{
+				"name": "github",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "linkedin",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "createdAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "updatedAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			}
+		]
 	}
 }

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -60,5 +60,197 @@
 
 	"SPARKPOST_APIKEY": "",
 
-	"IS_PRODUCTION": "false"
+	"IS_PRODUCTION": "false",
+
+	"REGISTRATION_DEFINITION": {
+		"name": "user_registration",
+		"type": "object",
+		"validations": "required",
+		"fields": [
+			{
+				"name": "id",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "firstName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "lastName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "email",
+				"type": "string",
+				"validations": "required,email",
+				"fields": []
+			},
+			{
+				"name": "shirtSize",
+				"type": "string",
+				"validations": "required,oneof=S M L XL",
+				"fields": []
+			},
+			{
+				"name": "diet",
+				"type": "string",
+				"validations": "required,oneof=NONE VEGAN VEGETARIAN",
+				"fields": []
+			},
+			{
+				"name": "age",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "graduationYear",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "transportation",
+				"type": "string",
+				"validations": "required,oneof=NONE BUS",
+				"fields": []
+			},
+			{
+				"name": "school",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "major",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "gender",
+				"type": "string",
+				"validations": "required,oneof=MALE FEMALE NONBINARY OTHER",
+				"fields": []
+			},
+			{
+				"name": "professionalInterest",
+				"type": "string",
+				"validations": "required,oneof=INTERNSHIP FULLTIME BOTH NONE",
+				"fields": []
+			},
+			{
+				"name": "github",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "linkedin",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "interests",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "isNovice",
+				"type": "boolean",
+				"validations": "required|isdefault",
+				"fields": []
+			},
+			{
+				"name": "isPrivate",
+				"type": "boolean",
+				"validations": "required|isdefault",
+				"fields": []
+			},
+			{
+				"name": "phoneNumber",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "longforms",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "response",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "extraInfos",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "response",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "osContributors",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "contactInfo",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "name",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "collaborators",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "github",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "createdAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "updatedAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			}
+		]
+	}
 }

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -140,9 +140,9 @@
 				"fields": []
 			},
 			{
-				"name": "professionalInterest",
-				"type": "string",
-				"validations": "required,oneof=INTERNSHIP FULLTIME BOTH NONE",
+				"name": "interests",
+				"type": "[]string",
+				"validations": "required,dive,oneof=INTERNSHIP FULLTIME",
 				"fields": []
 			},
 			{
@@ -158,86 +158,40 @@
 				"fields": []
 			},
 			{
-				"name": "interests",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "isNovice",
+				"name": "isBeginner",
 				"type": "boolean",
 				"validations": "required|isdefault",
 				"fields": []
 			},
 			{
-				"name": "isPrivate",
+				"name": "priorAttendence",
 				"type": "boolean",
 				"validations": "required|isdefault",
 				"fields": []
 			},
 			{
-				"name": "phoneNumber",
+				"name": "phone",
 				"type": "string",
 				"validations": "required",
 				"fields": []
 			},
 			{
-				"name": "longforms",
-				"type": "[]object",
+				"name": "skills",
+				"type": "[]string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "response",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
-				"name": "extraInfos",
-				"type": "[]object",
+				"name": "extraInfo",
+				"type": "string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "response",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
-				"name": "osContributors",
-				"type": "[]object",
+				"name": "teamMembers",
+				"type": "[]string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "contactInfo",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					},
-					{
-						"name": "name",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
-			},
-			{
-				"name": "collaborators",
-				"type": "[]object",
-				"validations": "required",
-				"fields": [
-					{
-						"name": "github",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
 				"name": "createdAt",
@@ -250,6 +204,37 @@
 				"type": "int",
 				"validations": "required",
 				"fields": []
+			},
+			{
+				"name": "beginnerInfo",
+				"type": "object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "versionControl",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "pullRequest",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "yearsExperience",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "technicalSkills",
+						"type": "[]string",
+						"validations": "required",
+						"fields": []
+					}
+				]
 			}
 		]
 	},

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -231,5 +231,66 @@
 				"fields": []
 			}
 		]
+	},
+	"MENTOR_REGISTRATION_DEFINITION": {
+		"name": "mentor_registration",
+		"type": "object",
+		"validations": "required",
+		"fields": [
+			{
+				"name": "id",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "firstName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "lastName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "email",
+				"type": "string",
+				"validations": "required,email",
+				"fields": []
+			},
+			{
+				"name": "shirtSize",
+				"type": "string",
+				"validations": "required,oneof=S M L XL",
+				"fields": []
+			},
+			{
+				"name": "github",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "linkedin",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "createdAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "updatedAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			}
+		]
 	}
 }

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -119,9 +119,9 @@
 				"fields": []
 			},
 			{
-				"name": "professionalInterest",
-				"type": "string",
-				"validations": "required,oneof=INTERNSHIP FULLTIME BOTH NONE",
+				"name": "interests",
+				"type": "[]string",
+				"validations": "required,dive,oneof=INTERNSHIP FULLTIME",
 				"fields": []
 			},
 			{
@@ -137,86 +137,40 @@
 				"fields": []
 			},
 			{
-				"name": "interests",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "isNovice",
+				"name": "isBeginner",
 				"type": "boolean",
 				"validations": "required|isdefault",
 				"fields": []
 			},
 			{
-				"name": "isPrivate",
+				"name": "priorAttendence",
 				"type": "boolean",
 				"validations": "required|isdefault",
 				"fields": []
 			},
 			{
-				"name": "phoneNumber",
+				"name": "phone",
 				"type": "string",
 				"validations": "required",
 				"fields": []
 			},
 			{
-				"name": "longforms",
-				"type": "[]object",
+				"name": "skills",
+				"type": "[]string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "response",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
-				"name": "extraInfos",
-				"type": "[]object",
+				"name": "extraInfo",
+				"type": "string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "response",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
-				"name": "osContributors",
-				"type": "[]object",
+				"name": "teamMembers",
+				"type": "[]string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "contactInfo",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					},
-					{
-						"name": "name",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
-			},
-			{
-				"name": "collaborators",
-				"type": "[]object",
-				"validations": "required",
-				"fields": [
-					{
-						"name": "github",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
 				"name": "createdAt",
@@ -229,6 +183,37 @@
 				"type": "int",
 				"validations": "required",
 				"fields": []
+			},
+			{
+				"name": "beginnerInfo",
+				"type": "object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "versionControl",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "pullRequest",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "yearsExperience",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "technicalSkills",
+						"type": "[]string",
+						"validations": "required",
+						"fields": []
+					}
+				]
 			}
 		]
 	},

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -39,5 +39,197 @@
 	"SPARKPOST_API": "https://api.sparkpost.com/api/v1",
 	"AUTH_REDIRECT_URI": "https://hackillinois.org/auth/",
 
-	"IS_PRODUCTION": "true"
+	"IS_PRODUCTION": "true",
+
+	"REGISTRATION_DEFINITION": {
+		"name": "user_registration",
+		"type": "object",
+		"validations": "required",
+		"fields": [
+			{
+				"name": "id",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "firstName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "lastName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "email",
+				"type": "string",
+				"validations": "required,email",
+				"fields": []
+			},
+			{
+				"name": "shirtSize",
+				"type": "string",
+				"validations": "required,oneof=S M L XL",
+				"fields": []
+			},
+			{
+				"name": "diet",
+				"type": "string",
+				"validations": "required,oneof=NONE VEGAN VEGETARIAN",
+				"fields": []
+			},
+			{
+				"name": "age",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "graduationYear",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "transportation",
+				"type": "string",
+				"validations": "required,oneof=NONE BUS",
+				"fields": []
+			},
+			{
+				"name": "school",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "major",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "gender",
+				"type": "string",
+				"validations": "required,oneof=MALE FEMALE NONBINARY OTHER",
+				"fields": []
+			},
+			{
+				"name": "professionalInterest",
+				"type": "string",
+				"validations": "required,oneof=INTERNSHIP FULLTIME BOTH NONE",
+				"fields": []
+			},
+			{
+				"name": "github",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "linkedin",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "interests",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "isNovice",
+				"type": "boolean",
+				"validations": "required|isdefault",
+				"fields": []
+			},
+			{
+				"name": "isPrivate",
+				"type": "boolean",
+				"validations": "required|isdefault",
+				"fields": []
+			},
+			{
+				"name": "phoneNumber",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "longforms",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "response",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "extraInfos",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "response",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "osContributors",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "contactInfo",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "name",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "collaborators",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "github",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "createdAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "updatedAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			}
+		]
+	}
 }

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -252,5 +252,66 @@
 				"fields": []
 			}
 		]
+	},
+	"MENTOR_REGISTRATION_DEFINITION": {
+		"name": "mentor_registration",
+		"type": "object",
+		"validations": "required",
+		"fields": [
+			{
+				"name": "id",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "firstName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "lastName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "email",
+				"type": "string",
+				"validations": "required,email",
+				"fields": []
+			},
+			{
+				"name": "shirtSize",
+				"type": "string",
+				"validations": "required,oneof=S M L XL",
+				"fields": []
+			},
+			{
+				"name": "github",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "linkedin",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "createdAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "updatedAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			}
+		]
 	}
 }

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -60,5 +60,197 @@
 
 	"SPARKPOST_APIKEY": "",
 
-	"IS_PRODUCTION": "false"
+	"IS_PRODUCTION": "false",
+
+	"REGISTRATION_DEFINITION": {
+		"name": "user_registration",
+		"type": "object",
+		"validations": "required",
+		"fields": [
+			{
+				"name": "id",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "firstName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "lastName",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "email",
+				"type": "string",
+				"validations": "required,email",
+				"fields": []
+			},
+			{
+				"name": "shirtSize",
+				"type": "string",
+				"validations": "required,oneof=S M L XL",
+				"fields": []
+			},
+			{
+				"name": "diet",
+				"type": "string",
+				"validations": "required,oneof=NONE VEGAN VEGETARIAN",
+				"fields": []
+			},
+			{
+				"name": "age",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "graduationYear",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "transportation",
+				"type": "string",
+				"validations": "required,oneof=NONE BUS",
+				"fields": []
+			},
+			{
+				"name": "school",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "major",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "gender",
+				"type": "string",
+				"validations": "required,oneof=MALE FEMALE NONBINARY OTHER",
+				"fields": []
+			},
+			{
+				"name": "professionalInterest",
+				"type": "string",
+				"validations": "required,oneof=INTERNSHIP FULLTIME BOTH NONE",
+				"fields": []
+			},
+			{
+				"name": "github",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "linkedin",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "interests",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "isNovice",
+				"type": "boolean",
+				"validations": "required|isdefault",
+				"fields": []
+			},
+			{
+				"name": "isPrivate",
+				"type": "boolean",
+				"validations": "required|isdefault",
+				"fields": []
+			},
+			{
+				"name": "phoneNumber",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "longforms",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "response",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "extraInfos",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "response",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "osContributors",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "contactInfo",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "name",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "collaborators",
+				"type": "[]object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "github",
+						"type": "string",
+						"validations": "required",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "createdAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "updatedAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			}
+		]
+	}
 }

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -63,7 +63,7 @@
 	"IS_PRODUCTION": "false",
 
 	"REGISTRATION_DEFINITION": {
-		"name": "user_registration",
+		"name": "mentor_registration",
 		"type": "object",
 		"validations": "required",
 		"fields": [
@@ -98,54 +98,6 @@
 				"fields": []
 			},
 			{
-				"name": "diet",
-				"type": "string",
-				"validations": "required,oneof=NONE VEGAN VEGETARIAN",
-				"fields": []
-			},
-			{
-				"name": "age",
-				"type": "int",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "graduationYear",
-				"type": "int",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "transportation",
-				"type": "string",
-				"validations": "required,oneof=NONE BUS",
-				"fields": []
-			},
-			{
-				"name": "school",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "major",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "gender",
-				"type": "string",
-				"validations": "required,oneof=MALE FEMALE NONBINARY OTHER",
-				"fields": []
-			},
-			{
-				"name": "interests",
-				"type": "[]string",
-				"validations": "required,dive,oneof=INTERNSHIP FULLTIME",
-				"fields": []
-			},
-			{
 				"name": "github",
 				"type": "string",
 				"validations": "required",
@@ -158,38 +110,8 @@
 				"fields": []
 			},
 			{
-				"name": "isBeginner",
-				"type": "boolean",
-				"validations": "required|isdefault",
-				"fields": []
-			},
-			{
-				"name": "priorAttendence",
-				"type": "boolean",
-				"validations": "required|isdefault",
-				"fields": []
-			},
-			{
-				"name": "phone",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "skills",
-				"type": "[]string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "extraInfo",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "teamMembers",
-				"type": "[]string",
+				"name": "age",
+				"type": "int",
 				"validations": "required",
 				"fields": []
 			},
@@ -204,37 +126,6 @@
 				"type": "int",
 				"validations": "required",
 				"fields": []
-			},
-			{
-				"name": "beginnerInfo",
-				"type": "object",
-				"validations": "required",
-				"fields": [
-					{
-						"name": "versionControl",
-						"type": "int",
-						"validations": "required",
-						"fields": []
-					},
-					{
-						"name": "pullRequest",
-						"type": "int",
-						"validations": "required",
-						"fields": []
-					},
-					{
-						"name": "yearsExperience",
-						"type": "int",
-						"validations": "required",
-						"fields": []
-					},
-					{
-						"name": "technicalSkills",
-						"type": "[]string",
-						"validations": "required",
-						"fields": []
-					}
-				]
 			}
 		]
 	},

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -140,9 +140,9 @@
 				"fields": []
 			},
 			{
-				"name": "professionalInterest",
-				"type": "string",
-				"validations": "required,oneof=INTERNSHIP FULLTIME BOTH NONE",
+				"name": "interests",
+				"type": "[]string",
+				"validations": "required,dive,oneof=INTERNSHIP FULLTIME",
 				"fields": []
 			},
 			{
@@ -158,86 +158,40 @@
 				"fields": []
 			},
 			{
-				"name": "interests",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "isNovice",
+				"name": "isBeginner",
 				"type": "boolean",
 				"validations": "required|isdefault",
 				"fields": []
 			},
 			{
-				"name": "isPrivate",
+				"name": "priorAttendence",
 				"type": "boolean",
 				"validations": "required|isdefault",
 				"fields": []
 			},
 			{
-				"name": "phoneNumber",
+				"name": "phone",
 				"type": "string",
 				"validations": "required",
 				"fields": []
 			},
 			{
-				"name": "longforms",
-				"type": "[]object",
+				"name": "skills",
+				"type": "[]string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "response",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
-				"name": "extraInfos",
-				"type": "[]object",
+				"name": "extraInfo",
+				"type": "string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "response",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
-				"name": "osContributors",
-				"type": "[]object",
+				"name": "teamMembers",
+				"type": "[]string",
 				"validations": "required",
-				"fields": [
-					{
-						"name": "contactInfo",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					},
-					{
-						"name": "name",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
-			},
-			{
-				"name": "collaborators",
-				"type": "[]object",
-				"validations": "required",
-				"fields": [
-					{
-						"name": "github",
-						"type": "string",
-						"validations": "required",
-						"fields": []
-					}
-				]
+				"fields": []
 			},
 			{
 				"name": "createdAt",
@@ -250,6 +204,37 @@
 				"type": "int",
 				"validations": "required",
 				"fields": []
+			},
+			{
+				"name": "beginnerInfo",
+				"type": "object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "versionControl",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "pullRequest",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "yearsExperience",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "technicalSkills",
+						"type": "[]string",
+						"validations": "required",
+						"fields": []
+					}
+				]
 			}
 		]
 	},

--- a/services/registration/config/config.go
+++ b/services/registration/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/HackIllinois/api/common/configloader"
+	"github.com/HackIllinois/api/common/datastore"
 	"os"
 )
 
@@ -14,6 +15,8 @@ var USER_SERVICE string
 var AUTH_SERVICE string
 var DECISION_SERVICE string
 var MAIL_SERVICE string
+
+var REGISTRATION_DEFINITION datastore.DataStoreDefinition
 
 func init() {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
@@ -59,6 +62,12 @@ func init() {
 	}
 
 	MAIL_SERVICE, err = cfg_loader.Get("MAIL_SERVICE")
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = cfg_loader.ParseInto("REGISTRATION_DEFINITION", &REGISTRATION_DEFINITION)
 
 	if err != nil {
 		panic(err)

--- a/services/registration/config/config.go
+++ b/services/registration/config/config.go
@@ -17,6 +17,7 @@ var DECISION_SERVICE string
 var MAIL_SERVICE string
 
 var REGISTRATION_DEFINITION datastore.DataStoreDefinition
+var MENTOR_REGISTRATION_DEFINITION datastore.DataStoreDefinition
 
 func init() {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
@@ -68,6 +69,12 @@ func init() {
 	}
 
 	err = cfg_loader.ParseInto("REGISTRATION_DEFINITION", &REGISTRATION_DEFINITION)
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = cfg_loader.ParseInto("MENTOR_REGISTRATION_DEFINITION", &MENTOR_REGISTRATION_DEFINITION)
 
 	if err != nil {
 		panic(err)

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -255,10 +255,10 @@ func CreateCurrentMentorRegistration(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError("Must provide id"))
 	}
 
-	var mentor_registration models.MentorRegistration
+	mentor_registration := datastore.NewDataStore(config.MENTOR_REGISTRATION_DEFINITION)
 	json.NewDecoder(r.Body).Decode(&mentor_registration)
 
-	mentor_registration.ID = id
+	mentor_registration.Data["id"] = id
 
 	user_info, err := service.GetUserInfo(id)
 
@@ -266,13 +266,13 @@ func CreateCurrentMentorRegistration(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
-	mentor_registration.GitHub = user_info.Username
-	mentor_registration.Email = user_info.Email
-	mentor_registration.FirstName = user_info.FirstName
-	mentor_registration.LastName = user_info.LastName
+	mentor_registration.Data["github"] = user_info.Username
+	mentor_registration.Data["email"] = user_info.Email
+	mentor_registration.Data["firstName"] = user_info.FirstName
+	mentor_registration.Data["lastName"] = user_info.LastName
 
-	mentor_registration.CreatedAt = time.Now().Unix()
-	mentor_registration.UpdatedAt = time.Now().Unix()
+	mentor_registration.Data["createdAt"] = time.Now().Unix()
+	mentor_registration.Data["updatedAt"] = time.Now().Unix()
 
 	err = service.CreateMentorRegistration(id, mentor_registration)
 
@@ -305,10 +305,10 @@ func UpdateCurrentMentorRegistration(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError("Must provide id"))
 	}
 
-	var mentor_registration models.MentorRegistration
+	mentor_registration := datastore.NewDataStore(config.MENTOR_REGISTRATION_DEFINITION)
 	json.NewDecoder(r.Body).Decode(&mentor_registration)
 
-	mentor_registration.ID = id
+	mentor_registration.Data["id"] = id
 
 	user_info, err := service.GetUserInfo(id)
 
@@ -322,13 +322,13 @@ func UpdateCurrentMentorRegistration(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
-	mentor_registration.GitHub = user_info.Username
-	mentor_registration.Email = user_info.Email
-	mentor_registration.FirstName = user_info.FirstName
-	mentor_registration.LastName = user_info.LastName
+	mentor_registration.Data["github"] = user_info.Username
+	mentor_registration.Data["email"] = user_info.Email
+	mentor_registration.Data["firstName"] = user_info.FirstName
+	mentor_registration.Data["lastName"] = user_info.LastName
 
-	mentor_registration.CreatedAt = original_registration.CreatedAt
-	mentor_registration.UpdatedAt = time.Now().Unix()
+	mentor_registration.Data["createdAt"] = original_registration.Data["'createdAt"]
+	mentor_registration.Data["updatedAt"] = time.Now().Unix()
 
 	err = service.UpdateMentorRegistration(id, mentor_registration)
 

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"encoding/json"
+	"github.com/HackIllinois/api/common/datastore"
 	"github.com/HackIllinois/api/common/errors"
+	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
 	"github.com/HackIllinois/api/services/registration/service"
 	"github.com/gorilla/mux"
@@ -94,10 +96,10 @@ func CreateCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError("Must provide id"))
 	}
 
-	var user_registration models.UserRegistration
+	user_registration := datastore.NewDataStore(config.REGISTRATION_DEFINITION)
 	json.NewDecoder(r.Body).Decode(&user_registration)
 
-	user_registration.ID = id
+	user_registration.Data["id"] = id
 
 	user_info, err := service.GetUserInfo(id)
 
@@ -105,13 +107,13 @@ func CreateCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
-	user_registration.GitHub = user_info.Username
-	user_registration.Email = user_info.Email
-	user_registration.FirstName = user_info.FirstName
-	user_registration.LastName = user_info.LastName
+	user_registration.Data["github"] = user_info.Username
+	user_registration.Data["email"] = user_info.Email
+	user_registration.Data["firstName"] = user_info.FirstName
+	user_registration.Data["lastName"] = user_info.LastName
 
-	user_registration.CreatedAt = time.Now().Unix()
-	user_registration.UpdatedAt = time.Now().Unix()
+	user_registration.Data["createdAt"] = time.Now().Unix()
+	user_registration.Data["updatedAt"] = time.Now().Unix()
 
 	err = service.CreateUserRegistration(id, user_registration)
 
@@ -167,10 +169,10 @@ func UpdateCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError("Must provide id"))
 	}
 
-	var user_registration models.UserRegistration
+	user_registration := datastore.NewDataStore(config.REGISTRATION_DEFINITION)
 	json.NewDecoder(r.Body).Decode(&user_registration)
 
-	user_registration.ID = id
+	user_registration.Data["id"] = id
 
 	user_info, err := service.GetUserInfo(id)
 
@@ -184,13 +186,13 @@ func UpdateCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError(err.Error()))
 	}
 
-	user_registration.GitHub = user_info.Username
-	user_registration.Email = user_info.Email
-	user_registration.FirstName = user_info.FirstName
-	user_registration.LastName = user_info.LastName
+	user_registration.Data["github"] = user_info.Username
+	user_registration.Data["email"] = user_info.Email
+	user_registration.Data["firstName"] = user_info.FirstName
+	user_registration.Data["lastName"] = user_info.LastName
 
-	user_registration.CreatedAt = original_registration.CreatedAt
-	user_registration.UpdatedAt = time.Now().Unix()
+	user_registration.Data["createdAt"] = original_registration.Data["createdAt"]
+	user_registration.Data["updatedAt"] = time.Now().Unix()
 
 	err = service.UpdateUserRegistration(id, user_registration)
 

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -327,7 +327,7 @@ func UpdateCurrentMentorRegistration(w http.ResponseWriter, r *http.Request) {
 	mentor_registration.Data["firstName"] = user_info.FirstName
 	mentor_registration.Data["lastName"] = user_info.LastName
 
-	mentor_registration.Data["createdAt"] = original_registration.Data["'createdAt"]
+	mentor_registration.Data["createdAt"] = original_registration.Data["createdAt"]
 	mentor_registration.Data["updatedAt"] = time.Now().Unix()
 
 	err = service.UpdateMentorRegistration(id, mentor_registration)

--- a/services/registration/models/mentor_registration.go
+++ b/services/registration/models/mentor_registration.go
@@ -1,13 +1,7 @@
 package models
 
-type MentorRegistration struct {
-	ID        string `json:"id"          validate:"required"`
-	FirstName string `json:"firstName"   validate:"required"`
-	LastName  string `json:"lastName"    validate:"required"`
-	Email     string `json:"email"       validate:"required,email"`
-	ShirtSize string `json:"shirtSize"   validate:"required,oneof=S M L XL"`
-	GitHub    string `json:"github"      validate:"required"`
-	Linkedin  string `json:"linkedin"    validate:"required"`
-	CreatedAt int64  `json:"createdAt"   validate:"required"`
-	UpdatedAt int64  `json:"updatedAt"   validate:"required"`
-}
+import (
+	"github.com/HackIllinois/api/common/datastore"
+)
+
+type MentorRegistration = datastore.DataStore

--- a/services/registration/models/user_registration.go
+++ b/services/registration/models/user_registration.go
@@ -1,46 +1,7 @@
 package models
 
-type UserRegistration struct {
-	ID                   string              `json:"id"                   validate:"required"`
-	FirstName            string              `json:"firstName"            validate:"required"`
-	LastName             string              `json:"lastName"             validate:"required"`
-	Email                string              `json:"email"                validate:"required,email"`
-	ShirtSize            string              `json:"shirtSize"            validate:"required,oneof=S M L XL"`
-	Diet                 string              `json:"diet"                 validate:"required,oneof=NONE VEGAN VEGETARIAN"`
-	Age                  int                 `json:"age"                  validate:"required"`
-	GraduationYear       int                 `json:"graduationYear"       validate:"required"`
-	Transportation       string              `json:"transportation"       validate:"required,oneof=NONE BUS"`
-	School               string              `json:"school"               validate:"required"`
-	Major                string              `json:"major"                validate:"required"`
-	Gender               string              `json:"gender"               validate:"required,oneof=MALE FEMALE NONBINARY OTHER"`
-	ProfessionalInterest string              `json:"professionalInterest" validate:"required,oneof=INTERNSHIP FULLTIME BOTH"`
-	GitHub               string              `json:"github"               validate:"required"`
-	Linkedin             string              `json:"linkedin"             validate:"required"`
-	Interests            string              `json:"interests"            validate:"required"`
-	IsNovice             bool                `json:"isNovice"             validate:"required|isdefault"`
-	IsPrivate            bool                `json:"isPrivate"            validate:"required|isdefault"`
-	PhoneNumber          string              `json:"phoneNumber"          validate:"required"`
-	LongForms            []UserLongForm      `json:"longforms"            validate:"required,dive,required"`
-	ExtraInfos           []UserExtraInfo     `json:"extraInfos"           validate:"required,dive,required"`
-	OsContributors       []UserOsContributor `json:"osContributors"       validate:"required,dive,required"`
-	Collaborators        []UserCollaborator  `json:"collaborators"        validate:"required,dive,required"`
-	CreatedAt            int64               `json:"createdAt"            validate:"required"`
-	UpdatedAt            int64               `json:"updatedAt"            validate:"required"`
-}
+import (
+	"github.com/HackIllinois/api/common/datastore"
+)
 
-type UserLongForm struct {
-	Response string `json:"response" validate:"required"`
-}
-
-type UserExtraInfo struct {
-	Response string `json:"response" validate:"required"`
-}
-
-type UserOsContributor struct {
-	Name        string `json:"name"        validate:"required"`
-	ContactInfo string `json:"contactInfo" validate:"required"`
-}
-
-type UserCollaborator struct {
-	Github string `json:"github" validate:"required"`
-}
+type UserRegistration = datastore.DataStore

--- a/services/registration/service/decision_service.go
+++ b/services/registration/service/decision_service.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/registration/config"
@@ -17,7 +19,18 @@ func AddInitialDecision(id string) error {
 		Status: "PENDING",
 	}
 
-	status, err := apirequest.Post(config.DECISION_SERVICE+"/decision/", &decision, nil)
+	body := bytes.Buffer{}
+	json.NewEncoder(&body).Encode(&decision)
+
+	req, err := http.NewRequest("POST", config.DECISION_SERVICE+"/decision/", &body)
+
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("HackIllinois-Identity", "registrationservice")
+
+	status, err := apirequest.Do(req, nil)
 
 	if err != nil {
 		return err

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -162,7 +162,7 @@ func GetMentorRegistration(id string) (*models.MentorRegistration, error) {
 	Creates the registration associated with the given mentor id
 */
 func CreateMentorRegistration(id string, mentor_registration models.MentorRegistration) error {
-	err := validate.Struct(mentor_registration)
+	err := mentor_registration.Validate()
 
 	if err != nil {
 		return err
@@ -186,7 +186,7 @@ func CreateMentorRegistration(id string, mentor_registration models.MentorRegist
 	Updates the registration associated with the given mentor id
 */
 func UpdateMentorRegistration(id string, mentor_registration models.MentorRegistration) error {
-	err := validate.Struct(mentor_registration)
+	err := mentor_registration.Validate()
 
 	if err != nil {
 		return err

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -48,7 +48,7 @@ func GetUserRegistration(id string) (*models.UserRegistration, error) {
 	Creates the registration associated with the given user id
 */
 func CreateUserRegistration(id string, user_registration models.UserRegistration) error {
-	err := validate.Struct(user_registration)
+	err := user_registration.Validate()
 
 	if err != nil {
 		return err
@@ -72,7 +72,7 @@ func CreateUserRegistration(id string, user_registration models.UserRegistration
 	Updates the registration associated with the given user id
 */
 func UpdateUserRegistration(id string, user_registration models.UserRegistration) error {
-	err := validate.Struct(user_registration)
+	err := user_registration.Validate()
 
 	if err != nil {
 		return err

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -92,7 +92,6 @@ func GetFilteredUserRegistrations(parameters map[string][]string) (*models.Filte
 	query := make(map[string]interface{})
 	for key, values := range parameters {
 		if len(values) == 1 {
-			key = strings.ToLower(key)
 			value_list := strings.Split(values[0], ",")
 
 			correctly_typed_value_list := make([]interface{}, len(value_list))
@@ -120,12 +119,12 @@ func GetFilteredUserRegistrations(parameters map[string][]string) (*models.Filte
 }
 
 func AssignValueType(key, value string) (interface{}, error) {
-	int_keys := []string{"age", "graduationyear"}
+	int_keys := []string{"age", "graduationYear"}
 	if Contains(int_keys, key) {
 		return strconv.Atoi(value)
 	}
 
-	bool_keys := []string{"isnovice", "isprivate"}
+	bool_keys := []string{"isNovice", "isPrivate"}
 	if Contains(bool_keys, key) {
 		return strconv.ParseBool(value)
 	}

--- a/services/registration/tests/registration_test.go
+++ b/services/registration/tests/registration_test.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/common/datastore"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
 	"github.com/HackIllinois/api/services/registration/service"
 	"reflect"
 	"testing"
+	"encoding/json"
 )
 
 var db database.Database
@@ -25,14 +27,14 @@ func init() {
 	Initialize db with test user and mentor info
 */
 func SetupTestDB(t *testing.T) {
-	user_registration := base_user_registration
+	user_registration := getBaseUserRegistration()
 	err := db.Insert("attendees", &user_registration)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	mentor_registration := base_mentor_registration
+	mentor_registration := getBaseMentorRegistration()
 	err = db.Insert("mentors", &mentor_registration)
 
 	if err != nil {
@@ -63,10 +65,10 @@ func TestGetUserRegistrationService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registration := base_user_registration
+	expected_registration := getBaseUserRegistration()
 
-	if !reflect.DeepEqual(user_registration, &expected_registration) {
-		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registration, user_registration)
+	if !reflect.DeepEqual(user_registration.Data["firstName"], expected_registration.Data["firstName"]) {
+		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registration.Data["firstName"], user_registration.Data["firstName"])
 	}
 
 	CleanupTestDB(t)
@@ -78,10 +80,10 @@ func TestGetUserRegistrationService(t *testing.T) {
 func TestCreateUserRegistrationService(t *testing.T) {
 	SetupTestDB(t)
 
-	new_registration := base_user_registration
-	new_registration.ID = "testid2"
-	new_registration.FirstName = "first2"
-	new_registration.LastName = "last2"
+	new_registration := getBaseUserRegistration()
+	new_registration.Data["id"] = "testid2"
+	new_registration.Data["firstName"] = "first2"
+	new_registration.Data["lastName"] = "last2"
 	err := service.CreateUserRegistration("testid2", new_registration)
 
 	if err != nil {
@@ -94,13 +96,13 @@ func TestCreateUserRegistrationService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registration := base_user_registration
-	expected_registration.ID = "testid2"
-	expected_registration.FirstName = "first2"
-	expected_registration.LastName = "last2"
+	expected_registration := getBaseUserRegistration()
+	expected_registration.Data["id"] = "testid2"
+	expected_registration.Data["firstName"] = "first2"
+	expected_registration.Data["lastName"] = "last2"
 
-	if !reflect.DeepEqual(user_registration, &expected_registration) {
-		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registration, user_registration)
+	if !reflect.DeepEqual(user_registration.Data["firstName"], expected_registration.Data["firstName"]) {
+		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registration.Data["firstName"], user_registration.Data["firstName"])
 	}
 
 	CleanupTestDB(t)
@@ -112,10 +114,10 @@ func TestCreateUserRegistrationService(t *testing.T) {
 func TestUpdateUserRegistrationService(t *testing.T) {
 	SetupTestDB(t)
 
-	updated_registration := base_user_registration
-	updated_registration.ID = "testid"
-	updated_registration.FirstName = "first2"
-	updated_registration.LastName = "last2"
+	updated_registration := getBaseUserRegistration()
+	updated_registration.Data["id"] = "testid"
+	updated_registration.Data["firstName"] = "first2"
+	updated_registration.Data["lastName"] = "last2"
 	err := service.UpdateUserRegistration("testid", updated_registration)
 
 	if err != nil {
@@ -128,13 +130,13 @@ func TestUpdateUserRegistrationService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registration := base_user_registration
-	expected_registration.ID = "testid"
-	expected_registration.FirstName = "first2"
-	expected_registration.LastName = "last2"
+	expected_registration := getBaseUserRegistration()
+	expected_registration.Data["id"] = "testid"
+	expected_registration.Data["firstName"] = "first2"
+	expected_registration.Data["lastName"] = "last2"
 
-	if !reflect.DeepEqual(user_registration, &expected_registration) {
-		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registration, user_registration)
+	if !reflect.DeepEqual(user_registration.Data["firstName"], expected_registration.Data["firstName"]) {
+		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registration.Data["firstName"], user_registration.Data["firstName"])
 	}
 
 	CleanupTestDB(t)
@@ -152,10 +154,10 @@ func TestGetMentorRegistrationService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registration := base_mentor_registration
+	expected_registration := getBaseMentorRegistration()
 
-	if !reflect.DeepEqual(mentor_registration, &expected_registration) {
-		t.Errorf("Wrong mentor info.\nExpected %v\ngot %v\n", expected_registration, mentor_registration)
+	if !reflect.DeepEqual(mentor_registration.Data["firstName"], expected_registration.Data["firstName"]) {
+		t.Errorf("Wrong mentor info.\nExpected %v\ngot %v\n", expected_registration.Data["firstName"], mentor_registration.Data["firstName"])
 	}
 
 	CleanupTestDB(t)
@@ -167,10 +169,10 @@ func TestGetMentorRegistrationService(t *testing.T) {
 func TestCreateMentorRegistrationService(t *testing.T) {
 	SetupTestDB(t)
 
-	new_registration := base_mentor_registration
-	new_registration.ID = "testid2"
-	new_registration.FirstName = "first2"
-	new_registration.LastName = "last2"
+	new_registration := getBaseMentorRegistration()
+	new_registration.Data["id"] = "testid2"
+	new_registration.Data["firstName"] = "first2"
+	new_registration.Data["lastName"] = "last2"
 	err := service.CreateMentorRegistration("testid2", new_registration)
 
 	if err != nil {
@@ -183,13 +185,13 @@ func TestCreateMentorRegistrationService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registration := base_mentor_registration
-	expected_registration.ID = "testid2"
-	expected_registration.FirstName = "first2"
-	expected_registration.LastName = "last2"
+	expected_registration := getBaseMentorRegistration()
+	expected_registration.Data["id"] = "testid2"
+	expected_registration.Data["firstName"] = "first2"
+	expected_registration.Data["lastName"] = "last2"
 
-	if !reflect.DeepEqual(mentor_registration, &expected_registration) {
-		t.Errorf("Wrong mentor info.\nExpected %v\ngot %v\n", expected_registration, mentor_registration)
+	if !reflect.DeepEqual(mentor_registration.Data["firstName"], expected_registration.Data["firstName"]) {
+		t.Errorf("Wrong mentor info.\nExpected %v\ngot %v\n", expected_registration.Data["firstName"], mentor_registration.Data["firstName"])
 	}
 
 	CleanupTestDB(t)
@@ -201,10 +203,10 @@ func TestCreateMentorRegistrationService(t *testing.T) {
 func TestUpdateMentorRegistrationService(t *testing.T) {
 	SetupTestDB(t)
 
-	updated_registration := base_mentor_registration
-	updated_registration.ID = "testid"
-	updated_registration.FirstName = "first2"
-	updated_registration.LastName = "last2"
+	updated_registration := getBaseMentorRegistration()
+	updated_registration.Data["id"] = "testid"
+	updated_registration.Data["firstName"] = "first2"
+	updated_registration.Data["lastName"] = "last2"
 	err := service.UpdateMentorRegistration("testid", updated_registration)
 
 	if err != nil {
@@ -217,13 +219,13 @@ func TestUpdateMentorRegistrationService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registration := base_mentor_registration
-	expected_registration.ID = "testid"
-	expected_registration.FirstName = "first2"
-	expected_registration.LastName = "last2"
+	expected_registration := getBaseMentorRegistration()
+	expected_registration.Data["id"] = "testid"
+	expected_registration.Data["firstName"] = "first2"
+	expected_registration.Data["lastName"] = "last2"
 
-	if !reflect.DeepEqual(mentor_registration, &expected_registration) {
-		t.Errorf("Wrong mentor info.\nExpected %v\ngot %v\n", expected_registration, mentor_registration)
+	if !reflect.DeepEqual(mentor_registration.Data["firstName"], expected_registration.Data["firstName"]) {
+		t.Errorf("Wrong mentor info.\nExpected %v\ngot %v\n", expected_registration.Data["firstName"], mentor_registration.Data["firstName"])
 	}
 
 	CleanupTestDB(t)
@@ -235,18 +237,19 @@ func TestUpdateMentorRegistrationService(t *testing.T) {
 func TestGetFilteredUserRegistrationsService(t *testing.T) {
 	SetupTestDB(t)
 
-	registration_1 := base_user_registration
+	registration_1 := getBaseUserRegistration()
 
-	registration_2 := base_user_registration
-	registration_2.ID = "testid2"
-	err := service.CreateUserRegistration(registration_2.ID, registration_2)
+	registration_2 := getBaseUserRegistration()
+	registration_2.Data["id"] = "testid2"
+
+	err := service.CreateUserRegistration(registration_2.Data["id"].(string), registration_2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Test capitalized keys
+	// Test single value and one keys
 	parameters := map[string][]string{
-		"ID": []string{"testid"},
+		"id": []string{"testid"},
 	}
 	user_registrations, err := service.GetFilteredUserRegistrations(parameters)
 	if err != nil {
@@ -258,8 +261,13 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 			registration_1,
 		},
 	}
-	if !reflect.DeepEqual(user_registrations, &expected_registrations) {
-		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations, user_registrations)
+
+	if(len(user_registrations.Registrations) != len(expected_registrations.Registrations)) {
+		t.Errorf("Wrong number of registrations.\nExpected %v\ngot %v\n", len(expected_registrations.Registrations), len(user_registrations.Registrations))
+	}
+
+	if !reflect.DeepEqual(user_registrations.Registrations[0].Data["firstName"], expected_registrations.Registrations[0].Data["firstName"]) {
+		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations.Registrations[0].Data["firstName"], user_registrations.Registrations[0].Data["firstName"])
 	}
 
 	// Test multiple values
@@ -277,8 +285,13 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 			registration_2,
 		},
 	}
-	if !reflect.DeepEqual(user_registrations, &expected_registrations) {
-		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations, user_registrations)
+
+	if(len(user_registrations.Registrations) != len(expected_registrations.Registrations)) {
+		t.Errorf("Wrong number of registrations.\nExpected %v\ngot %v\n", len(expected_registrations.Registrations), len(user_registrations.Registrations))
+	}
+
+	if !reflect.DeepEqual(user_registrations.Registrations[1].Data["firstName"], expected_registrations.Registrations[1].Data["firstName"]) {
+		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations.Registrations[1].Data["firstName"], user_registrations.Registrations[1].Data["firstName"])
 	}
 
 	// Test type casting
@@ -298,66 +311,93 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 			registration_2,
 		},
 	}
-	if !reflect.DeepEqual(user_registrations, &expected_registrations) {
-		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations, user_registrations)
+
+	if(len(user_registrations.Registrations) != len(expected_registrations.Registrations)) {
+		t.Errorf("Wrong number of registrations.\nExpected %v\ngot %v\n", len(expected_registrations.Registrations), len(user_registrations.Registrations))
+	}
+
+	if !reflect.DeepEqual(user_registrations.Registrations[1].Data["firstName"], expected_registrations.Registrations[1].Data["firstName"]) {
+		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations.Registrations[1].Data["firstName"], user_registrations.Registrations[1].Data["firstName"])
 	}
 
 	CleanupTestDB(t)
 }
 
-var base_user_registration models.UserRegistration = models.UserRegistration{
-	ID:                   "testid",
-	FirstName:            "first",
-	LastName:             "last",
-	Email:                "test@gmail.com",
-	ShirtSize:            "M",
-	Diet:                 "NONE",
-	Age:                  20,
-	GraduationYear:       2019,
-	Transportation:       "BUS",
-	School:               "University of Illinois at Urbana-Champaign",
-	Major:                "Computer Science",
-	Gender:               "MALE",
-	ProfessionalInterest: "INTERNSHIP",
-	GitHub:               "githubusername",
-	Linkedin:             "linkedinusername",
-	Interests:            "things",
-	IsNovice:             true,
-	IsPrivate:            false,
-	PhoneNumber:          "555-287-2903",
-	LongForms: []models.UserLongForm{
-		models.UserLongForm{
-			Response: "longformresponse",
-		},
-	},
-	ExtraInfos: []models.UserExtraInfo{
-		models.UserExtraInfo{
-			Response: "extrainforesponse",
-		},
-	},
-	OsContributors: []models.UserOsContributor{
-		models.UserOsContributor{
-			Name:        "contributorname",
-			ContactInfo: "contact@test.com",
-		},
-	},
-	Collaborators: []models.UserCollaborator{
-		models.UserCollaborator{
-			Github: "collaboratorgithub",
-		},
-	},
-	CreatedAt: 10,
-	UpdatedAt: 15,
+/*
+	Returns a basic user registration
+*/
+func getBaseUserRegistration() datastore.DataStore {
+	base_user_registration := datastore.NewDataStore(config.REGISTRATION_DEFINITION)
+	json.Unmarshal([]byte(user_registration_data), &base_user_registration)
+	return base_user_registration
 }
 
-var base_mentor_registration models.MentorRegistration = models.MentorRegistration{
-	ID:        "testid",
-	FirstName: "first",
-	LastName:  "last",
-	Email:     "test@gmail.com",
-	ShirtSize: "M",
-	GitHub:    "githubusername",
-	Linkedin:  "linkedinusername",
-	CreatedAt: 10,
-	UpdatedAt: 15,
+/*
+	Returns a basic mentor registration
+*/
+func getBaseMentorRegistration() datastore.DataStore {
+	base_mentor_registration := datastore.NewDataStore(config.MENTOR_REGISTRATION_DEFINITION)
+	json.Unmarshal([]byte(user_registration_data), &base_mentor_registration)
+	return base_mentor_registration
 }
+
+var user_registration_data string = `
+{
+	"id": "testid",
+	"firstName": "first",
+	"lastName": "last",
+	"email": "test@gmail.com",
+	"shirtSize": "M",
+	"diet": "NONE",
+	"age": 20,
+	"graduationYear": 2020,
+	"transportation": "NONE",
+	"school": "University of Illinois at Urbana-Champaign",
+	"major": "Computer Science",
+	"gender": "MALE",
+	"professionalInterest": "INTERNSHIP",
+	"github": "githubusername",
+	"linkedin": "linkedinusername",
+	"interests": "Software",
+	"isNovice": true,
+	"isPrivate": false,
+	"phoneNumber": "555-928-7402",
+	"longforms": [
+		{
+			"response": "This is a longform."
+		}
+	],
+	"extraInfos": [
+		{
+			"response": "This is an extra info."
+		}
+	],
+	"osContributors": [
+		{
+			"name": "Person",
+			"contactInfo": "person@gmail.com"
+		}
+	],
+	"collaborators": [
+		{
+			"github": "persongithub"
+		}
+	],
+	"createdAt": 10,
+	"updatedAt": 15
+}
+`
+
+var mentor_registration_data string = `
+{
+	"id": "testid",
+	"firstName": "first",
+	"lastName": "last",
+	"email": "test@gmail.com",
+	"shirtSize": "M",
+	"github": "githubusername",
+	"linkedin": "linkedinusername",
+	"createdAt": 10,
+	"updatedAt": 15
+}
+`

--- a/services/registration/tests/registration_test.go
+++ b/services/registration/tests/registration_test.go
@@ -298,7 +298,6 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 	parameters = map[string][]string{
 		"firstName": []string{"first"},
 		"age":       []string{"20"},
-		"isNovice":  []string{"true"},
 	}
 	user_registrations, err = service.GetFilteredUserRegistrations(parameters)
 	if err != nil {
@@ -348,41 +347,9 @@ var user_registration_data string = `
 	"lastName": "last",
 	"email": "test@gmail.com",
 	"shirtSize": "M",
-	"diet": "NONE",
-	"age": 20,
-	"graduationYear": 2020,
-	"transportation": "NONE",
-	"school": "University of Illinois at Urbana-Champaign",
-	"major": "Computer Science",
-	"gender": "MALE",
-	"professionalInterest": "INTERNSHIP",
 	"github": "githubusername",
 	"linkedin": "linkedinusername",
-	"interests": "Software",
-	"isNovice": true,
-	"isPrivate": false,
-	"phoneNumber": "555-928-7402",
-	"longforms": [
-		{
-			"response": "This is a longform."
-		}
-	],
-	"extraInfos": [
-		{
-			"response": "This is an extra info."
-		}
-	],
-	"osContributors": [
-		{
-			"name": "Person",
-			"contactInfo": "person@gmail.com"
-		}
-	],
-	"collaborators": [
-		{
-			"github": "persongithub"
-		}
-	],
+	"age": 20,
 	"createdAt": 10,
 	"updatedAt": 15
 }

--- a/services/registration/tests/registration_test.go
+++ b/services/registration/tests/registration_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/json"
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/common/datastore"
 	"github.com/HackIllinois/api/services/registration/config"
@@ -8,7 +9,6 @@ import (
 	"github.com/HackIllinois/api/services/registration/service"
 	"reflect"
 	"testing"
-	"encoding/json"
 )
 
 var db database.Database
@@ -262,7 +262,7 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 		},
 	}
 
-	if(len(user_registrations.Registrations) != len(expected_registrations.Registrations)) {
+	if len(user_registrations.Registrations) != len(expected_registrations.Registrations) {
 		t.Errorf("Wrong number of registrations.\nExpected %v\ngot %v\n", len(expected_registrations.Registrations), len(user_registrations.Registrations))
 	}
 
@@ -286,7 +286,7 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 		},
 	}
 
-	if(len(user_registrations.Registrations) != len(expected_registrations.Registrations)) {
+	if len(user_registrations.Registrations) != len(expected_registrations.Registrations) {
 		t.Errorf("Wrong number of registrations.\nExpected %v\ngot %v\n", len(expected_registrations.Registrations), len(user_registrations.Registrations))
 	}
 
@@ -312,7 +312,7 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 		},
 	}
 
-	if(len(user_registrations.Registrations) != len(expected_registrations.Registrations)) {
+	if len(user_registrations.Registrations) != len(expected_registrations.Registrations) {
 		t.Errorf("Wrong number of registrations.\nExpected %v\ngot %v\n", len(expected_registrations.Registrations), len(user_registrations.Registrations))
 	}
 


### PR DESCRIPTION
The PR updates the registration service to use the `datastore` package in `common`. With this update the registration definitions are loaded from the config file.

Once this PR is merged HackIllinois and R|P will be able to deploy the same binaries into production with different configuration files.

Exposed behavior and functionality to API users has not been modified.

- [x] Use `datastore` for configuration registrations
- [x] Update registration controller, service, and tests


Other minor changes:
- [x] Fix bug regarding registration -> decision service communication
- [x] Hide the `_id` attribute from datastore users