### PR TITLE
Arbor v0.3 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
     - go get -t ./...
     - sudo apt-get -y install python3 python3-pip
 script:
-    - cd $GOPATH/src/github.com/arbor-dev/arbor && git fetch origin dev/v0.3 && git checkout dev/v0.3 && cd -
     - "[ $(gofmt -l . | wc -l) == 0 ]"
     - make all
     - make test


### PR DESCRIPTION
Arbor's `dev/v0.3` has been merged into master, so we can now use arbor's `master` branch.

See arbor-dev/arbor#61.