### PR TITLE
Update user info with applicant names from registration (#233)

### DIFF
--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -168,6 +168,25 @@ func CreateCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Update user's name (if needed) using registration info
+	is_user_nameless := user_info.FirstName == "" || user_info.LastName == ""
+
+	if is_user_nameless {
+		first_name, first_ok := user_registration.Data["firstName"].(string)
+		last_name, last_ok := user_registration.Data["lastName"].(string)
+
+		if first_ok && last_ok {
+			user_info.FirstName = first_name
+			user_info.LastName = last_name
+			err = service.SetUserInfo(user_info)
+
+			if err != nil {
+				errors.WriteError(w, r, errors.InternalError(err.Error(), "Could not set user's name."))
+				return
+			}
+		}
+	}
+
 	json.NewEncoder(w).Encode(updated_registration)
 }
 

--- a/services/registration/service/user_service.go
+++ b/services/registration/service/user_service.go
@@ -25,3 +25,20 @@ func GetUserInfo(id string) (*models.UserInfo, error) {
 
 	return &user_info, nil
 }
+
+/*
+	Update basic user info in user service
+*/
+func SetUserInfo(user_info *models.UserInfo) error {
+	status, err := apirequest.Post(config.USER_SERVICE+"/user/", user_info, nil)
+
+	if err != nil {
+		return err
+	}
+
+	if status != http.StatusOK {
+		return errors.New("User service failed to update information")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes #233 
Modified the POST /registration/attendee/ endpoint to update user info in the user service if the user's name is empty and the registration schema contains name fields.

1. How should I implement unit tests for this? registration_test.go only tests within the registration service, but here I am invoking the user service. 
2. Should I update documentation/.../Registration.md to reflect this?