### PR TITLE
Blobstore

### DIFF
--- a/documentation/docs/reference/services/Upload.md
+++ b/documentation/docs/reference/services/Upload.md
@@ -39,3 +39,73 @@ Response format:
 	"resume": "https://bucket.s3.amazonaws.com/resume.pdf"
 }
 ```
+
+GET /upload/blobstore/ID/
+-------------------------
+
+Returns the blob stored with the `id` `ID`.
+
+Response format:
+```
+{
+	"id": "exampleblob",
+	"data": {
+		"thing1": "hi",
+		"thing2": "hello"
+	}
+}
+```
+
+POST /upload/blobstore/
+-----------------------
+
+Creates and stores a blob with the specified `id` and `data`. `data` can be a single json field or an json object.
+
+Request format:
+```
+{
+	"id": "exampleblob",
+	"data": {
+		"thing1": "hi",
+		"thing2": "hello"
+	}
+}
+```
+
+Response format:
+```
+{
+	"id": "exampleblob",
+	"data": {
+		"thing1": "hi",
+		"thing2": "hello"
+	}
+}
+```
+
+PUT /upload/blobstore/
+----------------------
+
+Updates the blob with the specified `id`. `data` can be a single json field or an json object.
+
+Request format:
+```
+{
+	"id": "exampleblob",
+	"data": {
+		"thing1": "hi",
+		"thing2": "hello"
+	}
+}
+```
+
+Response format:
+```
+{
+	"id": "exampleblob",
+	"data": {
+		"thing1": "hi",
+		"thing2": "hello"
+	}
+}
+```

--- a/gateway/services/upload.go
+++ b/gateway/services/upload.go
@@ -31,6 +31,24 @@ var UploadRoutes = arbor.RouteCollection{
 		"/upload/resume/{id}/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(GetUploadInfo).ServeHTTP,
 	},
+	arbor.Route{
+		"CreateBlob",
+		"POST",
+		"/upload/blobstore/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(CreateBlob).ServeHTTP,
+	},
+	arbor.Route{
+		"UpdateBlob",
+		"PUT",
+		"/upload/blobstore/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateBlob).ServeHTTP,
+	},
+	arbor.Route{
+		"GetBlob",
+		"GET",
+		"/upload/blobstore/{id}/",
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetBlob).ServeHTTP,
+	},
 }
 
 func GetCurrentUploadInfo(w http.ResponseWriter, r *http.Request) {
@@ -42,5 +60,17 @@ func UpdateCurrentUploadInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetUploadInfo(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.UPLOAD_SERVICE+r.URL.String(), InfoFormat, "", r)
+}
+
+func CreateBlob(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, config.UPLOAD_SERVICE+r.URL.String(), InfoFormat, "", r)
+}
+
+func UpdateBlob(w http.ResponseWriter, r *http.Request) {
+	arbor.PUT(w, config.UPLOAD_SERVICE+r.URL.String(), InfoFormat, "", r)
+}
+
+func GetBlob(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, config.UPLOAD_SERVICE+r.URL.String(), InfoFormat, "", r)
 }

--- a/services/upload/controller/controller.go
+++ b/services/upload/controller/controller.go
@@ -19,7 +19,7 @@ func SetupController(route *mux.Route) {
 
 	router.Handle("/blobstore/", alice.New().ThenFunc(CreateBlob)).Methods("POST")
 	router.Handle("/blobstore/", alice.New().ThenFunc(UpdateBlob)).Methods("PUT")
-	router.Handle("/blobstore/{id}", alice.New().ThenFunc(GetBlob)).Methods("GET")
+	router.Handle("/blobstore/{id}/", alice.New().ThenFunc(GetBlob)).Methods("GET")
 }
 
 /*

--- a/services/upload/controller/controller.go
+++ b/services/upload/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"github.com/HackIllinois/api/common/errors"
+	"github.com/HackIllinois/api/services/upload/models"
 	"github.com/HackIllinois/api/services/upload/service"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
@@ -15,6 +16,10 @@ func SetupController(route *mux.Route) {
 	router.Handle("/resume/upload/", alice.New().ThenFunc(GetUpdateUserResume)).Methods("GET")
 	router.Handle("/resume/", alice.New().ThenFunc(GetCurrentUserResume)).Methods("GET")
 	router.Handle("/resume/{id}/", alice.New().ThenFunc(GetUserResume)).Methods("GET")
+
+	router.Handle("/blobstore/", alice.New().ThenFunc(CreateBlob)).Methods("POST")
+	router.Handle("/blobstore/", alice.New().ThenFunc(UpdateBlob)).Methods("PUT")
+	router.Handle("/blobstore/{id}", alice.New().ThenFunc(GetBlob)).Methods("GET")
 }
 
 /*
@@ -60,4 +65,71 @@ func GetUpdateUserResume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(resume)
+}
+
+/*
+	Endpoint to get a blob
+*/
+func GetBlob(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+
+	blob, err := service.GetBlob(id)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Unable to retrieve blob."))
+	}
+
+	json.NewEncoder(w).Encode(blob)
+}
+
+/*
+	Endpoint to create and store a blob
+*/
+func CreateBlob(w http.ResponseWriter, r *http.Request) {
+	var blob models.Blob
+	json.NewDecoder(r.Body).Decode(&blob)
+
+	if blob.ID == "" {
+		panic(errors.InternalError("Must set an id for the blob.", "Must set an id for the blob."))
+	}
+
+	err := service.CreateBlob(blob)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Unable to create blob."))
+	}
+
+	stored_blob, err := service.GetBlob(blob.ID)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Unable to retrieve blob."))
+	}
+
+	json.NewEncoder(w).Encode(stored_blob)
+}
+
+/*
+	Endpoint to update a blob
+*/
+func UpdateBlob(w http.ResponseWriter, r *http.Request) {
+	var blob models.Blob
+	json.NewDecoder(r.Body).Decode(&blob)
+
+	if blob.ID == "" {
+		panic(errors.InternalError("Must set an id for the blob.", "Must set an id for the blob."))
+	}
+
+	err := service.UpdateBlob(blob)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Unable to update blob."))
+	}
+
+	stored_blob, err := service.GetBlob(blob.ID)
+
+	if err != nil {
+		panic(errors.InternalError(err.Error(), "Unable to retrieve blob."))
+	}
+
+	json.NewEncoder(w).Encode(stored_blob)
 }

--- a/services/upload/models/blob.go
+++ b/services/upload/models/blob.go
@@ -1,6 +1,6 @@
 package models
 
 type Blob struct {
-	ID   string                 `json:"id"`
-	Data map[string]interface{} `json:"data"`
+	ID   string      `json:"id"`
+	Data interface{} `json:"data"`
 }

--- a/services/upload/models/blob.go
+++ b/services/upload/models/blob.go
@@ -1,0 +1,6 @@
+package models
+
+type Blob struct {
+	ID   string                 `json:"id"`
+	Data map[string]interface{} `json:"data"`
+}

--- a/services/upload/tests/upload_test.go
+++ b/services/upload/tests/upload_test.go
@@ -1,11 +1,161 @@
 package tests
 
 import (
+	"fmt"
+	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/services/upload/config"
+	"github.com/HackIllinois/api/services/upload/models"
+	"github.com/HackIllinois/api/services/upload/service"
+	"os"
+	"reflect"
 	"testing"
 )
 
+var db database.Database
+
+func TestMain(m *testing.M) {
+	err := config.Initialize()
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+
+	}
+
+	err = service.Initialize()
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	db, err = database.InitDatabase(config.UPLOAD_DB_HOST, config.UPLOAD_DB_NAME)
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	return_code := m.Run()
+
+	os.Exit(return_code)
+}
+
 /*
-	Placeholder test for travis build
+	Initialize database with test upload info
 */
-func TestPlaceholder(t *testing.T) {
+func SetupTestDB(t *testing.T) {
+	err := db.Insert("blobstore", &models.Blob{
+		ID:   "testid",
+		Data: "testdata",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+	Drop test db
+*/
+func CleanupTestDB(t *testing.T) {
+	err := db.DropDatabase()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+	Service level test for getting a blob from db
+*/
+func TestGetBlobService(t *testing.T) {
+	SetupTestDB(t)
+
+	blob, err := service.GetBlob("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_blob := &models.Blob{
+		ID:   "testid",
+		Data: "testdata",
+	}
+
+	if !reflect.DeepEqual(blob, expected_blob) {
+		t.Errorf("Wrong blob. Expected %v, got %v", expected_blob, blob)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for creating a blob
+*/
+func TestCreateBlobService(t *testing.T) {
+	SetupTestDB(t)
+
+	new_blob := models.Blob{
+		ID:   "testid2",
+		Data: "testdata2",
+	}
+
+	err := service.CreateBlob(new_blob)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retrieved_blob, err := service.GetBlob("testid2")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_blob := &models.Blob{
+		ID:   "testid2",
+		Data: "testdata2",
+	}
+
+	if !reflect.DeepEqual(retrieved_blob, expected_blob) {
+		t.Errorf("Wrong blob. Expected %v, got %v", expected_blob, retrieved_blob)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for updating a blob
+*/
+func TestUpdateBlobService(t *testing.T) {
+	SetupTestDB(t)
+
+	updated_blob := models.Blob{
+		ID:   "testid",
+		Data: "testdata2",
+	}
+
+	err := service.UpdateBlob(updated_blob)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retrieved_blob, err := service.GetBlob("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_blob := &models.Blob{
+		ID:   "testid",
+		Data: "testdata2",
+	}
+
+	if !reflect.DeepEqual(retrieved_blob, expected_blob) {
+		t.Errorf("Wrong blob. Expected %v, got %v", expected_blob, retrieved_blob)
+	}
+
+	CleanupTestDB(t)
 }


### PR DESCRIPTION
Addresses #181 

This PR adds a blobstore to the uploads service allowing `Admin` and `Staff` users to store arbitrary data which can be retrieved without authentication by other users. The most common use case for this is constants which are needed by multiple frontends.

The following routes have been added:
```
GET  /upload/blobstore/{id}/
POST /upload/blobstore/
PUT  /upload/blobstore/
```


- [x] Add blobstore to upload service
- [x] Expose routes via gateway
- [x] Update docs
- [x] Write tests