### PR TITLE
Remove Alice deps from services

### DIFF
--- a/common/apiserver/apiserver.go
+++ b/common/apiserver/apiserver.go
@@ -6,7 +6,6 @@ import (
 	"github.com/HackIllinois/api/common/config"
 	"github.com/HackIllinois/api/common/middleware"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"github.com/thoas/stats"
 	"net/http"
 	"time"
@@ -25,8 +24,8 @@ func StartServer(address string, router *mux.Router, name string, initialize fun
 	stats_middleware := stats.New()
 	router.Use(stats_middleware.Handler)
 
-	router.Handle(fmt.Sprintf("/%s/internal/healthstats/", name), alice.New().ThenFunc(GetHealthStats(stats_middleware))).Methods("GET")
-	router.Handle(fmt.Sprintf("/%s/internal/reload/", name), alice.New().ThenFunc(Reload(initialize))).Methods("GET")
+	router.HandleFunc(fmt.Sprintf("/%s/internal/healthstats/", name), GetHealthStats(stats_middleware)).Methods("GET")
+	router.HandleFunc(fmt.Sprintf("/%s/internal/reload/", name), Reload(initialize)).Methods("GET")
 
 	server := &http.Server{
 		Handler:      router,

--- a/services/auth/controller/controller.go
+++ b/services/auth/controller/controller.go
@@ -9,21 +9,20 @@ import (
 	"github.com/HackIllinois/api/services/auth/models"
 	"github.com/HackIllinois/api/services/auth/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/roles/", alice.New().ThenFunc(GetCurrentUserRoles)).Methods("GET")
-	router.Handle("/roles/list/", alice.New().ThenFunc(GetRolesLists)).Methods("GET")
-	router.Handle("/roles/list/{role}/", alice.New().ThenFunc(GetUserListByRole)).Methods("GET")
-	router.Handle("/{provider}/", alice.New().ThenFunc(Authorize)).Methods("GET")
-	router.Handle("/code/{provider}/", alice.New().ThenFunc(Login)).Methods("POST")
-	router.Handle("/roles/{id}/", alice.New().ThenFunc(GetRoles)).Methods("GET")
-	router.Handle("/roles/add/", alice.New().ThenFunc(AddRole)).Methods("PUT")
-	router.Handle("/roles/remove/", alice.New().ThenFunc(RemoveRole)).Methods("PUT")
-	router.Handle("/token/refresh/", alice.New().ThenFunc(RefreshToken)).Methods("GET")
+	router.HandleFunc("/roles/", GetCurrentUserRoles).Methods("GET")
+	router.HandleFunc("/roles/list/", GetRolesLists).Methods("GET")
+	router.HandleFunc("/roles/list/{role}/", GetUserListByRole).Methods("GET")
+	router.HandleFunc("/{provider}/", Authorize).Methods("GET")
+	router.HandleFunc("/code/{provider}/", Login).Methods("POST")
+	router.HandleFunc("/roles/{id}/", GetRoles).Methods("GET")
+	router.HandleFunc("/roles/add/", AddRole).Methods("PUT")
+	router.HandleFunc("/roles/remove/", RemoveRole).Methods("PUT")
+	router.HandleFunc("/token/refresh/", RefreshToken).Methods("GET")
 }
 
 /*

--- a/services/checkin/controller/controller.go
+++ b/services/checkin/controller/controller.go
@@ -6,20 +6,19 @@ import (
 	"github.com/HackIllinois/api/services/checkin/models"
 	"github.com/HackIllinois/api/services/checkin/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/", alice.New().ThenFunc(CreateUserCheckin)).Methods("POST")
-	router.Handle("/", alice.New().ThenFunc(UpdateUserCheckin)).Methods("PUT")
-	router.Handle("/", alice.New().ThenFunc(GetCurrentUserCheckin)).Methods("GET")
-	router.Handle("/list/", alice.New().ThenFunc(GetAllCheckedInUsers)).Methods("GET")
-	router.Handle("/{id}/", alice.New().ThenFunc(GetUserCheckin)).Methods("GET")
+	router.HandleFunc("/", CreateUserCheckin).Methods("POST")
+	router.HandleFunc("/", UpdateUserCheckin).Methods("PUT")
+	router.HandleFunc("/", GetCurrentUserCheckin).Methods("GET")
+	router.HandleFunc("/list/", GetAllCheckedInUsers).Methods("GET")
+	router.HandleFunc("/{id}/", GetUserCheckin).Methods("GET")
 
-	router.Handle("/internal/stats/", alice.New().ThenFunc(GetStats)).Methods("GET")
+	router.HandleFunc("/internal/stats/", GetStats).Methods("GET")
 }
 
 /*

--- a/services/decision/controller/controller.go
+++ b/services/decision/controller/controller.go
@@ -11,19 +11,18 @@ import (
 	"github.com/HackIllinois/api/services/decision/models"
 	"github.com/HackIllinois/api/services/decision/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/", alice.New().ThenFunc(GetCurrentDecision)).Methods("GET")
-	router.Handle("/", alice.New().ThenFunc(UpdateDecision)).Methods("POST")
-	router.Handle("/finalize/", alice.New().ThenFunc(FinalizeDecision)).Methods("POST")
-	router.Handle("/filter/", alice.New().ThenFunc(GetFilteredDecisions)).Methods("GET")
-	router.Handle("/{id}/", alice.New().ThenFunc(GetDecision)).Methods("GET")
+	router.HandleFunc("/", GetCurrentDecision).Methods("GET")
+	router.HandleFunc("/", UpdateDecision).Methods("POST")
+	router.HandleFunc("/finalize/", FinalizeDecision).Methods("POST")
+	router.HandleFunc("/filter/", GetFilteredDecisions).Methods("GET")
+	router.HandleFunc("/{id}/", GetDecision).Methods("GET")
 
-	router.Handle("/internal/stats/", alice.New().ThenFunc(GetStats)).Methods("GET")
+	router.HandleFunc("/internal/stats/", GetStats).Methods("GET")
 }
 
 /*

--- a/services/event/controller/controller.go
+++ b/services/event/controller/controller.go
@@ -9,27 +9,26 @@ import (
 	"github.com/HackIllinois/api/services/event/models"
 	"github.com/HackIllinois/api/services/event/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/favorite/", alice.New().ThenFunc(GetEventFavorites)).Methods("GET")
-	router.Handle("/favorite/add/", alice.New().ThenFunc(AddEventFavorite)).Methods("POST")
-	router.Handle("/favorite/remove/", alice.New().ThenFunc(RemoveEventFavorite)).Methods("POST")
+	router.HandleFunc("/favorite/", GetEventFavorites).Methods("GET")
+	router.HandleFunc("/favorite/add/", AddEventFavorite).Methods("POST")
+	router.HandleFunc("/favorite/remove/", RemoveEventFavorite).Methods("POST")
 
-	router.Handle("/{id}/", alice.New().ThenFunc(GetEvent)).Methods("GET")
-	router.Handle("/{id}/", alice.New().ThenFunc(DeleteEvent)).Methods("DELETE")
-	router.Handle("/", alice.New().ThenFunc(CreateEvent)).Methods("POST")
-	router.Handle("/", alice.New().ThenFunc(UpdateEvent)).Methods("PUT")
-	router.Handle("/", alice.New().ThenFunc(GetAllEvents)).Methods("GET")
+	router.HandleFunc("/{id}/", GetEvent).Methods("GET")
+	router.HandleFunc("/{id}/", DeleteEvent).Methods("DELETE")
+	router.HandleFunc("/", CreateEvent).Methods("POST")
+	router.HandleFunc("/", UpdateEvent).Methods("PUT")
+	router.HandleFunc("/", GetAllEvents).Methods("GET")
 
-	router.Handle("/track/", alice.New().ThenFunc(MarkUserAsAttendingEvent)).Methods("POST")
-	router.Handle("/track/event/{id}/", alice.New().ThenFunc(GetEventTrackingInfo)).Methods("GET")
-	router.Handle("/track/user/{id}/", alice.New().ThenFunc(GetUserTrackingInfo)).Methods("GET")
+	router.HandleFunc("/track/", MarkUserAsAttendingEvent).Methods("POST")
+	router.HandleFunc("/track/event/{id}/", GetEventTrackingInfo).Methods("GET")
+	router.HandleFunc("/track/user/{id}/", GetUserTrackingInfo).Methods("GET")
 
-	router.Handle("/internal/stats/", alice.New().ThenFunc(GetStats)).Methods("GET")
+	router.HandleFunc("/internal/stats/", GetStats).Methods("GET")
 }
 
 /*

--- a/services/mail/controller/controller.go
+++ b/services/mail/controller/controller.go
@@ -6,20 +6,19 @@ import (
 	"github.com/HackIllinois/api/services/mail/models"
 	"github.com/HackIllinois/api/services/mail/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/send/", alice.New().ThenFunc(SendMail)).Methods("POST")
-	router.Handle("/send/list/", alice.New().ThenFunc(SendMailList)).Methods("POST")
-	router.Handle("/list/", alice.New().ThenFunc(GetAllMailLists)).Methods("GET")
-	router.Handle("/list/create/", alice.New().ThenFunc(CreateMailList)).Methods("POST")
-	router.Handle("/list/add/", alice.New().ThenFunc(AddToMailList)).Methods("POST")
-	router.Handle("/list/remove/", alice.New().ThenFunc(RemoveFromMailList)).Methods("POST")
-	router.Handle("/list/{id}/", alice.New().ThenFunc(GetMailList)).Methods("GET")
+	router.HandleFunc("/send/", SendMail).Methods("POST")
+	router.HandleFunc("/send/list/", SendMailList).Methods("POST")
+	router.HandleFunc("/list/", GetAllMailLists).Methods("GET")
+	router.HandleFunc("/list/create/", CreateMailList).Methods("POST")
+	router.HandleFunc("/list/add/", AddToMailList).Methods("POST")
+	router.HandleFunc("/list/remove/", RemoveFromMailList).Methods("POST")
+	router.HandleFunc("/list/{id}/", GetMailList).Methods("GET")
 }
 
 /*

--- a/services/notifications/controller/controller.go
+++ b/services/notifications/controller/controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/HackIllinois/api/services/notifications/models"
 	"github.com/HackIllinois/api/services/notifications/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
 	"time"
 )
@@ -15,17 +14,17 @@ import (
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/topic/", alice.New().ThenFunc(GetAllTopics)).Methods("GET")
-	router.Handle("/topic/", alice.New().ThenFunc(CreateTopic)).Methods("POST")
-	router.Handle("/topic/all/", alice.New().ThenFunc(GetAllNotifications)).Methods("GET")
-	router.Handle("/topic/public/", alice.New().ThenFunc(GetAllPublicNotifications)).Methods("GET")
-	router.Handle("/topic/{id}/", alice.New().ThenFunc(GetNotificationsForTopic)).Methods("GET")
-	router.Handle("/topic/{id}/", alice.New().ThenFunc(PublishNotificationToTopic)).Methods("POST")
-	router.Handle("/topic/{id}/", alice.New().ThenFunc(DeleteTopic)).Methods("DELETE")
-	router.Handle("/topic/{id}/subscribe/", alice.New().ThenFunc(SubscribeToTopic)).Methods("POST")
-	router.Handle("/topic/{id}/unsubscribe/", alice.New().ThenFunc(UnsubscribeToTopic)).Methods("POST")
-	router.Handle("/device/", alice.New().ThenFunc(RegisterDeviceToUser)).Methods("POST")
-	router.Handle("/order/{id}/", alice.New().ThenFunc(GetNotificationOrder)).Methods("GET")
+	router.HandleFunc("/topic/", GetAllTopics).Methods("GET")
+	router.HandleFunc("/topic/", CreateTopic).Methods("POST")
+	router.HandleFunc("/topic/all/", GetAllNotifications).Methods("GET")
+	router.HandleFunc("/topic/public/", GetAllPublicNotifications).Methods("GET")
+	router.HandleFunc("/topic/{id}/", GetNotificationsForTopic).Methods("GET")
+	router.HandleFunc("/topic/{id}/", PublishNotificationToTopic).Methods("POST")
+	router.HandleFunc("/topic/{id}/", DeleteTopic).Methods("DELETE")
+	router.HandleFunc("/topic/{id}/subscribe/", SubscribeToTopic).Methods("POST")
+	router.HandleFunc("/topic/{id}/unsubscribe/", UnsubscribeToTopic).Methods("POST")
+	router.HandleFunc("/device/", RegisterDeviceToUser).Methods("POST")
+	router.HandleFunc("/order/{id}/", GetNotificationOrder).Methods("GET")
 }
 
 /*

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -8,7 +8,6 @@ import (
 	"github.com/HackIllinois/api/services/registration/models"
 	"github.com/HackIllinois/api/services/registration/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
 	"time"
 )
@@ -16,22 +15,22 @@ import (
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/", alice.New().ThenFunc(GetAllCurrentRegistrations)).Methods("GET")
+	router.HandleFunc("/", GetAllCurrentRegistrations).Methods("GET")
 
-	router.Handle("/attendee/", alice.New().ThenFunc(GetCurrentUserRegistration)).Methods("GET")
-	router.Handle("/attendee/", alice.New().ThenFunc(CreateCurrentUserRegistration)).Methods("POST")
-	router.Handle("/attendee/", alice.New().ThenFunc(UpdateCurrentUserRegistration)).Methods("PUT")
-	router.Handle("/filter/", alice.New().ThenFunc(GetFilteredUserRegistrations)).Methods("GET")
+	router.HandleFunc("/attendee/", GetCurrentUserRegistration).Methods("GET")
+	router.HandleFunc("/attendee/", CreateCurrentUserRegistration).Methods("POST")
+	router.HandleFunc("/attendee/", UpdateCurrentUserRegistration).Methods("PUT")
+	router.HandleFunc("/filter/", GetFilteredUserRegistrations).Methods("GET")
 
-	router.Handle("/mentor/", alice.New().ThenFunc(GetCurrentMentorRegistration)).Methods("GET")
-	router.Handle("/mentor/", alice.New().ThenFunc(CreateCurrentMentorRegistration)).Methods("POST")
-	router.Handle("/mentor/", alice.New().ThenFunc(UpdateCurrentMentorRegistration)).Methods("PUT")
+	router.HandleFunc("/mentor/", GetCurrentMentorRegistration).Methods("GET")
+	router.HandleFunc("/mentor/", CreateCurrentMentorRegistration).Methods("POST")
+	router.HandleFunc("/mentor/", UpdateCurrentMentorRegistration).Methods("PUT")
 
-	router.Handle("/{id}/", alice.New().ThenFunc(GetAllRegistrations)).Methods("GET")
-	router.Handle("/attendee/{id}/", alice.New().ThenFunc(GetUserRegistration)).Methods("GET")
-	router.Handle("/mentor/{id}", alice.New().ThenFunc(GetMentorRegistration)).Methods("GET")
+	router.HandleFunc("/{id}/", GetAllRegistrations).Methods("GET")
+	router.HandleFunc("/attendee/{id}/", GetUserRegistration).Methods("GET")
+	router.HandleFunc("/mentor/{id}", GetMentorRegistration).Methods("GET")
 
-	router.Handle("/internal/stats/", alice.New().ThenFunc(GetStats)).Methods("GET")
+	router.HandleFunc("/internal/stats/", GetStats).Methods("GET")
 }
 
 /*

--- a/services/rsvp/controller/controller.go
+++ b/services/rsvp/controller/controller.go
@@ -7,20 +7,19 @@ import (
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/filter/", alice.New().ThenFunc(GetFilteredRsvps)).Methods("GET")
-	router.Handle("/{id}/", alice.New().ThenFunc(GetUserRsvp)).Methods("GET")
-	router.Handle("/", alice.New().ThenFunc(GetCurrentUserRsvp)).Methods("GET")
-	router.Handle("/", alice.New().ThenFunc(CreateCurrentUserRsvp)).Methods("POST")
-	router.Handle("/", alice.New().ThenFunc(UpdateCurrentUserRsvp)).Methods("PUT")
+	router.HandleFunc("/filter/", GetFilteredRsvps).Methods("GET")
+	router.HandleFunc("/{id}/", GetUserRsvp).Methods("GET")
+	router.HandleFunc("/", GetCurrentUserRsvp).Methods("GET")
+	router.HandleFunc("/", CreateCurrentUserRsvp).Methods("POST")
+	router.HandleFunc("/", UpdateCurrentUserRsvp).Methods("PUT")
 
-	router.Handle("/internal/stats/", alice.New().ThenFunc(GetStats)).Methods("GET")
+	router.HandleFunc("/internal/stats/", GetStats).Methods("GET")
 }
 
 /*

--- a/services/stat/controller/controller.go
+++ b/services/stat/controller/controller.go
@@ -5,15 +5,14 @@ import (
 	"github.com/HackIllinois/api/common/errors"
 	"github.com/HackIllinois/api/services/stat/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/{name}/", alice.New().ThenFunc(GetStat)).Methods("GET")
-	router.Handle("/", alice.New().ThenFunc(GetAllStat)).Methods("GET")
+	router.HandleFunc("/{name}/", GetStat).Methods("GET")
+	router.HandleFunc("/", GetAllStat).Methods("GET")
 
 }
 

--- a/services/upload/controller/controller.go
+++ b/services/upload/controller/controller.go
@@ -6,20 +6,19 @@ import (
 	"github.com/HackIllinois/api/services/upload/models"
 	"github.com/HackIllinois/api/services/upload/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/resume/upload/", alice.New().ThenFunc(GetUpdateUserResume)).Methods("GET")
-	router.Handle("/resume/", alice.New().ThenFunc(GetCurrentUserResume)).Methods("GET")
-	router.Handle("/resume/{id}/", alice.New().ThenFunc(GetUserResume)).Methods("GET")
+	router.HandleFunc("/resume/upload/", GetUpdateUserResume).Methods("GET")
+	router.HandleFunc("/resume/", GetCurrentUserResume).Methods("GET")
+	router.HandleFunc("/resume/{id}/", GetUserResume).Methods("GET")
 
-	router.Handle("/blobstore/", alice.New().ThenFunc(CreateBlob)).Methods("POST")
-	router.Handle("/blobstore/", alice.New().ThenFunc(UpdateBlob)).Methods("PUT")
-	router.Handle("/blobstore/{id}/", alice.New().ThenFunc(GetBlob)).Methods("GET")
+	router.HandleFunc("/blobstore/", CreateBlob).Methods("POST")
+	router.HandleFunc("/blobstore/", UpdateBlob).Methods("PUT")
+	router.HandleFunc("/blobstore/{id}/", GetBlob).Methods("GET")
 }
 
 /*

--- a/services/user/controller/controller.go
+++ b/services/user/controller/controller.go
@@ -6,23 +6,22 @@ import (
 	"github.com/HackIllinois/api/services/user/models"
 	"github.com/HackIllinois/api/services/user/service"
 	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.Handle("/", alice.New().ThenFunc(GetCurrentUserInfo)).Methods("GET")
-	router.Handle("/", alice.New().ThenFunc(SetUserInfo)).Methods("POST")
-	router.Handle("/filter/", alice.New().ThenFunc(GetFilteredUserInfo)).Methods("GET")
+	router.HandleFunc("/", GetCurrentUserInfo).Methods("GET")
+	router.HandleFunc("/", SetUserInfo).Methods("POST")
+	router.HandleFunc("/filter/", GetFilteredUserInfo).Methods("GET")
 
-	router.Handle("/qr/", alice.New().ThenFunc(GetCurrentQrCodeInfo)).Methods("GET")
-	router.Handle("/qr/{id}/", alice.New().ThenFunc(GetQrCodeInfo)).Methods("GET")
+	router.HandleFunc("/qr/", GetCurrentQrCodeInfo).Methods("GET")
+	router.HandleFunc("/qr/{id}/", GetQrCodeInfo).Methods("GET")
 
-	router.Handle("/{id}/", alice.New().ThenFunc(GetUserInfo)).Methods("GET")
+	router.HandleFunc("/{id}/", GetUserInfo).Methods("GET")
 
-	router.Handle("/internal/stats/", alice.New().ThenFunc(GetStats)).Methods("GET")
+	router.HandleFunc("/internal/stats/", GetStats).Methods("GET")
 }
 
 /*


### PR DESCRIPTION
Resolves #212. Codemoded out Alice dependencies from service controller files.

Verified that API still boots and ensured that a services continue to work manually.