### PR TITLE
Fix APNS payload format

### DIFF
--- a/services/notifications/models/apns_container.go
+++ b/services/notifications/models/apns_container.go
@@ -1,0 +1,5 @@
+package models
+
+type APNSContainer struct {
+	Alert APNSAlert `json:"alert"`
+}

--- a/services/notifications/models/apns_container.go
+++ b/services/notifications/models/apns_container.go
@@ -2,4 +2,5 @@ package models
 
 type APNSContainer struct {
 	Alert APNSAlert `json:"alert"`
+	Sound string    `json:"sound"`
 }

--- a/services/notifications/models/apns_payload.go
+++ b/services/notifications/models/apns_payload.go
@@ -1,5 +1,5 @@
 package models
 
 type APNSPayload struct {
-	Alert APNSAlert `json:"alert"`
+	Container APNSContainer `json:"aps"`
 }

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -482,6 +482,7 @@ func GenerateNotificationJson(notification models.Notification) (*string, error)
 				Title: notification.Title,
 				Body:  notification.Body,
 			},
+			Sound: "default",
 		},
 	}
 

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -477,9 +477,11 @@ func GetAllDevices() (*[]models.Device, error) {
 
 func GenerateNotificationJson(notification models.Notification) (*string, error) {
 	apns_payload := models.APNSPayload{
-		Alert: models.APNSAlert{
-			Title: notification.Title,
-			Body:  notification.Body,
+		Container: models.APNSContainer{
+			Alert: models.APNSAlert{
+				Title: notification.Title,
+				Body:  notification.Body,
+			},
 		},
 	}
 


### PR DESCRIPTION
Fixes APNS payload format, wrapping the `alert` key in an `aps` dictionary.