### PR TITLE
Copy through Registration and RSVP data for better stats

### DIFF
--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -359,7 +359,8 @@
 	"RSVP_STAT_FIELDS": [
 		"isAttending",
 		"diet",
-		"transportation"
+		"transportation",
+		"registrationData.attendee.school"
 	],
 
 	"RSVP_DEFINITION": {

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -469,6 +469,12 @@
 				"type": "string",
 				"validations": "",
 				"fields": []
+			},
+			{
+				"name": "registrationData",
+				"type": "object",
+				"validations": "",
+				"fields": []
 			}
 		]
 	}

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -334,7 +334,8 @@
 	"RSVP_STAT_FIELDS": [
 		"isAttending",
 		"diet",
-		"transportation"
+		"transportation",
+		"registrationData.attendee.school"
 	],
 
 	"RSVP_DEFINITION": {

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -444,6 +444,12 @@
 				"type": "string",
 				"validations": "",
 				"fields": []
+			},
+			{
+				"name": "registrationData",
+				"type": "object",
+				"validations": "",
+				"fields": []
 			}
 		]
 	}

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -238,6 +238,12 @@
 				"type": "boolean",
 				"validations": "required|isdefault",
 				"fields": []
+			},
+			{
+				"name": "registrationData",
+				"type": "object",
+				"validations": "",
+				"fields": []
 			}
 		]
 	}

--- a/services/checkin/controller/controller.go
+++ b/services/checkin/controller/controller.go
@@ -69,6 +69,14 @@ func CreateUserCheckin(w http.ResponseWriter, r *http.Request) {
 		panic(errors.AttributeMismatchError("Reasons for not being able to check-in include: no RSVP, no staff override (in case of no RSVP), or check-ins are not allowed at this time.", "Attendee is not allowed to check-in."))
 	}
 
