### PR TITLE
Config Reload

### DIFF
--- a/common/apiserver/apiserver.go
+++ b/common/apiserver/apiserver.go
@@ -11,7 +11,13 @@ import (
 	"time"
 )
 
-func StartServer(address string, router *mux.Router, name string) error {
+func StartServer(address string, router *mux.Router, name string, initialize func() error) error {
+	err := initialize()
+
+	if err != nil {
+		return err
+	}
+
 	router.Use(middleware.ErrorMiddleware)
 	router.Use(middleware.ContentTypeMiddleware)
 

--- a/common/apiserver/apiserver.go
+++ b/common/apiserver/apiserver.go
@@ -25,6 +25,7 @@ func StartServer(address string, router *mux.Router, name string, initialize fun
 	router.Use(stats_middleware.Handler)
 
 	router.Handle(fmt.Sprintf("/%s/internal/healthstats/", name), alice.New().ThenFunc(GetHealthStats(stats_middleware))).Methods("GET")
+	router.Handle(fmt.Sprintf("/%s/internal/reload/", name), alice.New().ThenFunc(Reload(initialize))).Methods("GET")
 
 	server := &http.Server{
 		Handler:      router,
@@ -56,5 +57,20 @@ func GetHealthStats(stats_middleware *stats.Stats) http.HandlerFunc {
 		}
 
 		json.NewEncoder(w).Encode(health_stats)
+	}
+}
+
+/*
+	Reinitializes the service causing configuration variables to be reread
+*/
+func Reload(initialize func() error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := initialize()
+
+		if err != nil {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
 	}
 }

--- a/common/database/database.go
+++ b/common/database/database.go
@@ -5,6 +5,7 @@ package database
 */
 type Database interface {
 	Connect(host string) error
+	Close()
 	FindOne(collection_name string, query interface{}, result interface{}) error
 	FindAll(collection_name string, query interface{}, result interface{}) error
 	RemoveOne(collection_name string, query interface{}) error

--- a/common/database/mongo_database.go
+++ b/common/database/mongo_database.go
@@ -64,6 +64,13 @@ func (db *MongoDatabase) Connect(host string) error {
 }
 
 /*
+	Close the global session to the given mongo database
+*/
+func (db *MongoDatabase) Close() {
+	db.global_session.Close()
+}
+
+/*
 	Returns a copy of the global session for use by a connection
 */
 func (db *MongoDatabase) GetSession() *mgo.Session {

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -14,6 +14,12 @@ func Initialize() error {
 		return err
 	}
 
+	err = services.Initialize()
+
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1,20 +1,27 @@
 package gateway
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/gateway/config"
 	"github.com/HackIllinois/api/gateway/services"
 	"github.com/arbor-dev/arbor/server"
-	"os"
+	"log"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
 
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	config.LoadArborConfig()

--- a/gateway/services/health.go
+++ b/gateway/services/health.go
@@ -4,27 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/HackIllinois/api/common/apirequest"
-	"github.com/HackIllinois/api/gateway/config"
 	"github.com/HackIllinois/api/gateway/middleware"
 	"github.com/HackIllinois/api/gateway/models"
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
 	"net/http"
 )
-
-var ServiceLocations = map[string]string{
-	"auth":          config.AUTH_SERVICE,
-	"user":          config.USER_SERVICE,
-	"registration":  config.REGISTRATION_SERVICE,
-	"decision":      config.DECISION_SERVICE,
-	"rsvp":          config.RSVP_SERVICE,
-	"checkin":       config.CHECKIN_SERVICE,
-	"upload":        config.UPLOAD_SERVICE,
-	"mail":          config.MAIL_SERVICE,
-	"event":         config.EVENT_SERVICE,
-	"stat":          config.STAT_SERVICE,
-	"notifications": config.NOTIFICATIONS_SERVICE,
-}
 
 var HealthRoutes = arbor.RouteCollection{
 	arbor.Route{

--- a/gateway/services/reload.go
+++ b/gateway/services/reload.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"net/http"
 	"encoding/json"
 	"fmt"
 	"github.com/HackIllinois/api/common/apirequest"
@@ -9,7 +8,9 @@ import (
 	"github.com/HackIllinois/api/gateway/models"
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
+	"net/http"
 )
+
 var ReloadRoutes = arbor.RouteCollection{
 	arbor.Route{
 		"Reload",
@@ -40,7 +41,7 @@ func Reload(w http.ResponseWriter, r *http.Request) {
 
 	reload_info := map[string][]string{
 		"success": reload_success,
-		"failed": reload_failed,
+		"failed":  reload_failed,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/gateway/services/reload.go
+++ b/gateway/services/reload.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/HackIllinois/api/common/apirequest"
+	"github.com/HackIllinois/api/gateway/config"
 	"github.com/HackIllinois/api/gateway/middleware"
 	"github.com/HackIllinois/api/gateway/models"
 	"github.com/arbor-dev/arbor"
@@ -23,6 +24,14 @@ var ReloadRoutes = arbor.RouteCollection{
 func Reload(w http.ResponseWriter, r *http.Request) {
 	reload_success := []string{}
 	reload_failed := []string{}
+
+	err := ReloadGateway()
+
+	if err != nil {
+		reload_failed = append(reload_failed, "gateway")
+	} else {
+		reload_success = append(reload_success, "gateway")
+	}
 
 	for service_name, service_location := range ServiceLocations {
 		status, err := apirequest.Get(fmt.Sprintf("%s/%s/internal/reload/", service_location, service_name), nil)
@@ -47,4 +56,20 @@ func Reload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	json.NewEncoder(w).Encode(reload_info)
+}
+
+func ReloadGateway() error {
+	err := config.Initialize()
+
+	if err != nil {
+		return err
+	}
+
+	err = Initialize()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/gateway/services/reload.go
+++ b/gateway/services/reload.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"net/http"
+	"encoding/json"
+	"fmt"
+	"github.com/HackIllinois/api/common/apirequest"
+	"github.com/HackIllinois/api/gateway/middleware"
+	"github.com/HackIllinois/api/gateway/models"
+	"github.com/arbor-dev/arbor"
+	"github.com/justinas/alice"
+)
+var ReloadRoutes = arbor.RouteCollection{
+	arbor.Route{
+		"Reload",
+		"GET",
+		"/reload/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(Reload).ServeHTTP,
+	},
+}
+
+func Reload(w http.ResponseWriter, r *http.Request) {
+	reload_success := []string{}
+	reload_failed := []string{}
+
+	for service_name, service_location := range ServiceLocations {
+		status, err := apirequest.Get(fmt.Sprintf("%s/%s/internal/reload/", service_location, service_name), nil)
+
+		if err != nil {
+			reload_failed = append(reload_failed, service_name)
+			continue
+		}
+
+		if status == http.StatusOK {
+			reload_success = append(reload_success, service_name)
+		} else {
+			reload_failed = append(reload_failed, service_name)
+		}
+	}
+
+	reload_info := map[string][]string{
+		"success": reload_success,
+		"failed": reload_failed,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(reload_info)
+}

--- a/gateway/services/services.go
+++ b/gateway/services/services.go
@@ -2,10 +2,10 @@ package services
 
 import (
 	"fmt"
+	"github.com/HackIllinois/api/gateway/config"
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
 	"net/http"
-	"github.com/HackIllinois/api/gateway/config"
 )
 
 var ServiceLocations map[string]string

--- a/gateway/services/services.go
+++ b/gateway/services/services.go
@@ -5,7 +5,28 @@ import (
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
 	"net/http"
+	"github.com/HackIllinois/api/gateway/config"
 )
+
+var ServiceLocations map[string]string
+
+func Initialize() error {
+	ServiceLocations = map[string]string{
+		"auth":          config.AUTH_SERVICE,
+		"user":          config.USER_SERVICE,
+		"registration":  config.REGISTRATION_SERVICE,
+		"decision":      config.DECISION_SERVICE,
+		"rsvp":          config.RSVP_SERVICE,
+		"checkin":       config.CHECKIN_SERVICE,
+		"upload":        config.UPLOAD_SERVICE,
+		"mail":          config.MAIL_SERVICE,
+		"event":         config.EVENT_SERVICE,
+		"stat":          config.STAT_SERVICE,
+		"notifications": config.NOTIFICATIONS_SERVICE,
+	}
+
+	return nil
+}
 
 var Routes = arbor.RouteCollection{
 	arbor.Route{
@@ -41,8 +62,9 @@ func RegisterAPIs() arbor.RouteCollection {
 	Routes = append(Routes, MailRoutes...)
 	Routes = append(Routes, EventRoutes...)
 	Routes = append(Routes, StatRoutes...)
-	Routes = append(Routes, HealthRoutes...)
 	Routes = append(Routes, NotificationsRoutes...)
+	Routes = append(Routes, HealthRoutes...)
+	Routes = append(Routes, ReloadRoutes...)
 	return Routes
 }
 

--- a/services/auth/main.go
+++ b/services/auth/main.go
@@ -1,34 +1,40 @@
 package auth
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/auth/config"
 	"github.com/HackIllinois/api/services/auth/controller"
 	"github.com/HackIllinois/api/services/auth/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/auth"))
 
-	log.Fatal(apiserver.StartServer(config.AUTH_PORT, router, "auth"))
+	log.Fatal(apiserver.StartServer(config.AUTH_PORT, router, "auth", Initialize))
 }

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -13,6 +13,11 @@ import (
 var db database.Database
 
 func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
 	var err error
 	db, err = database.InitDatabase(config.AUTH_DB_HOST, config.AUTH_DB_NAME)
 

--- a/services/checkin/main.go
+++ b/services/checkin/main.go
@@ -1,34 +1,40 @@
 package checkin
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/checkin/config"
 	"github.com/HackIllinois/api/services/checkin/controller"
 	"github.com/HackIllinois/api/services/checkin/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/checkin"))
 
-	log.Fatal(apiserver.StartServer(config.CHECKIN_PORT, router, "checkin"))
+	log.Fatal(apiserver.StartServer(config.CHECKIN_PORT, router, "checkin", Initialize))
 }

--- a/services/checkin/service/checkin_service.go
+++ b/services/checkin/service/checkin_service.go
@@ -12,6 +12,11 @@ import (
 var db database.Database
 
 func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
 	var err error
 	db, err = database.InitDatabase(config.CHECKIN_DB_HOST, config.CHECKIN_DB_NAME)
 

--- a/services/decision/main.go
+++ b/services/decision/main.go
@@ -1,34 +1,40 @@
 package decision
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/decision/config"
 	"github.com/HackIllinois/api/services/decision/controller"
 	"github.com/HackIllinois/api/services/decision/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/decision"))
 
-	log.Fatal(apiserver.StartServer(config.DECISION_PORT, router, "decision"))
+	log.Fatal(apiserver.StartServer(config.DECISION_PORT, router, "decision", Initialize))
 }

--- a/services/decision/service/decision_service.go
+++ b/services/decision/service/decision_service.go
@@ -18,6 +18,11 @@ var validate *validator.Validate
 var db database.Database
 
 func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
 	var err error
 	db, err = database.InitDatabase(config.DECISION_DB_HOST, config.DECISION_DB_NAME)
 

--- a/services/event/main.go
+++ b/services/event/main.go
@@ -1,34 +1,40 @@
 package event
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/event/config"
 	"github.com/HackIllinois/api/services/event/controller"
 	"github.com/HackIllinois/api/services/event/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/event"))
 
-	log.Fatal(apiserver.StartServer(config.EVENT_PORT, router, "event"))
+	log.Fatal(apiserver.StartServer(config.EVENT_PORT, router, "event", Initialize))
 }

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -16,6 +16,11 @@ var validate *validator.Validate
 var db database.Database
 
 func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
 	var err error
 	db, err = database.InitDatabase(config.EVENT_DB_HOST, config.EVENT_DB_NAME)
 

--- a/services/mail/main.go
+++ b/services/mail/main.go
@@ -1,34 +1,40 @@
 package mail
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/mail/config"
 	"github.com/HackIllinois/api/services/mail/controller"
 	"github.com/HackIllinois/api/services/mail/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/mail"))
 
-	log.Fatal(apiserver.StartServer(config.MAIL_PORT, router, "mail"))
+	log.Fatal(apiserver.StartServer(config.MAIL_PORT, router, "mail", Initialize))
 }

--- a/services/mail/service/mail_service.go
+++ b/services/mail/service/mail_service.go
@@ -15,6 +15,11 @@ import (
 var db database.Database
 
 func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
 	var err error
 	db, err = database.InitDatabase(config.MAIL_DB_HOST, config.MAIL_DB_NAME)
 

--- a/services/notifications/main.go
+++ b/services/notifications/main.go
@@ -1,34 +1,40 @@
 package notifications
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/notifications/config"
 	"github.com/HackIllinois/api/services/notifications/controller"
 	"github.com/HackIllinois/api/services/notifications/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/notifications"))
 
