### PR TITLE
Service health endpoints

### DIFF
--- a/common/apiserver/apiserver.go
+++ b/common/apiserver/apiserver.go
@@ -1,0 +1,14 @@
+package apiserver
+
+import (
+	"net/http"
+	"github.com/gorilla/mux"
+	"github.com/HackIllinois/api/common/middleware"
+)
+
+func StartServer(address string, router *mux.Router) error {
+	router.Use(middleware.ErrorMiddleware)
+	router.Use(middleware.ContentTypeMiddleware)
+
+	return http.ListenAndServe(address, router)
+}

--- a/common/apiserver/apiserver.go
+++ b/common/apiserver/apiserver.go
@@ -1,14 +1,14 @@
 package apiserver
 
 import (
-	"fmt"
-	"time"
-	"net/http"
 	"encoding/json"
+	"fmt"
+	"github.com/HackIllinois/api/common/middleware"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
-	"github.com/HackIllinois/api/common/middleware"
 	"github.com/thoas/stats"
+	"net/http"
+	"time"
 )
 
 func StartServer(address string, router *mux.Router, name string) error {

--- a/common/apiserver/apiserver.go
+++ b/common/apiserver/apiserver.go
@@ -1,14 +1,22 @@
 package apiserver
 
 import (
+	"time"
 	"net/http"
 	"github.com/gorilla/mux"
 	"github.com/HackIllinois/api/common/middleware"
 )
 
-func StartServer(address string, router *mux.Router) error {
+func StartServer(address string, router *mux.Router, name string) error {
 	router.Use(middleware.ErrorMiddleware)
 	router.Use(middleware.ContentTypeMiddleware)
 
-	return http.ListenAndServe(address, router)
+	server := &http.Server{
+		Handler:      router,
+		Addr:         address,
+		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  10 * time.Second,
+	}
+
+	return server.ListenAndServe()
 }

--- a/common/apiserver/apiserver.go
+++ b/common/apiserver/apiserver.go
@@ -1,15 +1,24 @@
 package apiserver
 
 import (
+	"fmt"
 	"time"
 	"net/http"
+	"encoding/json"
 	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
 	"github.com/HackIllinois/api/common/middleware"
+	"github.com/thoas/stats"
 )
 
 func StartServer(address string, router *mux.Router, name string) error {
 	router.Use(middleware.ErrorMiddleware)
 	router.Use(middleware.ContentTypeMiddleware)
+
+	stats_middleware := stats.New()
+	router.Use(stats_middleware.Handler)
+
+	router.Handle(fmt.Sprintf("/%s/internal/healthstats/", name), alice.New().ThenFunc(GetHealthStats(stats_middleware))).Methods("GET")
 
 	server := &http.Server{
 		Handler:      router,
@@ -19,4 +28,14 @@ func StartServer(address string, router *mux.Router, name string) error {
 	}
 
 	return server.ListenAndServe()
+}
+
+func GetHealthStats(stats_middleware *stats.Stats) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		health_stats := stats_middleware.Data()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		json.NewEncoder(w).Encode(health_stats)
+	}
 }

--- a/services/auth/main.go
+++ b/services/auth/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/auth"))
 
-	log.Fatal(apiserver.StartServer(config.AUTH_PORT, router))
+	log.Fatal(apiserver.StartServer(config.AUTH_PORT, router, "auth"))
 }

--- a/services/auth/main.go
+++ b/services/auth/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/auth/config"
 	"github.com/HackIllinois/api/services/auth/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/auth"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.AUTH_PORT, router))
+	log.Fatal(apiserver.StartServer(config.AUTH_PORT, router))
 }

--- a/services/checkin/main.go
+++ b/services/checkin/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/checkin"))
 
-	log.Fatal(apiserver.StartServer(config.CHECKIN_PORT, router))
+	log.Fatal(apiserver.StartServer(config.CHECKIN_PORT, router, "checkin"))
 }

--- a/services/checkin/main.go
+++ b/services/checkin/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/checkin/config"
 	"github.com/HackIllinois/api/services/checkin/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/checkin"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.CHECKIN_PORT, router))
+	log.Fatal(apiserver.StartServer(config.CHECKIN_PORT, router))
 }

--- a/services/decision/main.go
+++ b/services/decision/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/decision"))
 
-	log.Fatal(apiserver.StartServer(config.DECISION_PORT, router))
+	log.Fatal(apiserver.StartServer(config.DECISION_PORT, router, "decision"))
 }

--- a/services/decision/main.go
+++ b/services/decision/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/decision/config"
 	"github.com/HackIllinois/api/services/decision/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/decision"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.DECISION_PORT, router))
