### PR TITLE
Log all API Errors

### DIFF
--- a/common/middleware/error.go
+++ b/common/middleware/error.go
@@ -7,17 +7,39 @@ import (
 	"net/http"
 )
 
+type ErrorLogEntry struct {
+	ID    string
+	Error interface{}
+}
+
+func LogError(id string, error_message interface{}) {
+	log_entry := ErrorLogEntry{
+		ID:    id,
+		Error: error_message,
+	}
+
+	error_log_message, err := json.Marshal(log_entry)
+
+	if err != nil {
+		fmt.Printf("Failed to marshal error for id: %v\n", id)
+		return
+	}
+
+	fmt.Printf("ERROR: %v\n", string(error_log_message))
+}
+
 func ErrorMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
-			if r := recover(); r != nil {
+			if rec := recover(); rec != nil {
 				w.Header().Set("Content-Type", "application/json")
-				switch panic_error := r.(type) {
+				switch panic_error := rec.(type) {
 				case errors.APIError:
+					LogError(r.Header.Get("HackIllinois-Identity"), panic_error)
 					w.WriteHeader(panic_error.Status)
 					json.NewEncoder(w).Encode(panic_error)
 				default:
-					fmt.Println(r)
+					LogError(r.Header.Get("HackIllinois-Identity"), rec)
 					w.WriteHeader(http.StatusInternalServerError)
 					json.NewEncoder(w).Encode(errors.APIError{Status: 500, Message: "Unknown Error"})
 				}


### PR DESCRIPTION
Addresses #18 

This PR adds logging of all responses which do not return with a 200 status. This allows us to trace problems when handling a request across multiple services.

#18 also talks about implementing a logging package for usage throughout the services. This can be added in the future, but is not necessary for the initial logging requests for tracking failed requests in production.