### PR TITLE
Expires at timestamp

### DIFF
--- a/common/utils/time.go
+++ b/common/utils/time.go
@@ -1,0 +1,5 @@
+package slice_utils
+
+func HoursToUnixSeconds(hours int) int64 {
+	return int64(hours) * 60 * 60
+}

--- a/services/decision/config/config.go
+++ b/services/decision/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/HackIllinois/api/common/configloader"
 	"os"
+	"strconv"
 )
 
 var DECISION_DB_HOST string
@@ -11,6 +12,8 @@ var DECISION_DB_NAME string
 var DECISION_PORT string
 
 var MAIL_SERVICE string
+
+var DECISION_EXPIRATION_HOURS int
 
 func Initialize() error {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
@@ -42,6 +45,20 @@ func Initialize() error {
 	if err != nil {
 		return err
 	}
+
+	decision_expiration_str, err := cfg_loader.Get("DECISION_EXPIRATION_HOURS")
+
+	if err != nil {
+		return err
+	}
+
+	decision_expiration, err := strconv.Atoi(decision_expiration_str)
+
+	if err != nil {
+		return err
+	}
+
+	DECISION_EXPIRATION_HOURS = decision_expiration
 
 	return nil
 }

--- a/services/decision/controller/controller.go
+++ b/services/decision/controller/controller.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/HackIllinois/api/common/errors"
+	"github.com/HackIllinois/api/common/utils"
+	"github.com/HackIllinois/api/services/decision/config"
 	"github.com/HackIllinois/api/services/decision/models"
 	"github.com/HackIllinois/api/services/decision/service"
 	"github.com/gorilla/mux"
@@ -81,6 +83,7 @@ func UpdateDecision(w http.ResponseWriter, r *http.Request) {
 
 	decision.Reviewer = r.Header.Get("HackIllinois-Identity")
 	decision.Timestamp = time.Now().Unix()
+	decision.ExpiresAt = decision.Timestamp + slice_utils.HoursToUnixSeconds(config.DECISION_EXPIRATION_HOURS)
 	// Finalized is always false, unless explicitly set to true via the appropriate endpoint.
 	decision.Finalized = false
 
@@ -128,6 +131,7 @@ func FinalizeDecision(w http.ResponseWriter, r *http.Request) {
 	latest_decision.Wave = existing_decision_history.Wave
 	latest_decision.Reviewer = r.Header.Get("HackIllinois-Identity")
 	latest_decision.Timestamp = time.Now().Unix()
+	latest_decision.ExpiresAt = latest_decision.Timestamp + slice_utils.HoursToUnixSeconds(config.DECISION_EXPIRATION_HOURS)
 
 	err = service.UpdateDecision(id, latest_decision)
 

--- a/services/decision/controller/controller.go
+++ b/services/decision/controller/controller.go
@@ -39,13 +39,17 @@ func GetCurrentDecision(w http.ResponseWriter, r *http.Request) {
 	}
 
 	decision_view := models.DecisionView{
-		ID:     decision.ID,
-		Status: decision.Status,
+		ID: decision.ID,
 	}
 
-	// Masks the decision if not finalized
-	if !decision.Finalized {
-		decision_view.Status = "PENDING"
+	// Expose the decision if it has been finalized
+	if decision.Finalized {
+		decision_view.Status = decision.Status
+
+		// Expose the expiration only for finalized ACCEPTED decisions
+		if decision.Status == "ACCEPTED" {
+			decision_view.ExpiresAt = decision.ExpiresAt
+		}
 	}
 
 	json.NewEncoder(w).Encode(decision_view)

--- a/services/decision/models/decision.go
+++ b/services/decision/models/decision.go
@@ -7,4 +7,5 @@ type Decision struct {
 	Wave      int    `json:"wave"      validate:""`
 	Reviewer  string `json:"reviewer"  validate:"required"`
 	Timestamp int64  `json:"timestamp" validate:"required"`
+	ExpiresAt int64  `json:"expiresAt" validate:"required"`
 }

--- a/services/decision/models/decision_history.go
+++ b/services/decision/models/decision_history.go
@@ -7,5 +7,6 @@ type DecisionHistory struct {
 	Wave      int        `json:"wave"`
 	Reviewer  string     `json:"reviewer"`
 	Timestamp int64      `json:"timestamp"`
+	ExpiresAt int64      `json:"expiresAt"`
 	History   []Decision `json:"history"`
 }

--- a/services/decision/models/decision_view.go
+++ b/services/decision/models/decision_view.go
@@ -1,6 +1,7 @@
 package models
 
 type DecisionView struct {
-	ID     string `json:"id"`
-	Status string `json:"status"`
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	ExpiresAt int64  `json:"expiresAt" `
 }

--- a/services/decision/service/decision_service.go
+++ b/services/decision/service/decision_service.go
@@ -86,6 +86,7 @@ func UpdateDecision(id string, decision models.Decision) error {
 	decision_history.History = append(decision_history.History, decision)
 	decision_history.Reviewer = decision.Reviewer
 	decision_history.Timestamp = decision.Timestamp
+	decision_history.ExpiresAt = decision.ExpiresAt
 
 	selector := database.QuerySelector{"id": id}
 
@@ -114,7 +115,7 @@ func HasDecision(id string) (bool, error) {
 }
 
 func AssignValueType(key, value string) (interface{}, error) {
-	int_keys := []string{"wave", "timestamp"}
+	int_keys := []string{"wave", "timestamp", "expiresat"}
 	if slice_utils.ContainsString(int_keys, key) {
 		return strconv.Atoi(value)
 	}

--- a/services/decision/tests/decision_test.go
+++ b/services/decision/tests/decision_test.go
@@ -53,6 +53,7 @@ func SetupTestDB(t *testing.T) {
 		Wave:      0,
 		Reviewer:  "reviewerid",
 		Timestamp: 1,
+		ExpiresAt: 5,
 		History: []models.Decision{
 			{
 				Finalized: false,
@@ -61,6 +62,7 @@ func SetupTestDB(t *testing.T) {
 				Wave:      0,
 				Reviewer:  "reviewerid",
 				Timestamp: 1,
+				ExpiresAt: 5,
 			},
 		},
 	})
@@ -100,6 +102,7 @@ func TestGetDecisionService(t *testing.T) {
 		Wave:      0,
 		Reviewer:  "reviewerid",
 		Timestamp: 1,
+		ExpiresAt: 5,
 		History: []models.Decision{
 			{
 				Finalized: false,
@@ -108,6 +111,7 @@ func TestGetDecisionService(t *testing.T) {
 				Wave:      0,
 				Reviewer:  "reviewerid",
 				Timestamp: 1,
+				ExpiresAt: 5,
 			},
 		},
 	}
@@ -132,6 +136,7 @@ func TestUpdateDecisionService(t *testing.T) {
 		Wave:      1,
 		Reviewer:  "reviewerid",
 		Timestamp: 2,
+		ExpiresAt: 7,
 	})
 
 	if err != nil {
@@ -151,6 +156,7 @@ func TestUpdateDecisionService(t *testing.T) {
 		Wave:      1,
 		Reviewer:  "reviewerid",
 		Timestamp: 2,
+		ExpiresAt: 7,
 		History: []models.Decision{
 			{
 				Finalized: false,
@@ -159,6 +165,7 @@ func TestUpdateDecisionService(t *testing.T) {
 				Wave:      0,
 				Reviewer:  "reviewerid",
 				Timestamp: 1,
+				ExpiresAt: 5,
 			},
 			{
 				Finalized: false,
@@ -167,6 +174,7 @@ func TestUpdateDecisionService(t *testing.T) {
 				Wave:      1,
 				Reviewer:  "reviewerid",
 				Timestamp: 2,
+				ExpiresAt: 7,
 			},
 		},
 	}
@@ -190,6 +198,7 @@ func TestGetFilteredDecisionsService(t *testing.T) {
 		Wave:      1,
 		Reviewer:  "reviewerid",
 		Timestamp: 2,
+		ExpiresAt: 7,
 		History: []models.Decision{
 			{
 				ID:        "testid2",
@@ -197,6 +206,7 @@ func TestGetFilteredDecisionsService(t *testing.T) {
 				Wave:      1,
 				Reviewer:  "reviewerid",
 				Timestamp: 2,
+				ExpiresAt: 7,
 			},
 		},
 	}

--- a/services/rsvp/config/config.go
+++ b/services/rsvp/config/config.go
@@ -4,7 +4,6 @@ import (
 	"github.com/HackIllinois/api/common/configloader"
 	"github.com/HackIllinois/api/common/datastore"
 	"os"
-	"strconv"
 )
 
 var RSVP_DB_HOST string
@@ -15,8 +14,6 @@ var RSVP_PORT string
 var AUTH_SERVICE string
 var DECISION_SERVICE string
 var MAIL_SERVICE string
-
-var DECISION_EXPIRATION_HOURS int
 
 var RSVP_DEFINITION datastore.DataStoreDefinition
 
@@ -64,20 +61,6 @@ func Initialize() error {
 	if err != nil {
 		return err
 	}
-
-	decision_expiration_str, err := cfg_loader.Get("DECISION_EXPIRATION_HOURS")
-
-	if err != nil {
-		return err
-	}
-
-	decision_expiration, err := strconv.Atoi(decision_expiration_str)
-
-	if err != nil {
-		return err
-	}
-
-	DECISION_EXPIRATION_HOURS = decision_expiration
 
 	err = cfg_loader.ParseInto("RSVP_DEFINITION", &RSVP_DEFINITION)
 

--- a/services/rsvp/models/user_decision.go
+++ b/services/rsvp/models/user_decision.go
@@ -6,4 +6,5 @@ type UserDecision struct {
 	Wave      int    `json:"wave"`
 	Finalized bool   `json:"finalized"`
 	Timestamp int64  `json:"timestamp"`
+	ExpiresAt int64  `json:"expiresAt"`
 }

--- a/services/rsvp/service/decision_service.go
+++ b/services/rsvp/service/decision_service.go
@@ -24,12 +24,5 @@ func IsApplicantAcceptedAndActive(id string) (bool, bool, error) {
 		return false, false, errors.New("Decision service failed to return status.")
 	}
 
-	return decision.Status == "ACCEPTED" && decision.Finalized, time.Now().Unix() < decision.Timestamp+HoursToUnixSeconds(config.DECISION_EXPIRATION_HOURS), nil
-}
-
-/*
-	Converts hours to seconds for usage with unix timestamps
-*/
-func HoursToUnixSeconds(hours int) int64 {
-	return int64(hours) * 60 * 60
+	return decision.Status == "ACCEPTED" && decision.Finalized, time.Now().Unix() < decision.ExpiresAt, nil
 }


### PR DESCRIPTION
Addresses #167 

This PR moves the logic determining how long a decision is active for from the rsvp service to the user service. This allows frontends to determine if a decision is still active before going through the entire RSVP process.

- [x] Add `expiresAt` timestamp to decision and use it in the rsvp service