-	log.Fatal(apiserver.StartServer(config.NOTIFICATIONS_PORT, router, "notifications"))
+	log.Fatal(apiserver.StartServer(config.NOTIFICATIONS_PORT, router, "notifications", Initialize))
 }

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -32,7 +32,6 @@ func Initialize() error {
 		db = nil
 	}
 
-
 	var err error
 	db, err = database.InitDatabase(config.NOTIFICATIONS_DB_HOST, config.NOTIFICATIONS_DB_NAME)
 

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -27,6 +27,12 @@ func Initialize() error {
 	}))
 	client = sns.New(sess)
 
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
+
 	var err error
 	db, err = database.InitDatabase(config.NOTIFICATIONS_DB_HOST, config.NOTIFICATIONS_DB_NAME)
 

--- a/services/registration/main.go
+++ b/services/registration/main.go
@@ -1,34 +1,40 @@
 package registration
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/controller"
 	"github.com/HackIllinois/api/services/registration/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/registration"))
 
-	log.Fatal(apiserver.StartServer(config.REGISTRATION_PORT, router, "registration"))
+	log.Fatal(apiserver.StartServer(config.REGISTRATION_PORT, router, "registration", Initialize))
 }

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -15,6 +15,11 @@ var validate *validator.Validate
 var db database.Database
 
 func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
 	var err error
 	db, err = database.InitDatabase(config.REGISTRATION_DB_HOST, config.REGISTRATION_DB_NAME)
 

