### PR TITLE
Event favorites

### DIFF
--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -207,3 +207,65 @@ Response format:
 	]
 }
 ```
+
+GET /event/favorite/
+--------------------
+
+Returns the event favorites for the current user.
+
+Response format:
+```
+{
+	"id": "github001",
+	"events": [
+		"Example Event 1",
+		"Example Event 2"
+	]
+}
+```
+
+POST /event/favorite/add/
+-------------------------
+
+Adds the given event to the favorites for the current user.
+
+Request format:
+```
+{
+	"eventName": "Example Event",
+}
+```
+
+Response format:
+```
+{
+	"id": "github001",
+	"events": [
+		"Example Event",
+		"Example Event 1",
+		"Example Event 2"
+	]
+}
+```
+
+POST /event/favorite/remove/
+----------------------------
+
+Removes the given event from the favorites for the current user.
+
+Request format:
+```
+{
+	"eventName": "Example Event 1",
+}
+```
+
+Response format:
+```
+{
+	"id": "github001",
+	"events": [
+		"Example Event 2"
+	]
+}
+```

--- a/gateway/services/event.go
+++ b/gateway/services/event.go
@@ -19,19 +19,19 @@ var EventRoutes = arbor.RouteCollection{
 		"GetEventFavorites",
 		"GET",
 		"/event/favorite/",
-		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetEventFavorites).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(GetEventFavorites).ServeHTTP,
 	},
 	arbor.Route{
 		"AddEventFavorite",
 		"POST",
 		"/event/favorite/add/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(AddEventFavorite).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(AddEventFavorite).ServeHTTP,
 	},
 	arbor.Route{
 		"RemoveEventFavorite",
 		"POST",
 		"/event/favorite/remove/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveEventFavorite).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveEventFavorite).ServeHTTP,
 	},
 	arbor.Route{
 		"MarkUserAsAttendingEvent",

--- a/gateway/services/event.go
+++ b/gateway/services/event.go
@@ -16,6 +16,24 @@ const EventFormat string = "JSON"
 
 var EventRoutes = arbor.RouteCollection{
 	arbor.Route{
+		"GetEventFavorites",
+		"GET",
+		"/event/favorite/",
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetEventFavorites).ServeHTTP,
+	},
+	arbor.Route{
+		"AddEventFavorite",
+		"POST",
+		"/event/favorite/add/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(AddEventFavorite).ServeHTTP,
+	},
+	arbor.Route{
+		"RemoveEventFavorite",
+		"POST",
+		"/event/favorite/remove/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveEventFavorite).ServeHTTP,
+	},
+	arbor.Route{
 		"MarkUserAsAttendingEvent",
 		"POST",
 		"/event/track/",
@@ -91,4 +109,16 @@ func GetEventTrackingInfo(w http.ResponseWriter, r *http.Request) {
 
 func GetUserTrackingInfo(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, EventURL+r.URL.String(), EventFormat, "", r)
+}
+
+func GetEventFavorites(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, EventURL+r.URL.String(), EventFormat, "", r)
+}
+
+func AddEventFavorite(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, EventURL+r.URL.String(), EventFormat, "", r)
+}
+
+func RemoveEventFavorite(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, EventURL+r.URL.String(), EventFormat, "", r)
 }

--- a/services/event/controller/controller.go
+++ b/services/event/controller/controller.go
@@ -14,6 +14,10 @@ import (
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
+	router.Handle("/favorite/", alice.New().ThenFunc(GetEventFavorites)).Methods("GET")
+	router.Handle("/favorite/add/", alice.New().ThenFunc(AddEventFavorite)).Methods("POST")
+	router.Handle("/favorite/remove/", alice.New().ThenFunc(RemoveEventFavorite)).Methods("POST")
+
 	router.Handle("/{name}/", alice.New().ThenFunc(GetEvent)).Methods("GET")
 	router.Handle("/{name}/", alice.New().ThenFunc(DeleteEvent)).Methods("DELETE")
 	router.Handle("/", alice.New().ThenFunc(CreateEvent)).Methods("POST")
@@ -187,6 +191,69 @@ func MarkUserAsAttendingEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(tracking_status)
+}
+
+/*
+	Endpoint to get the current user's event favorites
+*/
+func GetEventFavorites(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+
+	favorites, err := service.GetEventFavorites(id)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(favorites)
+}
+
+/*
+	Endpoint to add an event favorite for the current user
+*/
+func AddEventFavorite(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+
+	var event_favorite_modification models.EventFavoriteModification
+	json.NewDecoder(r.Body).Decode(&event_favorite_modification)
+
+	err := service.AddEventFavorite(id, event_favorite_modification.EventName)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	favorites, err := service.GetEventFavorites(id)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(favorites)
+}
+
+/*
+	Endpoint to remove an event favorite for the current user
+*/
+func RemoveEventFavorite(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+
+	var event_favorite_modification models.EventFavoriteModification
+	json.NewDecoder(r.Body).Decode(&event_favorite_modification)
+
+	err := service.RemoveEventFavorite(id, event_favorite_modification.EventName)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	favorites, err := service.GetEventFavorites(id)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(favorites)
 }
 
 /*

--- a/services/event/models/event_favorite_modification.go
+++ b/services/event/models/event_favorite_modification.go
@@ -1,0 +1,5 @@
+package models
+
+type EventFavoriteModification struct {
+	EventName string `json:"eventName"`
+}

--- a/services/event/models/event_favorites.go
+++ b/services/event/models/event_favorites.go
@@ -1,0 +1,6 @@
+package models
+
+type EventFavorites struct {
+	ID     string   `json:"id"`
+	Events []string `json:"events"`
+}

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/common/utils"
 	"github.com/HackIllinois/api/services/event/config"
 	"github.com/HackIllinois/api/services/event/models"
 	"gopkg.in/go-playground/validator.v9"
@@ -320,6 +321,89 @@ func IsEventActive(event_name string) (bool, error) {
 	} else {
 		return current_time < end_time, nil
 	}
+}
+
+/*
+	Returns the event favorites for the user with the given id
+*/
+func GetEventFavorites(id string) (*models.EventFavorites, error) {
+	query := database.QuerySelector{
+		"id": id,
+	}
+
+	var event_favorites models.EventFavorites
+	err := db.FindOne("favorites", query, &event_favorites)
+
+	if err != nil {
+		if err == database.ErrNotFound {
+			err  = db.Insert("favorites", &models.EventFavorites{
+				ID:    id,
+				Events: []string{},
+			})
+
+			if err != nil {
+				return nil, err
+			}
+
+			err = db.FindOne("favorites", query, &event_favorites)
+
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	return &event_favorites, nil
+}
+
+/*
+	Adds the given event to the favorites for the user with the given id
+*/
+func AddEventFavorite(id string, event string) (error) {
+	selector := database.QuerySelector{
+		"id": id,
+	}
+
+	event_favorites, err := GetEventFavorites(id)
+
+	if err != nil {
+		return err
+	}
+
+	if !slice_utils.ContainsString(event_favorites.Events, event) {
+		event_favorites.Events = append(event_favorites.Events, event)
+	}
+
+	err = db.Update("favorites", selector, event_favorites)
+
+	return err
+}
+
+/*
+	Removes the given event to the favorites for the user with the given id
+*/
+func RemoveEventFavorite(id string, event string) (error) {
+	selector := database.QuerySelector{
+		"id": id,
+	}
+
+	event_favorites, err := GetEventFavorites(id)
+
+	if err != nil {
+		return err
+	}
+
+	event_favorites.Events, err = slice_utils.RemoveString(event_favorites.Events, event)
+
+	if err != nil {
+		return errors.New("User's event favorites does not have specified event")
+	}
+
+	err = db.Update("favorites", selector, event_favorites)
+
+	return err
 }
 
 /*

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -336,8 +336,8 @@ func GetEventFavorites(id string) (*models.EventFavorites, error) {
 
 	if err != nil {
 		if err == database.ErrNotFound {
-			err  = db.Insert("favorites", &models.EventFavorites{
-				ID:    id,
+			err = db.Insert("favorites", &models.EventFavorites{
+				ID:     id,
 				Events: []string{},
 			})
 
@@ -361,7 +361,7 @@ func GetEventFavorites(id string) (*models.EventFavorites, error) {
 /*
 	Adds the given event to the favorites for the user with the given id
 */
-func AddEventFavorite(id string, event string) (error) {
+func AddEventFavorite(id string, event string) error {
 	selector := database.QuerySelector{
 		"id": id,
 	}
@@ -384,7 +384,7 @@ func AddEventFavorite(id string, event string) (error) {
 /*
 	Removes the given event to the favorites for the user with the given id
 */
-func RemoveEventFavorite(id string, event string) (error) {
+func RemoveEventFavorite(id string, event string) error {
 	selector := database.QuerySelector{
 		"id": id,
 	}

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -366,6 +366,12 @@ func AddEventFavorite(id string, event string) error {
 		"id": id,
 	}
 
+	_, err := GetEvent(event)
+
+	if err != nil {
+		return errors.New("Could not find event with the given name")
+	}
+
 	event_favorites, err := GetEventFavorites(id)
 
 	if err != nil {

--- a/services/event/tests/event_test.go
+++ b/services/event/tests/event_test.go
@@ -479,3 +479,93 @@ func TestIsEventActive(t *testing.T) {
 
 	CleanupTestDB(t)
 }
+
+/*
+	Tests that getting event favorites works correctly at the service level
+*/
+func TestGetEventFavorites(t *testing.T) {
+	SetupTestDB(t)
+
+	event_favorites, err := service.GetEventFavorites("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_event_favorites := models.EventFavorites{
+		ID:     "testid",
+		Events: []string{},
+	}
+
+	if !reflect.DeepEqual(event_favorites, &expected_event_favorites) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", &expected_event_favorites, event_favorites)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Tests that adding event favorites works correctly at the service level
+*/
+func TestAddEventFavorite(t *testing.T) {
+	SetupTestDB(t)
+
+	err := service.AddEventFavorite("testid", "testname")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event_favorites, err := service.GetEventFavorites("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_event_favorites := models.EventFavorites{
+		ID:     "testid",
+		Events: []string{"testname"},
+	}
+
+	if !reflect.DeepEqual(event_favorites, &expected_event_favorites) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", &expected_event_favorites, event_favorites)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Tests that removing event favorites works correctly at the service level
+*/
+func TestRemoveEventFavorite(t *testing.T) {
+	SetupTestDB(t)
+
+	err := service.AddEventFavorite("testid", "testname")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = service.RemoveEventFavorite("testid", "testname")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event_favorites, err := service.GetEventFavorites("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_event_favorites := models.EventFavorites{
+		ID:     "testid",
+		Events: []string{},
+	}
+
+	if !reflect.DeepEqual(event_favorites, &expected_event_favorites) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", &expected_event_favorites, event_favorites)
+	}
+
+	CleanupTestDB(t)
+}


### PR DESCRIPTION
Addresses #9 

This PR adds event favorites. The following three routes have been added for getting and modifying the user's event favorites.

```
GET /event/favorite/
POST /event/favorite/add/
POST /event/favorite/remove/
```