### PR TITLE
Add ability to subscribe users to topics corresponding with roles

### DIFF
--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -92,9 +92,9 @@
                 "Staff": "Staff",
                 "Mentor": "Mentor",
                 "Applicant": "Applicant",
-                "Attendee", "Attendee",
-                "User", "User",
-                "Sponsor", "Sponsor"
+                "Attendee": "Attendee",
+                "User": "User",
+                "Sponsor": "Sponsor"
         },
 
 

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -88,7 +88,7 @@
 	},
 
         "GROUP_TOPIC_MAP": {
-                "Admin": "Admins"
+                "Admin": "Admin"
         },
 
 	"REGISTRATION_STAT_FIELDS": [

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -88,8 +88,15 @@
 	},
 
         "GROUP_TOPIC_MAP": {
-                "Admin": "Admin"
+                "Admin": "Admin",
+                "Staff": "Staff",
+                "Mentor": "Mentor",
+                "Applicant": "Applicant",
+                "Attendee", "Attendee",
+                "User", "User",
+                "Sponsor", "Sponsor"
         },
+
 
 	"REGISTRATION_STAT_FIELDS": [
 		"major",

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -87,6 +87,10 @@
 		"event": "http://localhost:8010/event/internal/stats/"
 	},
 
+        "GROUP_TOPIC_MAP": {
+                "Admin": "Admins"
+        },
+
 	"REGISTRATION_STAT_FIELDS": [
 		"major",
 		"school",

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -67,9 +67,9 @@
                 "Staff": "Staff",
                 "Mentor": "Mentor",
                 "Applicant": "Applicant",
-                "Attendee", "Attendee",
-                "User", "User",
-                "Sponsor", "Sponsor"
+                "Attendee": "Attendee",
+                "User": "User",
+                "Sponsor": "Sponsor"
         },
 
 

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -62,6 +62,17 @@
 		"event": "http://event.api.:8010/event/internal/stats/"
 	},
 
+        "GROUP_TOPIC_MAP": {
+                "Admin": "Admin",
+                "Staff": "Staff",
+                "Mentor": "Mentor",
+                "Applicant": "Applicant",
+                "Attendee", "Attendee",
+                "User", "User",
+                "Sponsor", "Sponsor"
+        },
+
+
 	"REGISTRATION_STAT_FIELDS": [
 		"major",
 		"school",

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -81,6 +81,8 @@
 		"registration": "http://localhost:8004/registration/internal/stats/"
 	},
 