--- a/services/rsvp/main.go
+++ b/services/rsvp/main.go
@@ -1,34 +1,40 @@
 package rsvp
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/controller"
 	"github.com/HackIllinois/api/services/rsvp/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/rsvp"))
 
-	log.Fatal(apiserver.StartServer(config.RSVP_PORT, router, "rsvp"))
+	log.Fatal(apiserver.StartServer(config.RSVP_PORT, router, "rsvp", Initialize))
 }

--- a/services/rsvp/service/rsvp_service.go
+++ b/services/rsvp/service/rsvp_service.go
@@ -10,6 +10,11 @@ import (
 var db database.Database
 
 func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
 	var err error
 	db, err = database.InitDatabase(config.RSVP_DB_HOST, config.RSVP_DB_NAME)
 

--- a/services/stat/main.go
+++ b/services/stat/main.go
@@ -1,34 +1,40 @@
 package stat
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/stat/config"
 	"github.com/HackIllinois/api/services/stat/controller"
 	"github.com/HackIllinois/api/services/stat/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/stat"))
 
-	log.Fatal(apiserver.StartServer(config.STAT_PORT, router, "stat"))
+	log.Fatal(apiserver.StartServer(config.STAT_PORT, router, "stat", Initialize))
 }

--- a/services/upload/main.go
+++ b/services/upload/main.go
@@ -1,34 +1,40 @@
 package upload
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/upload/config"
 	"github.com/HackIllinois/api/services/upload/controller"
 	"github.com/HackIllinois/api/services/upload/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/upload"))
 