+	log.Fatal(apiserver.StartServer(config.DECISION_PORT, router))
 }

--- a/services/event/main.go
+++ b/services/event/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/event"))
 
-	log.Fatal(apiserver.StartServer(config.EVENT_PORT, router))
+	log.Fatal(apiserver.StartServer(config.EVENT_PORT, router, "event"))
 }

--- a/services/event/main.go
+++ b/services/event/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/event/config"
 	"github.com/HackIllinois/api/services/event/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/event"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.EVENT_PORT, router))
+	log.Fatal(apiserver.StartServer(config.EVENT_PORT, router))
 }

--- a/services/mail/main.go
+++ b/services/mail/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/mail"))
 
-	log.Fatal(apiserver.StartServer(config.MAIL_PORT, router))
+	log.Fatal(apiserver.StartServer(config.MAIL_PORT, router, "mail"))
 }

--- a/services/mail/main.go
+++ b/services/mail/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/mail/config"
 	"github.com/HackIllinois/api/services/mail/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/mail"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.MAIL_PORT, router))
+	log.Fatal(apiserver.StartServer(config.MAIL_PORT, router))
 }

--- a/services/registration/main.go
+++ b/services/registration/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/registration"))
 
-	log.Fatal(apiserver.StartServer(config.REGISTRATION_PORT, router))
+	log.Fatal(apiserver.StartServer(config.REGISTRATION_PORT, router, "registration"))
 }

--- a/services/registration/main.go
+++ b/services/registration/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/registration"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.REGISTRATION_PORT, router))
+	log.Fatal(apiserver.StartServer(config.REGISTRATION_PORT, router))
 }

--- a/services/rsvp/main.go
+++ b/services/rsvp/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/rsvp"))
 
-	log.Fatal(apiserver.StartServer(config.RSVP_PORT, router))
+	log.Fatal(apiserver.StartServer(config.RSVP_PORT, router, "rsvp"))
 }

--- a/services/rsvp/main.go
+++ b/services/rsvp/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/rsvp"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.RSVP_PORT, router))
+	log.Fatal(apiserver.StartServer(config.RSVP_PORT, router))
 }

--- a/services/stat/main.go
+++ b/services/stat/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/stat/config"
 	"github.com/HackIllinois/api/services/stat/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/stat"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.STAT_PORT, router))
+	log.Fatal(apiserver.StartServer(config.STAT_PORT, router))
 }

--- a/services/stat/main.go
+++ b/services/stat/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/stat"))
 
-	log.Fatal(apiserver.StartServer(config.STAT_PORT, router))
+	log.Fatal(apiserver.StartServer(config.STAT_PORT, router, "stat"))
 }

--- a/services/upload/main.go
+++ b/services/upload/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/upload/config"
 	"github.com/HackIllinois/api/services/upload/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/upload"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.UPLOAD_PORT, router))
+	log.Fatal(apiserver.StartServer(config.UPLOAD_PORT, router))
 }

--- a/services/upload/main.go
+++ b/services/upload/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/upload"))
 
-	log.Fatal(apiserver.StartServer(config.UPLOAD_PORT, router))
+	log.Fatal(apiserver.StartServer(config.UPLOAD_PORT, router, "upload"))
 }

--- a/services/user/main.go
+++ b/services/user/main.go
@@ -12,5 +12,5 @@ func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/user"))
 
-	log.Fatal(apiserver.StartServer(config.USER_PORT, router))
+	log.Fatal(apiserver.StartServer(config.USER_PORT, router, "user"))
 }

--- a/services/user/main.go
+++ b/services/user/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"github.com/HackIllinois/api/common/middleware"
+	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/user/config"
 	"github.com/HackIllinois/api/services/user/controller"
 	"github.com/gorilla/mux"
 	"log"
-	"net/http"
 )
 
 func main() {
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/user"))
 
-	router.Use(middleware.ErrorMiddleware)
-	router.Use(middleware.ContentTypeMiddleware)
-	log.Fatal(http.ListenAndServe(config.USER_PORT, router))
+	log.Fatal(apiserver.StartServer(config.USER_PORT, router))
 }


### PR DESCRIPTION
Addresses #53 

Adds a new endpoint to each service at `/{service_name}/internal/healthstats/` which reports information on average response time, http response status codes, etc.

This PR adds a new `apiserver` package to common which handles the common server startup code for each service. Requests also now have a request timeout of 10 seconds.

If the average response time get too high or we see an unusual number of non 200 return status codes, we can have the health check fail and restart the container.