### PR TITLE
Expose role based query endpoints to auth service

### DIFF
--- a/documentation/docs/reference/services/Authorization.md
+++ b/documentation/docs/reference/services/Authorization.md
@@ -123,3 +123,39 @@ Response format:
 	"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFybmF2c2Fua2FyYW5AZ21haWwuY29tIiwiZXhwIjoxNTI1ODQ1MzA0LCJpZCI6MCwicm9sZXMiOlsiVXNlciJdfQ.lYxFGSNDU9q7FoQHNHGvpKu1fTHf8yHsKPg8FDt9L-s"
 }
 ```
+
+GET /auth/roles/list/
+-----------------------
+
+Gets the list of valid roles a user can have.
+
+Response format:
+```
+{
+	"roles": [
+		"Admin",
+		"Staff",
+		"Mentor",
+		"Applicant",
+		"Attendee",
+		"User",
+		"Sponsor"
+	]
+}
+```
+
+GET /auth/roles/list/ROLE/
+--------------------------
+
+Gets the list of users with the role `ROLE`.
+
+Response format:
+```
+{
+	"userIds": [
+		"google901283019238091820933",
+		"google908290138109283982388",
+		"github1290381"
+	]
+}
+```

--- a/gateway/services/auth.go
+++ b/gateway/services/auth.go
@@ -20,6 +20,18 @@ var AuthRoutes = arbor.RouteCollection{
 		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(GetUserRoles).ServeHTTP,
 	},
 	arbor.Route{
+		"GetRolesLists",
+		"GET",
+		"/auth/roles/list/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(GetRolesLists).ServeHTTP,
+	},
+	arbor.Route{
+		"GetUserListByRole",
+		"GET",
+		"/auth/roles/list/{role}/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(GetUserListByRole).ServeHTTP,
+	},
+	arbor.Route{
 		"OauthRedirect",
 		"GET",
 		"/auth/{provider}/",
@@ -66,6 +78,14 @@ func OauthCode(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetUserRoles(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.AUTH_SERVICE+r.URL.String(), AuthFormat, "", r)
+}
+
+func GetRolesLists(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.AUTH_SERVICE+r.URL.String(), AuthFormat, "", r)
+}
+
+func GetUserListByRole(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, config.AUTH_SERVICE+r.URL.String(), AuthFormat, "", r)
 }
 

--- a/services/auth/models/roles.go
+++ b/services/auth/models/roles.go
@@ -11,3 +11,5 @@ const (
 	UserRole      = "User"
 	SponsorRole   = "Sponsor"
 )
+
+var Roles []Role = []Role{AdminRole, StaffRole, MentorRole, ApplicantRole, AttendeeRole, UserRole, SponsorRole}

--- a/services/auth/models/user_list.go
+++ b/services/auth/models/user_list.go
@@ -1,0 +1,5 @@
+package models
+
+type UserList struct {
+	UserIDs []string `json:"userIds"`
+}

--- a/services/auth/models/user_role_list.go
+++ b/services/auth/models/user_role_list.go
@@ -1,0 +1,5 @@
+package models
+
+type UserRoleList struct {
+	Roles []Role `json:"roles"`
+}

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -149,14 +149,14 @@ func AddAutomaticRoleGrants(id string, email string) error {
 /*
 	Returns a list of valid roles for a user to be assigned
 */
-func GetValidRoles() ([]models.Role) {
+func GetValidRoles() []models.Role {
 	return models.Roles
 }
 
 /*
 	Returns a list of user ids with a given role
 */
-func GetUsersByRole(role models.Role) ([]string, error){
+func GetUsersByRole(role models.Role) ([]string, error) {
 	query := database.QuerySelector{
 		"roles": database.QuerySelector{
 			"$elemMatch": database.QuerySelector{
@@ -180,4 +180,3 @@ func GetUsersByRole(role models.Role) ([]string, error){
 
 	return userids, nil
 }
-

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -145,3 +145,39 @@ func AddAutomaticRoleGrants(id string, email string) error {
 
 	return nil
 }
+
+/*
+	Returns a list of valid roles for a user to be assigned
+*/
+func GetValidRoles() ([]models.Role) {
+	return models.Roles
+}
+
+/*
+	Returns a list of user ids with a given role
+*/
+func GetUsersByRole(role models.Role) ([]string, error){
+	query := database.QuerySelector{
+		"roles": database.QuerySelector{
+			"$elemMatch": database.QuerySelector{
+				"$eq": role,
+			},
+		},
+	}
+
+	var users []models.UserRoles
+	err := db.FindAll("roles", query, &users)
+
+	if err != nil {
+		return nil, err
+	}
+
+	userids := make([]string, len(users))
+
+	for i, user := range users {
+		userids[i] = user.ID
+	}
+
+	return userids, nil
+}
+

--- a/services/auth/tests/roles_test.go
+++ b/services/auth/tests/roles_test.go
@@ -171,3 +171,30 @@ func TestRemoveRoleService(t *testing.T) {
 
 	CleanupTestDB(t)
 }
+
+func TestGetUsersByRoleService(t *testing.T) {
+	SetupTestDB(t)
+
+	err := db.Insert("roles", &models.UserRoles{
+		ID:    "testid2",
+		Roles: []string{"Staff"},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userids, err := service.GetUsersByRole("Staff")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_userids := []string{"testid2"}
+
+	if !reflect.DeepEqual(userids, expected_userids) {
+		t.Errorf("Wrong user ids. Expected %v, got %v", expected_userids, userids)
+	}
+
+	CleanupTestDB(t)
+}


### PR DESCRIPTION
This PR adds two new endpoints `GET /auth/roles/list/` and `GET /auth/roles/list/ROLE/` which return a list of valid roles and a list of user's with a specified role respectively.

These endpoints will be useful for automatically managing user subscriptions to role based notification topics.