-	log.Fatal(apiserver.StartServer(config.UPLOAD_PORT, router, "upload"))
+	log.Fatal(apiserver.StartServer(config.UPLOAD_PORT, router, "upload", Initialize))
 }

--- a/services/user/main.go
+++ b/services/user/main.go
@@ -1,34 +1,40 @@
 package user
 
 import (
-	"fmt"
 	"github.com/HackIllinois/api/common/apiserver"
 	"github.com/HackIllinois/api/services/user/config"
 	"github.com/HackIllinois/api/services/user/controller"
 	"github.com/HackIllinois/api/services/user/service"
 	"github.com/gorilla/mux"
 	"log"
-	"os"
 )
 
-func Entry() {
+func Initialize() error {
 	err := config.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
 
 	}
 
 	err = service.Initialize()
 
 	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	router := mux.NewRouter()
 	controller.SetupController(router.PathPrefix("/user"))
 
-	log.Fatal(apiserver.StartServer(config.USER_PORT, router, "user"))
+	log.Fatal(apiserver.StartServer(config.USER_PORT, router, "user", Initialize))
 }

--- a/services/user/service/user_service.go
+++ b/services/user/service/user_service.go
@@ -12,6 +12,11 @@ import (
 var db database.Database
 
 func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
 	var err error
 	db, err = database.InitDatabase(config.USER_DB_HOST, config.USER_DB_NAME)
 


### PR DESCRIPTION
This PR allows configuration updates to be deployed without restarting the API. When a user with an `Admin` token makes a request to `GET /reload/` the gateway will reload it's configuration and then send a request to each service asking it to reload it's configuration. The list of successful and unsuccessful reloads is returned to in the response body.

This, in effect, addresses #23 since API administrations can now change the secret in the configuration and then hit the `GET /reload/` endpoint revoking all tokens.