### PR TITLE
Modifiable event names

### DIFF
--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -1,14 +1,15 @@
 Event
 =====
 
-GET /event/EVENTNAME/
+GET /event/EVENTID/
 ---------------------
 
-Returns the event with the name of `EVENTNAME`. `EVENTNAME` should be url encoded.
+Returns the event with the id of `EVENTID`.
 
 Response format:
 ```
 {
+	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Event 10",
 	"description": "This is a description",
 	"startTime": 1532202702,
@@ -35,6 +36,7 @@ Response format:
 {
 	events: [
 		{
+			"id": "52fdfc072182654f163f5f0f9a621d72",
 			"name": "Example Event 10",
 			"description": "This is a description",
 			"startTime": 1532202702,
@@ -50,6 +52,7 @@ Response format:
 			"eventType": "WORKSHOP"
 		},
 		{
+			"id": "52fdfcab71282654f163f5f0f9a621d72",
 			"name": "Example Event 11",
 			"description": "This is another description",
 			"startTime": 1532202702,
@@ -95,6 +98,7 @@ Request format:
 Response format:
 ```
 {
+	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Event 10",
 	"description": "This is a description",
 	"startTime": 1532202702,
@@ -111,15 +115,15 @@ Response format:
 }
 ```
 
-DELETE /event/EVENTNAME/
+DELETE /event/EVENTID/
 -----------
 
-Endpoint to delete an event with name `EVENTNAME`. `EVENTNAME` should be url encoded.
-It removes the `EVENTNAME` from the event trackers, and every user's tracker.
+Endpoint to delete an event with name `EVENTID`. It removes the `EVENTID` from the event trackers, and every user's tracker.
 
 Response format:
 ```
 {
+	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Event 10",
 	"description": "This is a description",
 	"startTime": 1532202702,
@@ -139,11 +143,12 @@ Response format:
 PUT /event/
 ----------
 
-Updates the event with the name specified in the `name` field of the request. Returns the updated event.
+Updates the event with the id specified in the `id` field of the request. Returns the updated event.
 
 Request format:
 ```
 {
+	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Event 10",
 	"description": "This is a description",
 	"startTime": 1532202702,
@@ -163,6 +168,7 @@ Request format:
 Response format:
 ```
 {
+	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Event 10",
 	"description": "This is a description",
 	"startTime": 1532202702,
@@ -187,7 +193,7 @@ Marks the specified user as attending the specified event. Returns the tracker f
 Request format:
 ```
 {
-	"eventName": "Example Event",
+	"eventId": "52fdfc072182654f163f5f0f9a621d72",
 	"userId": "github0000001"
 }
 ```
@@ -196,7 +202,7 @@ Response format:
 ```
 {
 	"eventTracker": {
-		"eventName": "Example Event",
+		"eventId": "52fdfc072182654f163f5f0f9a621d72",
 		"users": [
 			"github0000001",
 		]
@@ -204,21 +210,21 @@ Response format:
 	"userTracker": {
 		"userId": "github0000001",
 		"events": [
-			"Example Event"
+			"52fdfc072182654f163f5f0f9a621d72"
 		]
 	}
 }
 ```
 
-GET /event/track/event/EVENTNAME/
+GET /event/track/event/EVENTID/
 ---------------------------------
 
-Returns the tracker for the event with the name `EVENTNAME`.
+Returns the tracker for the event with the id `EVENTID`.
 
 Response format:
 ```
 {
-	"eventName": "Example Event",
+	"eventId": "52fdfc072182654f163f5f0f9a621d72",
 	"users": [
 		"github0000001",
 	]
@@ -235,7 +241,7 @@ Response format:
 {
 	"userId": "github0000001",
 	"events": [
-		"Example Event"
+		"52fdfc072182654f163f5f0f9a621d72"
 	]
 }
 ```
@@ -250,8 +256,8 @@ Response format:
 {
 	"id": "github001",
 	"events": [
-		"Example Event 1",
-		"Example Event 2"
+		"52fdfc072182654f163f5f0f9a621d72",
+		"34edfc072182654f163f5f0f9a621d72"
 	]
 }
 ```
@@ -264,7 +270,7 @@ Adds the given event to the favorites for the current user.
 Request format:
 ```
 {
-	"eventName": "Example Event",
+	"eventId": "52fdfc072182654f163f5f0f9a621d72"
 }
 ```
 
@@ -273,9 +279,8 @@ Response format:
 {
 	"id": "github001",
 	"events": [
-		"Example Event",
-		"Example Event 1",
-		"Example Event 2"
+		"52fdfc072182654f163f5f0f9a621d72",
+		"34dffc072182654f163f5f0f9a621d72"
 	]
 }
 ```
@@ -288,7 +293,7 @@ Removes the given event from the favorites for the current user.
 Request format:
 ```
 {
-	"eventName": "Example Event 1",
+	"eventId": "52fdfc072182654f163f5f0f9a621d72",
 }
 ```
 
@@ -297,7 +302,7 @@ Response format:
 {
 	"id": "github001",
 	"events": [
-		"Example Event 2"
+		"52fdfc072182654f163f5f0f9a621d72"
 	]
 }
 ```

--- a/services/event/controller/controller.go
+++ b/services/event/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/HackIllinois/api/common/errors"
+	"github.com/HackIllinois/api/common/utils"
 	"github.com/HackIllinois/api/services/event/models"
 	"github.com/HackIllinois/api/services/event/service"
 	"github.com/gorilla/mux"
@@ -18,26 +19,26 @@ func SetupController(route *mux.Route) {
 	router.Handle("/favorite/add/", alice.New().ThenFunc(AddEventFavorite)).Methods("POST")
 	router.Handle("/favorite/remove/", alice.New().ThenFunc(RemoveEventFavorite)).Methods("POST")
 
-	router.Handle("/{name}/", alice.New().ThenFunc(GetEvent)).Methods("GET")
-	router.Handle("/{name}/", alice.New().ThenFunc(DeleteEvent)).Methods("DELETE")
+	router.Handle("/{id}/", alice.New().ThenFunc(GetEvent)).Methods("GET")
+	router.Handle("/{id}/", alice.New().ThenFunc(DeleteEvent)).Methods("DELETE")
 	router.Handle("/", alice.New().ThenFunc(CreateEvent)).Methods("POST")
 	router.Handle("/", alice.New().ThenFunc(UpdateEvent)).Methods("PUT")
 	router.Handle("/", alice.New().ThenFunc(GetAllEvents)).Methods("GET")
 
 	router.Handle("/track/", alice.New().ThenFunc(MarkUserAsAttendingEvent)).Methods("POST")
-	router.Handle("/track/event/{name}/", alice.New().ThenFunc(GetEventTrackingInfo)).Methods("GET")
+	router.Handle("/track/event/{id}/", alice.New().ThenFunc(GetEventTrackingInfo)).Methods("GET")
 	router.Handle("/track/user/{id}/", alice.New().ThenFunc(GetUserTrackingInfo)).Methods("GET")
 
 	router.Handle("/internal/stats/", alice.New().ThenFunc(GetStats)).Methods("GET")
 }
 
 /*
-	Endpoint to get the event with the specified name
+	Endpoint to get the event with the specified id
 */
 func GetEvent(w http.ResponseWriter, r *http.Request) {
-	name := mux.Vars(r)["name"]
+	id := mux.Vars(r)["id"]
 
-	event, err := service.GetEvent(name)
+	event, err := service.GetEvent(id)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not fetch the event details."))
@@ -47,14 +48,14 @@ func GetEvent(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	Endpoint to delete an event with the specified name.
+	Endpoint to delete an event with the specified id.
 	It removes the event from the event trackers, and every user's tracker.
 	On successful deletion, it returns the event that was deleted.
 */
 func DeleteEvent(w http.ResponseWriter, r *http.Request) {
-	name := mux.Vars(r)["name"]
+	id := mux.Vars(r)["id"]
 
-	event, err := service.DeleteEvent(name)
+	event, err := service.DeleteEvent(id)
 
 	if err != nil {
 		panic(errors.InternalError(err.Error(), "Could not delete either the event, event trackers, or user trackers, or an intermediary subroutine failed."))
@@ -83,13 +84,15 @@ func CreateEvent(w http.ResponseWriter, r *http.Request) {
 	var event models.Event
 	json.NewDecoder(r.Body).Decode(&event)
 
-	err := service.CreateEvent(event.Name, event)
+	event.ID = slice_utils.GenerateUniqueID()
+
+	err := service.CreateEvent(event.ID, event)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not create new event."))
 	}
 
-	updated_event, err := service.GetEvent(event.Name)
+	updated_event, err := service.GetEvent(event.ID)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not get updated event."))
@@ -105,13 +108,13 @@ func UpdateEvent(w http.ResponseWriter, r *http.Request) {
 	var event models.Event
 	json.NewDecoder(r.Body).Decode(&event)
 
-	err := service.UpdateEvent(event.Name, event)
+	err := service.UpdateEvent(event.ID, event)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not update the event."))
 	}
 
-	updated_event, err := service.GetEvent(event.Name)
+	updated_event, err := service.GetEvent(event.ID)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not get updated event details."))
@@ -124,9 +127,9 @@ func UpdateEvent(w http.ResponseWriter, r *http.Request) {
 	Endpoint to get tracking info by event
 */
 func GetEventTrackingInfo(w http.ResponseWriter, r *http.Request) {
-	name := mux.Vars(r)["name"]
+	id := mux.Vars(r)["id"]
 
-	tracker, err := service.GetEventTracker(name)
+	tracker, err := service.GetEventTracker(id)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not get event tracker."))
@@ -167,13 +170,13 @@ func MarkUserAsAttendingEvent(w http.ResponseWriter, r *http.Request) {
 		panic(errors.AttributeMismatchError("User must be checked-in to attend event.", "User must be checked-in to attend event."))
 	}
 
-	err = service.MarkUserAsAttendingEvent(tracking_info.EventName, tracking_info.UserID)
+	err = service.MarkUserAsAttendingEvent(tracking_info.EventID, tracking_info.UserID)
 
 	if err != nil {
 		panic(errors.InternalError(err.Error(), "Could not mark user as attending the event."))
 	}
 
-	event_tracker, err := service.GetEventTracker(tracking_info.EventName)
+	event_tracker, err := service.GetEventTracker(tracking_info.EventID)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not get event trackers."))
@@ -217,7 +220,7 @@ func AddEventFavorite(w http.ResponseWriter, r *http.Request) {
 	var event_favorite_modification models.EventFavoriteModification
 	json.NewDecoder(r.Body).Decode(&event_favorite_modification)
 
-	err := service.AddEventFavorite(id, event_favorite_modification.EventName)
+	err := service.AddEventFavorite(id, event_favorite_modification.EventID)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not add an event favorite for the current user."))
@@ -241,7 +244,7 @@ func RemoveEventFavorite(w http.ResponseWriter, r *http.Request) {
 	var event_favorite_modification models.EventFavoriteModification
 	json.NewDecoder(r.Body).Decode(&event_favorite_modification)
 
-	err := service.RemoveEventFavorite(id, event_favorite_modification.EventName)
+	err := service.RemoveEventFavorite(id, event_favorite_modification.EventID)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not remove an event favorite for the current user."))

--- a/services/event/models/event.go
+++ b/services/event/models/event.go
@@ -1,6 +1,7 @@
 package models
 
 type Event struct {
+	ID          string          `json:"id"                  validate:"required"`
 	Name        string          `json:"name"                validate:"required"`
 	Description string          `json:"description"         validate:"required"`
 	StartTime   int64           `json:"startTime"           validate:"required"`

--- a/services/event/models/event_favorite_modification.go
+++ b/services/event/models/event_favorite_modification.go
@@ -1,5 +1,5 @@
 package models
 
 type EventFavoriteModification struct {
-	EventName string `json:"eventName"`
+	EventID string `json:"eventId"`
 }

--- a/services/event/models/event_tracker.go
+++ b/services/event/models/event_tracker.go
@@ -1,6 +1,6 @@
 package models
 
 type EventTracker struct {
-	EventName string   `json:"eventName"`
-	Users     []string `json:"users"`
+	EventID string   `json:"eventId"`
+	Users   []string `json:"users"`
 }

--- a/services/event/models/tracking_info.go
+++ b/services/event/models/tracking_info.go
@@ -1,6 +1,6 @@
 package models
 
 type TrackingInfo struct {
-	EventName string `json:"eventName"`
-	UserID    string `json:"userId"`
+	EventID string `json:"eventId"`
+	UserID  string `json:"userId"`
 }

--- a/services/event/tests/event_test.go
+++ b/services/event/tests/event_test.go
@@ -50,6 +50,7 @@ var TestTime = time.Now().Unix()
 */
 func SetupTestDB(t *testing.T) {
 	event := models.Event{
+		ID:          "testid",
 		Name:        "testname",
 		Description: "testdescription",
 		StartTime:   TestTime,
@@ -72,8 +73,8 @@ func SetupTestDB(t *testing.T) {
 	}
 
 	event_tracker := models.EventTracker{
-		EventName: "testname",
-		Users:     []string{},
+		EventID: "testid",
+		Users:   []string{},
 	}
 
 	err = db.Insert("eventtrackers", &event_tracker)
@@ -101,6 +102,7 @@ func TestGetAllEventsService(t *testing.T) {
 	SetupTestDB(t)
 
 	event := models.Event{
+		ID:          "testid2",
 		Name:        "testname2",
 		Description: "testdescription2",
 		StartTime:   TestTime,
@@ -131,6 +133,7 @@ func TestGetAllEventsService(t *testing.T) {
 	expected_event_list := models.EventList{
 		Events: []models.Event{
 			{
+				ID:          "testid",
 				Name:        "testname",
 				Description: "testdescription",
 				StartTime:   TestTime,
@@ -146,6 +149,7 @@ func TestGetAllEventsService(t *testing.T) {
 				},
 			},
 			{
+				ID:          "testid2",
 				Name:        "testname2",
 				Description: "testdescription2",
 				StartTime:   TestTime,
@@ -177,13 +181,14 @@ func TestGetAllEventsService(t *testing.T) {
 func TestGetEventService(t *testing.T) {
 	SetupTestDB(t)
 
-	event, err := service.GetEvent("testname")
+	event, err := service.GetEvent("testid")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expected_event := models.Event{
+		ID:          "testid",
 		Name:        "testname",
 		Description: "testdescription",
 		StartTime:   TestTime,
@@ -213,6 +218,7 @@ func TestCreateEventService(t *testing.T) {
 	SetupTestDB(t)
 
 	new_event := models.Event{
+		ID:          "testid2",
 		Name:        "testname2",
 		Description: "testdescription2",
 		StartTime:   TestTime,
@@ -228,19 +234,20 @@ func TestCreateEventService(t *testing.T) {
 		},
 	}
 
-	err := service.CreateEvent("testname2", new_event)
+	err := service.CreateEvent("testid2", new_event)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	event, err := service.GetEvent("testname2")
+	event, err := service.GetEvent("testid2")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expected_event := models.Event{
+		ID:          "testid2",
 		Name:        "testname2",
 		Description: "testdescription2",
 		StartTime:   TestTime,
@@ -269,23 +276,23 @@ func TestCreateEventService(t *testing.T) {
 func TestDeleteEventService(t *testing.T) {
 	SetupTestDB(t)
 
-	event_name := "testname"
+	event_id := "testid"
 
 	// Mark 3 users as attending the event
 
-	err := service.MarkUserAsAttendingEvent(event_name, "user0")
+	err := service.MarkUserAsAttendingEvent(event_id, "user0")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = service.MarkUserAsAttendingEvent(event_name, "user1")
+	err = service.MarkUserAsAttendingEvent(event_id, "user1")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = service.MarkUserAsAttendingEvent(event_name, "user2")
+	err = service.MarkUserAsAttendingEvent(event_id, "user2")
 
 	if err != nil {
 		t.Fatal(err)
@@ -293,21 +300,21 @@ func TestDeleteEventService(t *testing.T) {
 
 	// Try to delete the event
 
-	_, err = service.DeleteEvent(event_name)
+	_, err = service.DeleteEvent(event_id)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Try to find the event in the events db
-	event, err := service.GetEvent(event_name)
+	event, err := service.GetEvent(event_id)
 
 	if err == nil {
 		t.Errorf("Found event %v in events database.", event)
 	}
 
 	// Try to find the event in the eventtrackers db
-	event_tracker, err := service.GetEventTracker(event_name)
+	event_tracker, err := service.GetEventTracker(event_id)
 
 	if err == nil {
 		t.Errorf("Found event in the eventtracker %v.", event_tracker)
@@ -319,7 +326,7 @@ func TestDeleteEventService(t *testing.T) {
 
 	for _, user_tracker := range user_trackers {
 		for _, event := range user_tracker.Events {
-			if event == event_name {
+			if event == event_id {
 				t.Errorf("Found event in the usertracker %v.", user_tracker)
 			}
 		}
@@ -335,6 +342,7 @@ func TestUpdateEventService(t *testing.T) {
 	SetupTestDB(t)
 
 	event := models.Event{
+		ID:          "testid",
 		Name:        "testname",
 		Description: "testdescription2",
 		StartTime:   TestTime,
@@ -350,19 +358,20 @@ func TestUpdateEventService(t *testing.T) {
 		},
 	}
 
-	err := service.UpdateEvent("testname", event)
+	err := service.UpdateEvent("testid", event)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	updated_event, err := service.GetEvent("testname")
+	updated_event, err := service.GetEvent("testid")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expected_event := models.Event{
+		ID:          "testid",
 		Name:        "testname",
 		Description: "testdescription2",
 		StartTime:   TestTime,
@@ -391,21 +400,21 @@ func TestUpdateEventService(t *testing.T) {
 func TestMarkUserAsAttendingEventService(t *testing.T) {
 	SetupTestDB(t)
 
-	err := service.MarkUserAsAttendingEvent("testname", "testuser")
+	err := service.MarkUserAsAttendingEvent("testid", "testuser")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	event_tracker, err := service.GetEventTracker("testname")
+	event_tracker, err := service.GetEventTracker("testid")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expected_event_tracker := models.EventTracker{
-		EventName: "testname",
-		Users:     []string{"testuser"},
+		EventID: "testid",
+		Users:   []string{"testuser"},
 	}
 
 	if !reflect.DeepEqual(event_tracker, &expected_event_tracker) {
@@ -420,7 +429,7 @@ func TestMarkUserAsAttendingEventService(t *testing.T) {
 
 	expected_user_tracker := models.UserTracker{
 		UserID: "testuser",
-		Events: []string{"testname"},
+		Events: []string{"testid"},
 	}
 
 	if !reflect.DeepEqual(user_tracker, &expected_user_tracker) {
@@ -437,27 +446,27 @@ func TestMarkUserAsAttendingEventService(t *testing.T) {
 func TestMarkUserAsAttendingEventErrorService(t *testing.T) {
 	SetupTestDB(t)
 
-	err := service.MarkUserAsAttendingEvent("testname", "testuser")
+	err := service.MarkUserAsAttendingEvent("testid", "testuser")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = service.MarkUserAsAttendingEvent("testname", "testuser")
+	err = service.MarkUserAsAttendingEvent("testid", "testuser")
 
 	if err == nil {
 		t.Fatal("User was marked as attending event twice")
 	}
 
-	event_tracker, err := service.GetEventTracker("testname")
+	event_tracker, err := service.GetEventTracker("testid")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expected_event_tracker := models.EventTracker{
-		EventName: "testname",
-		Users:     []string{"testuser"},
+		EventID: "testid",
+		Users:   []string{"testuser"},
 	}
 
 	if !reflect.DeepEqual(event_tracker, &expected_event_tracker) {
@@ -472,7 +481,7 @@ func TestMarkUserAsAttendingEventErrorService(t *testing.T) {
 
 	expected_user_tracker := models.UserTracker{
 		UserID: "testuser",
-		Events: []string{"testname"},
+		Events: []string{"testid"},
 	}
 
 	if !reflect.DeepEqual(user_tracker, &expected_user_tracker) {
@@ -491,6 +500,7 @@ func TestIsEventActive(t *testing.T) {
 	// Creating a 30 minute long event that SHOULD NOT be active
 	const ONE_MINUTE_IN_SECONDS = 60
 	new_event := models.Event{
+		ID:          "testid3",
 		Name:        "testiseventactive",
 		Description: "testdescription2",
 		StartTime:   TestTime + ONE_MINUTE_IN_SECONDS*40,
@@ -506,9 +516,9 @@ func TestIsEventActive(t *testing.T) {
 		},
 	}
 
-	service.CreateEvent(new_event.Name, new_event)
+	service.CreateEvent(new_event.ID, new_event)
 
-	is_active, err := service.IsEventActive("testiseventactive")
+	is_active, err := service.IsEventActive("testid3")
 
 	if err != nil {
 		t.Fatal(err)
@@ -520,13 +530,14 @@ func TestIsEventActive(t *testing.T) {
 	}
 
 	// Creating a 20 minute long event that SHOULD be active
+	new_event.ID = "testid4"
 	new_event.Name = "test2iseventactive"
 	new_event.StartTime = TestTime
 	new_event.EndTime = TestTime + ONE_MINUTE_IN_SECONDS*20
 
-	service.CreateEvent(new_event.Name, new_event)
+	service.CreateEvent(new_event.ID, new_event)
 
-	is_active, err = service.IsEventActive("test2iseventactive")
+	is_active, err = service.IsEventActive("testid4")
 
 	if err != nil {
 		t.Fatal(err)
@@ -570,7 +581,7 @@ func TestGetEventFavorites(t *testing.T) {
 func TestAddEventFavorite(t *testing.T) {
 	SetupTestDB(t)
 
-	err := service.AddEventFavorite("testid", "testname")
+	err := service.AddEventFavorite("testid", "testid")
 
 	if err != nil {
 		t.Fatal(err)
@@ -584,7 +595,7 @@ func TestAddEventFavorite(t *testing.T) {
 
 	expected_event_favorites := models.EventFavorites{
 		ID:     "testid",
-		Events: []string{"testname"},
+		Events: []string{"testid"},
 	}
 
 	if !reflect.DeepEqual(event_favorites, &expected_event_favorites) {
@@ -600,13 +611,13 @@ func TestAddEventFavorite(t *testing.T) {
 func TestRemoveEventFavorite(t *testing.T) {
 	SetupTestDB(t)
 
-	err := service.AddEventFavorite("testid", "testname")
+	err := service.AddEventFavorite("testid", "testid")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = service.RemoveEventFavorite("testid", "testname")
+	err = service.RemoveEventFavorite("testid", "testid")
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Addresses #171 

Refactor event service to key events by a uniquely generated ID rather than the event name. This allows the event name to be modified after the event is created and allows multiple events with the same name to be created.

- [x] Key events by unique ID