+	rsvp_data, err := service.GetRsvpData(user_checkin.ID)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Could not retrieve rsvp data."))
+	}
+
+	user_checkin.RsvpData = rsvp_data
+
 	err = service.CreateUserCheckin(user_checkin.ID, user_checkin)
 
 	if err != nil {
@@ -99,7 +107,15 @@ func UpdateUserCheckin(w http.ResponseWriter, r *http.Request) {
 	var user_checkin models.UserCheckin
 	json.NewDecoder(r.Body).Decode(&user_checkin)
 
-	err := service.UpdateUserCheckin(user_checkin.ID, user_checkin)
+	rsvp_data, err := service.GetRsvpData(user_checkin.ID)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Could not retrieve rsvp data."))
+	}
+
+	user_checkin.RsvpData = rsvp_data
+
+	err = service.UpdateUserCheckin(user_checkin.ID, user_checkin)
 
 	if err != nil {
 		panic(errors.DatabaseError(err.Error(), "Could not update user check-in information."))

--- a/services/checkin/models/user_checkin.go
+++ b/services/checkin/models/user_checkin.go
@@ -1,8 +1,9 @@
 package models
 
 type UserCheckin struct {
-	ID              string `json:"id"`
-	Override        bool   `json:"override"`
-	HasCheckedIn    bool   `json:"hasCheckedIn"`
-	HasPickedUpSwag bool   `json:"hasPickedUpSwag"`
+	ID              string                 `json:"id"`
+	Override        bool                   `json:"override"`
+	HasCheckedIn    bool                   `json:"hasCheckedIn"`
+	HasPickedUpSwag bool                   `json:"hasPickedUpSwag"`
+	RsvpData        map[string]interface{} `json:"rsvpData"`
 }

--- a/services/checkin/service/rsvp_service.go
+++ b/services/checkin/service/rsvp_service.go
@@ -25,3 +25,21 @@ func IsAttendeeRsvped(id string) (bool, error) {
 
 	return rsvp.IsAttending, nil
 }
+
+/*
+	Retrieve rsvp data from rsvp service
+*/
+func GetRsvpData(id string) (map[string]interface{}, error) {
+	rsvp_data := make(map[string]interface{})
+	status, err := apirequest.Get(config.RSVP_SERVICE+"/rsvp/"+id+"/", &rsvp_data)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, errors.New("Unable to retrieve data from rsvp service.")
+	}
+
+	return rsvp_data, nil
+}

--- a/services/checkin/tests/checkin_test.go
+++ b/services/checkin/tests/checkin_test.go
@@ -49,6 +49,7 @@ func SetupTestDB(t *testing.T) {
 		ID:              "testid",
 		HasCheckedIn:    true,
 		HasPickedUpSwag: true,
+		RsvpData:        map[string]interface{}{},
 	}
 
 	err := db.Insert("checkins", &checkin)
@@ -85,10 +86,11 @@ func TestGetUserCheckinService(t *testing.T) {
 		ID:              "testid",
 		HasCheckedIn:    true,
 		HasPickedUpSwag: true,
+		RsvpData:        map[string]interface{}{},
 	}
 
 	if !reflect.DeepEqual(checkin, &expected_checkin) {
-		t.Errorf("Wrong user info. Expected %v, got %v", expected_checkin, checkin)
+		t.Errorf("Wrong user info. Expected %v, got %v", &expected_checkin, checkin)
 	}
 
 	CleanupTestDB(t)
@@ -104,6 +106,7 @@ func TestCreateUserCheckinService(t *testing.T) {
 		ID:              "testid2",
 		HasCheckedIn:    true,
 		HasPickedUpSwag: false,
+		RsvpData:        map[string]interface{}{},
 	}
 
 	err := service.CreateUserCheckin("testid2", new_checkin)
@@ -122,10 +125,11 @@ func TestCreateUserCheckinService(t *testing.T) {
 		ID:              "testid2",
 		HasCheckedIn:    true,
 		HasPickedUpSwag: false,
+		RsvpData:        map[string]interface{}{},
 	}
 
 	if !reflect.DeepEqual(checkin, &expected_checkin) {
-		t.Errorf("Wrong user info. Expected %v, got %v", expected_checkin, checkin)
+		t.Errorf("Wrong user info. Expected %v, got %v", &expected_checkin, checkin)
 	}
 
 	CleanupTestDB(t)
@@ -141,6 +145,7 @@ func TestUpdateUserCheckinService(t *testing.T) {
 		ID:              "testid",
 		HasCheckedIn:    true,
 		HasPickedUpSwag: false,
+		RsvpData:        map[string]interface{}{},
 	}
 
 	err := service.UpdateUserCheckin("testid", checkin)
@@ -159,10 +164,11 @@ func TestUpdateUserCheckinService(t *testing.T) {
 		ID:              "testid",
 		HasCheckedIn:    true,
 		HasPickedUpSwag: false,
+		RsvpData:        map[string]interface{}{},
 	}
 
 	if !reflect.DeepEqual(updated_checkin, &expected_checkin) {
-		t.Errorf("Wrong user info. Expected %v, got %v", expected_checkin, updated_checkin)
+		t.Errorf("Wrong user info. Expected %v, got %v", &expected_checkin, updated_checkin)
 	}
 
 	CleanupTestDB(t)
@@ -178,6 +184,7 @@ func TestGetAllCheckedInUsersService(t *testing.T) {
 		ID:              "testid2",
 		HasCheckedIn:    false,
 		HasPickedUpSwag: false,
+		RsvpData:        map[string]interface{}{},
 	}
 
 	err := service.CreateUserCheckin("testid2", new_checkin)
@@ -190,6 +197,7 @@ func TestGetAllCheckedInUsersService(t *testing.T) {
 		ID:              "testid3",
 		HasCheckedIn:    true,
 		HasPickedUpSwag: false,
+		RsvpData:        map[string]interface{}{},
 	}
 
 	err = service.CreateUserCheckin("testid3", new_checkin)

--- a/services/rsvp/config/config.go
+++ b/services/rsvp/config/config.go
@@ -12,6 +12,7 @@ var RSVP_DB_NAME string
 var RSVP_PORT string
 
 var AUTH_SERVICE string
+var REGISTRATION_SERVICE string
 var DECISION_SERVICE string
 var MAIL_SERVICE string
 
@@ -45,6 +46,12 @@ func Initialize() error {
 	}
 
 	AUTH_SERVICE, err = cfg_loader.Get("AUTH_SERVICE")
+
+	if err != nil {
+		return err
+	}
+
+	REGISTRATION_SERVICE, err = cfg_loader.Get("REGISTRATION_SERVICE")
 
 	if err != nil {
 		return err

--- a/services/rsvp/controller/controller.go
+++ b/services/rsvp/controller/controller.go
@@ -87,6 +87,14 @@ func CreateCurrentUserRsvp(w http.ResponseWriter, r *http.Request) {
 
 	rsvp.Data["id"] = id
 
+	registration_data, err := service.GetRegistrationData(id)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Could not retrieve registration data."))
+	}
+
+	rsvp.Data["registrationData"] = registration_data
+
 	err = service.CreateUserRsvp(id, rsvp)
 
 	if err != nil {
@@ -162,6 +170,14 @@ func UpdateCurrentUserRsvp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rsvp.Data["id"] = id
+
+	registration_data, err := service.GetRegistrationData(id)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Could not retrieve registration data."))
+	}
+
+	rsvp.Data["registrationData"] = registration_data
 
 	err = service.UpdateUserRsvp(id, rsvp)
 

--- a/services/rsvp/service/registration_service.go
+++ b/services/rsvp/service/registration_service.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"github.com/HackIllinois/api/common/apirequest"
+	"github.com/HackIllinois/api/services/rsvp/config"
+	"net/http"
+	"errors"
+)
+
+func GetRegistrationData(id string) (map[string]interface{}, error) {
+	registration_data := make(map[string]interface{})
+	status, err := apirequest.Get(config.REGISTRATION_SERVICE+"/registration/"+id+"/", &registration_data)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, errors.New("Unable to retrieve data from registration service.")
+	}
+
+	return registration_data, nil
+}

--- a/services/rsvp/service/registration_service.go
+++ b/services/rsvp/service/registration_service.go
@@ -1,10 +1,10 @@
 package service
 
 import (
+	"errors"
 	"github.com/HackIllinois/api/common/apirequest"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"net/http"
-	"errors"
 )
 
 func GetRegistrationData(id string) (map[string]interface{}, error) {

--- a/services/rsvp/service/registration_service.go
+++ b/services/rsvp/service/registration_service.go
@@ -7,6 +7,9 @@ import (
 	"net/http"
 )
 
+/*
+	Retrieve registration data from registration service
+*/
 func GetRegistrationData(id string) (map[string]interface{}, error) {
 	registration_data := make(map[string]interface{})
 	status, err := apirequest.Get(config.REGISTRATION_SERVICE+"/registration/"+id+"/", &registration_data)


### PR DESCRIPTION
Addresses #168 

This PR puts a copy of the user's registration data into the rsvp struct and a copy of the rsvp data into the checkin struct when an rsvp / checkin is created or updated. This PR also adds supported for nested stats (so you can now specify `registrationData.attendee.school` for example in the rsvp stats config). The addition of nested stats and copying through data allows services to generate much more useful stats through the existing interface the API exposes. System administrators will no longer need to manually try to relate data from different micro services via scripts to generate these stats.

- [x] Add registrationData field to RSVP struct
- [x] Add rsvpData field to Checkin struct
- [x] Add support for nested stats
- [x] Add example of nested stats usage