### PR TITLE
Concurrently fetch stats from all services

### DIFF
--- a/services/stat/models/async_stat.go
+++ b/services/stat/models/async_stat.go
@@ -1,0 +1,7 @@
+package models
+
+type AsyncStat struct {
+	Service string
+	Stat    *Stat
+	Error   error
+}


### PR DESCRIPTION
Resolves #12. Uses goroutines to concurrently fetch each individual service's stats for the `/stat/` endpoint. These results are then aggregated and returned on the main routine.

Tested manually by `GET`ting the relevant endpoint.

