### PR TITLE
Add rsvp deadline

### DIFF
--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -62,6 +62,8 @@
 
 	"IS_PRODUCTION": "false",
 
+	"DECISION_EXPIRATION_HOURS": "48",
+
 	"STAT_ENDPOINTS": {
 		"registration": "http://localhost:8004/registration/internal/stats/",
 		"decision": "http://localhost:8005/decision/internal/stats/",

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -41,6 +41,8 @@
 
 	"IS_PRODUCTION": "true",
 
+	"DECISION_EXPIRATION_HOURS": "48",
+
 	"STAT_ENDPOINTS": {
 		"registration": "http://registration.api.:8004/registration/internal/stats/",
 		"decision": "http://decision.api.:8005/decision/internal/stats/",

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -62,6 +62,8 @@
 
 	"IS_PRODUCTION": "false",
 
+	"DECISION_EXPIRATION_HOURS": "48",
+
 	"STAT_ENDPOINTS": {
 		"registration": "http://localhost:8004/registration/internal/stats/"
 	},

--- a/documentation/docs/reference/services/RSVP.md
+++ b/documentation/docs/reference/services/RSVP.md
@@ -35,7 +35,6 @@ Creates an rsvp for the user with the `id` in the JWT token provided in the Auth
 Request format:
 ```
 {
-	"id": "github0000001"
 	"isAttending": true,
 }
 ```
@@ -56,7 +55,6 @@ Updated the rsvp for the user with the `id` in the JWT token provided in the Aut
 Request format:
 ```
 {
-	"id": "github0000001"
 	"isAttending": true,
 }
 ```

--- a/services/rsvp/config/config.go
+++ b/services/rsvp/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/HackIllinois/api/common/configloader"
 	"os"
+	"strconv"
 )
 
 var RSVP_DB_HOST string
@@ -13,6 +14,8 @@ var RSVP_PORT string
 var AUTH_SERVICE string
 var DECISION_SERVICE string
 var MAIL_SERVICE string
+
+var DECISION_EXPIRATION_HOURS int
 
 func init() {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
@@ -56,4 +59,18 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	decision_expiration_str, err := cfg_loader.Get("DECISION_EXPIRATION_HOURS")
+
+	if err != nil {
+		panic(err)
+	}
+
+	decision_expiration, err := strconv.Atoi(decision_expiration_str)
+
+	if err != nil {
+		panic(err)
+	}
+
+	DECISION_EXPIRATION_HOURS = decision_expiration
 }

--- a/services/rsvp/controller/controller.go
+++ b/services/rsvp/controller/controller.go
@@ -62,7 +62,7 @@ func CreateCurrentUserRsvp(w http.ResponseWriter, r *http.Request) {
 		panic(errors.UnprocessableError("Must provide id"))
 	}
 
-	isAccepted, err := service.IsApplicantAccepted(id)
+	isAccepted, isActive, err := service.IsApplicantAcceptedAndActive(id)
 
 	if err != nil {
 		panic(errors.UnprocessableError(err.Error()))
@@ -70,6 +70,10 @@ func CreateCurrentUserRsvp(w http.ResponseWriter, r *http.Request) {
 
 	if !isAccepted {
 		panic(errors.UnprocessableError("Applicant must be accepted to rsvp"))
+	}
+
+	if !isActive {
+		panic(errors.UnprocessableError("Applicant decision has expired"))
 	}
 
 	var rsvp models.UserRsvp
@@ -116,6 +120,20 @@ func UpdateCurrentUserRsvp(w http.ResponseWriter, r *http.Request) {
 
 	if id == "" {
 		panic(errors.UnprocessableError("Must provide id"))
+	}
+
+	isAccepted, isActive, err := service.IsApplicantAcceptedAndActive(id)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	if !isAccepted {
+		panic(errors.UnprocessableError("Applicant must be accepted to modify rsvp"))
+	}
+
+	if !isActive {
+		panic(errors.UnprocessableError("Cannot modify rsvp, applicant decision has expired"))
 	}
 
 	original_rsvp, err := service.GetUserRsvp(id)

--- a/services/rsvp/models/user_decision.go
+++ b/services/rsvp/models/user_decision.go
@@ -1,6 +1,9 @@
 package models
 
 type UserDecision struct {
-	ID     string `json:"id"`
-	Status string `json:"status"`
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	Wave      int    `json:"wave"`
+	Finalized bool   `json:"finalized"`
+	Timestamp int64  `json:"timestamp"`
 }

--- a/services/rsvp/service/decision_service.go
+++ b/services/rsvp/service/decision_service.go
@@ -6,22 +6,30 @@ import (
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
 	"net/http"
+	"time"
 )
 
 /*
 	Checks if the user has been accepted in the decision service
 */
-func IsApplicantAccepted(id string) (bool, error) {
+func IsApplicantAcceptedAndActive(id string) (bool, bool, error) {
 	var decision models.UserDecision
 	status, err := apirequest.Get(config.DECISION_SERVICE+"/decision/"+id+"/", &decision)
 
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	if status != http.StatusOK {
-		return false, errors.New("Decision service failed to return status")
+		return false, false, errors.New("Decision service failed to return status")
 	}
 
-	return decision.Status == "ACCEPTED", nil
+	return decision.Status == "ACCEPTED" && decision.Finalized, time.Now().Unix() < decision.Timestamp+HoursToUnixSeconds(config.DECISION_EXPIRATION_HOURS), nil
+}
+
+/*
+	Converts hours to seconds for usage with unix timestamps
+*/
+func HoursToUnixSeconds(hours int) int64 {
+	return int64(hours) * 60 * 60
 }


### PR DESCRIPTION
Addresses #10 

This PR adds a deadline to rsvp by once given an `ACCEPTED` decision. The length of time a user can rsvp for is controlled by the configuration variable `DECISION_EXPIRATION_HOURS`.

The PR also includes fixes bugs which allowed users with an accepted but not finalized decision to rsvp to the event.