### PR TITLE
Publish notifications asynchronously

### DIFF
--- a/documentation/docs/reference/services/Notifications.md
+++ b/documentation/docs/reference/services/Notifications.md
@@ -105,7 +105,7 @@ Response format:
 POST /notifications/topic/TOPICID/
 ----------------------------------
 
-Publishes a notification to the topic with the ID `TOPICID`.
+Publishes a notification to the topic with the ID `TOPICID`. The `id` in the response is the ID for the notification order which is sending the actual notifications asynchronously.
 
 Request format:
 ```
@@ -118,8 +118,10 @@ Request format:
 Response format:
 ```
 {
-	"success": 5,
-	"failure": 0
+	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"success": 0,
+	"failure": 0,
+	"time": 1553564589
 }
 ```
 
@@ -186,8 +188,23 @@ Request format:
 Response format:
 ```
 {
-    "devices": [
-        "arn:example139091820398"
-    ]
+	"devices": [
+		"arn:example139091820398"
+	]
+}
+```
+
+GET /notifications/order/ID/
+----------------------------
+
+Returns the notification order with the `id` ID. This endpoint should be used to determine the status of an asynchronously published notification.
+
+Response format:
+```
+{
+	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"success": 5,
+	"failure": 0,
+	"time": 1553564589
 }
 ```

--- a/gateway/services/notifications.go
+++ b/gateway/services/notifications.go
@@ -73,6 +73,12 @@ var NotificationsRoutes = arbor.RouteCollection{
 		"/notifications/device/",
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.UserRole})).ThenFunc(RegisterDeviceToUser).ServeHTTP,
 	},
+	arbor.Route{
+		"GetNotificationOrder",
+		"GET",
+		"/notifications/order/{id}/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole})).ThenFunc(GetNotificationOrder).ServeHTTP,
+	},
 }
 
 func GetAllTopics(w http.ResponseWriter, r *http.Request) {
@@ -113,4 +119,8 @@ func UnsubscribeToTopic(w http.ResponseWriter, r *http.Request) {
 
 func RegisterDeviceToUser(w http.ResponseWriter, r *http.Request) {
 	arbor.POST(w, config.NOTIFICATIONS_SERVICE+r.URL.String(), NotificationsFormat, "", r)
+}
+
+func GetNotificationOrder(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.NOTIFICATIONS_SERVICE+r.URL.String(), NotificationsFormat, "", r)
 }

--- a/services/notifications/controller/controller.go
+++ b/services/notifications/controller/controller.go
@@ -25,6 +25,7 @@ func SetupController(route *mux.Route) {
 	router.Handle("/topic/{id}/subscribe/", alice.New().ThenFunc(SubscribeToTopic)).Methods("POST")
 	router.Handle("/topic/{id}/unsubscribe/", alice.New().ThenFunc(UnsubscribeToTopic)).Methods("POST")
 	router.Handle("/device/", alice.New().ThenFunc(RegisterDeviceToUser)).Methods("POST")
+	router.Handle("/order/{id}/", alice.New().ThenFunc(GetNotificationOrder)).Methods("GET")
 }
 
 /*
@@ -242,4 +243,19 @@ func RegisterDeviceToUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(device_list)
+}
+
+/*
+	Returns the notification order with the specified id
+*/
+func GetNotificationOrder(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+
+	order, err := service.GetNotificationOrder(id)
+
+	if err != nil {
+		panic(errors.DatabaseError(err.Error(), "Could not retrieve notification order."))
+	}
+
+	json.NewEncoder(w).Encode(order)
 }

--- a/services/notifications/controller/controller.go
+++ b/services/notifications/controller/controller.go
@@ -3,11 +3,13 @@ package controller
 import (
 	"encoding/json"
 	"github.com/HackIllinois/api/common/errors"
+	"github.com/HackIllinois/api/common/utils"
 	"github.com/HackIllinois/api/services/notifications/models"
 	"github.com/HackIllinois/api/services/notifications/service"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
 	"net/http"
+	"time"
 )
 
 func SetupController(route *mux.Route) {
@@ -143,14 +145,16 @@ func PublishNotificationToTopic(w http.ResponseWriter, r *http.Request) {
 	json.NewDecoder(r.Body).Decode(&notification)
 
 	notification.Topic = id
+	notification.ID = utils.GenerateUniqueID()
+	notification.Time = time.Now().Unix()
 
-	result, err := service.PublishNotificationToTopic(notification)
+	order, err := service.PublishNotificationToTopic(notification)
 
 	if err != nil {
 		panic(errors.InternalError(err.Error(), "Could not publish notification."))
 	}
 
-	json.NewEncoder(w).Encode(result)
+	json.NewEncoder(w).Encode(order)
 }
 
 /*

--- a/services/notifications/models/notification_order.go
+++ b/services/notifications/models/notification_order.go
@@ -1,0 +1,8 @@
+package models
+
+type NotificationOrder struct {
+	ID      string `json:"id"`
+	Success int    `json:"success"`
+	Failure int    `json:"failure"`
+	Time    int64  `json:"time"`
+}

--- a/services/notifications/models/publish_result.go
+++ b/services/notifications/models/publish_result.go
@@ -1,6 +1,0 @@
-package models
-
-type PublishResult struct {
-	Success int `json:"success"`
-	Failure int `json:"failure"`
-}

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -13,7 +13,7 @@ import (
 )
 
 var SNS_MESSAGE_STRUCTURE string = "json"
-var WORKER_POOL_SIZE int = 500
+var WORKER_POOL_SIZE int = 128
 
 var sess *session.Session
 var client *sns.SNS

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -405,7 +405,7 @@ func GetNotificationOrder(id string) (*models.NotificationOrder, error) {
 	}
 
 	var order models.NotificationOrder
-	err := db.FindOne("topics", selector, &order)
+	err := db.FindOne("orders", selector, &order)
 
 	if err != nil {
 		return nil, err

--- a/services/notifications/tests/notifications_test.go
+++ b/services/notifications/tests/notifications_test.go
@@ -437,19 +437,21 @@ func TestPublishNotificationToTopic(t *testing.T) {
 		Time:  3000,
 	}
 
-	result, err := service.PublishNotificationToTopic(notification)
+	order, err := service.PublishNotificationToTopic(notification)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expected_result := models.PublishResult{
+	expected_order := models.NotificationOrder{
+		ID:      "test_id2",
 		Success: 0,
 		Failure: 0,
+		Time:    3000,
 	}
 
-	if !reflect.DeepEqual(result, &expected_result) {
-		t.Errorf("Wrong topics.\nExpected %v\ngot %v\n", &expected_result, result)
+	if !reflect.DeepEqual(order, &expected_order) {
+		t.Errorf("Wrong topics.\nExpected %v\ngot %v\n", &expected_order, order)
 	}
 
 	CleanupTestDB(t)


### PR DESCRIPTION
Addresses #207 

This PR makes publishing notifications asynchronous. The publish endpoint returns an `id` of a `NotificationOrder`. This `id` can be sent to the `GET /notifications/order/{id}/` endpoint to get an update on the number of successful and failures for publishing the notification.

- [x] Return ID of NotificationOrder when publishing a notification
- [x] Provide Endpoint to retrieve status of NotificationOrder using the provided ID