+        "GROUP_TOPIC_MAP": {},
+
 	"REGISTRATION_STAT_FIELDS": [
 		"major",
 		"school"

--- a/documentation/docs/reference/services/Notifications.md
+++ b/documentation/docs/reference/services/Notifications.md
@@ -218,3 +218,25 @@ Response format:
 	"platform": "android"
 }
 ```
+
+## POST /notifications/update/
+
+Updates a user's subscribed topics to match their user roles
+
+Request format:
+
+```
+{
+}
+```
+
+Response format:
+
+```
+{
+	"topics": [
+		  "Admin",
+		  "Attendee"
+	]
+}
+```

--- a/gateway/services/notifications.go
+++ b/gateway/services/notifications.go
@@ -75,6 +75,12 @@ var NotificationsRoutes = arbor.RouteCollection{
 		"/notifications/{id}/info/",
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole})).ThenFunc(GetTopicInfo).ServeHTTP,
 	},
+	arbor.Route{
+		"UpdateUserSubscriptions",
+		"POST",
+		"/notifications/update/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.UserRole})).ThenFunc(UpdateUserSubscriptions).ServeHTTP,
+	},
 }
 
 func GetAllTopics(w http.ResponseWriter, r *http.Request) {
@@ -114,5 +120,9 @@ func RemoveUsersFromTopic(w http.ResponseWriter, r *http.Request) {
 }
 
 func RegisterDeviceToUser(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, NotificationsURL+r.URL.String(), NotificationsFormat, "", r)
+}
+
+func UpdateUserSubscriptions(w http.ResponseWriter, r *http.Request) {
 	arbor.POST(w, NotificationsURL+r.URL.String(), NotificationsFormat, "", r)
 }

--- a/gateway/services/notifications.go
+++ b/gateway/services/notifications.go
@@ -40,6 +40,12 @@ var NotificationsRoutes = arbor.RouteCollection{
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.UserRole})).ThenFunc(RegisterDeviceToUser).ServeHTTP,
 	},
 	arbor.Route{
+		"UpdateUserSubscriptions",
+		"POST",
+		"/notifications/update/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.UserRole})).ThenFunc(UpdateUserSubscriptions).ServeHTTP,
+	},
+	arbor.Route{
 		"GetNotificationsForTopic",
 		"GET",
 		"/notifications/{id}/",
@@ -74,12 +80,6 @@ var NotificationsRoutes = arbor.RouteCollection{
 		"GET",
 		"/notifications/{id}/info/",
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole})).ThenFunc(GetTopicInfo).ServeHTTP,
-	},
-	arbor.Route{
-		"UpdateUserSubscriptions",
-		"POST",
-		"/notifications/update/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.UserRole})).ThenFunc(UpdateUserSubscriptions).ServeHTTP,
 	},
 }
 

--- a/services/notifications/config/config.go
+++ b/services/notifications/config/config.go
@@ -17,6 +17,8 @@ var SNS_REGION string
 var ANDROID_PLATFORM_ARN string
 var IOS_PLATFORM_ARN string
 
+var GROUP_TOPIC_MAP map[string]string
+
 func init() {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
 
@@ -67,4 +69,10 @@ func init() {
 	}
 
 	IS_PRODUCTION = (production == "true")
+
+	err = cfg_loader.ParseInto("GROUP_TOPIC_MAP", &GROUP_TOPIC_MAP)
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/services/notifications/config/config.go
+++ b/services/notifications/config/config.go
@@ -19,6 +19,8 @@ var IOS_PLATFORM_ARN string
 
 var GROUP_TOPIC_MAP map[string]string
 
+var AUTH_SERVICE string
+
 func init() {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
 
@@ -71,6 +73,12 @@ func init() {
 	IS_PRODUCTION = (production == "true")
 
 	err = cfg_loader.ParseInto("GROUP_TOPIC_MAP", &GROUP_TOPIC_MAP)
+
+	if err != nil {
+		panic(err)
+	}
+
+	AUTH_SERVICE, err = cfg_loader.Get("AUTH_SERVICE")
 
 	if err != nil {
 		panic(err)

--- a/services/notifications/controller/controller.go
+++ b/services/notifications/controller/controller.go
@@ -17,6 +17,7 @@ func SetupController(route *mux.Route) {
 	router.Handle("/", alice.New().ThenFunc(CreateTopic)).Methods("POST")
 	router.Handle("/all/", alice.New().ThenFunc(GetAllNotifications)).Methods("GET")
 	router.Handle("/device/", alice.New().ThenFunc(RegisterDeviceToUser)).Methods("POST")
+	router.Handle("/update/", alice.New().ThenFunc(UpdateUserSubscriptions)).Methods("POST")
 	router.Handle("/{name}/", alice.New().ThenFunc(GetNotificationsForTopic)).Methods("GET")
 	router.Handle("/{name}/", alice.New().ThenFunc(DeleteTopic)).Methods("DELETE")
 	router.Handle("/{name}/", alice.New().ThenFunc(PublishNotification)).Methods("POST")
@@ -218,4 +219,23 @@ func RegisterDeviceToUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(device_registration)
+}
+
+/*
+        Subscribes a user to topics corresponding to their roles, and unsubscribes a user from all other topics 
+*/
+func UpdateUserSubscriptions(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+
+	if id == "" {
+		panic(errors.MalformedRequestError("Must provide id of user to update subscriptions", "Must provide id of user to update subscriptions"))
+	}
+
+	topic_list, err := service.UpdateUserSubscriptions(id)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Could not update user subscriptions."))
+	}
+
+	json.NewEncoder(w).Encode(topic_list)
 }

--- a/services/notifications/controller/controller.go
+++ b/services/notifications/controller/controller.go
@@ -222,7 +222,7 @@ func RegisterDeviceToUser(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-        Subscribes a user to topics corresponding to their roles, and unsubscribes a user from all other topics 
+   Subscribes a user to topics corresponding to their roles, and unsubscribes a user from all other topics
 */
 func UpdateUserSubscriptions(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")

--- a/services/notifications/models/user_roles.go
+++ b/services/notifications/models/user_roles.go
@@ -1,0 +1,6 @@
+package models
+
+type UserRoles struct {
+	ID    string   `json:"id"`
+	Roles []string `json:"roles"`
+}

--- a/services/notifications/service/auth_service.go
+++ b/services/notifications/service/auth_service.go
@@ -3,8 +3,8 @@ package service
 import (
 	"errors"
 	"github.com/HackIllinois/api/common/apirequest"
-	"github.com/HackIllinois/api/services/checkin/config"
-	"github.com/HackIllinois/api/services/checkin/models"
+	"github.com/HackIllinois/api/services/notifications/config"
+	"github.com/HackIllinois/api/services/notifications/models"
 	"net/http"
 )
 

--- a/services/notifications/service/auth_service.go
+++ b/services/notifications/service/auth_service.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"errors"
+	"github.com/HackIllinois/api/common/apirequest"
+	"github.com/HackIllinois/api/services/checkin/config"
+	"github.com/HackIllinois/api/services/checkin/models"
+	"net/http"
+)
+
+/*
+	Gets the roles for a user given id.
+*/
+func GetRoles(id string) (*models.UserRoles, error) {
+	var user_roles models.UserRoles
+	status, err := apirequest.Get(config.AUTH_SERVICE+"/auth/roles/"+id+"/", &user_roles)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, errors.New("Could not fetch roles from Auth service.")
+	}
+
+	return &user_roles, nil
+}

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -220,9 +220,9 @@ func GetNotificationsForTopic(topic_name string) (*models.NotificationList, erro
 }
 
 /*
-        Subscribes a user to topics corresponding to their roles, and unsubscribes a user from all other topics 
+   Subscribes a user to topics corresponding to their roles, and unsubscribes a user from all other topics
 */
-func UpdateUserSubscriptions(user_id string) (*models.TopicList, error)  {
+func UpdateUserSubscriptions(user_id string) (*models.TopicList, error) {
 	user_roles, err := GetRoles(user_id)
 
 	if err != nil {


### PR DESCRIPTION
Adds `POST` endpoint `/notifications/update/` that updates a user's topic subscriptions to match their roles.