### PR TITLE
Add registration filter endpoint (#244)

### DIFF
--- a/documentation/docs/reference/services/Registration.md
+++ b/documentation/docs/reference/services/Registration.md
@@ -519,7 +519,7 @@ Response format:
 }
 ```
 
-GET /registration/filter/?key=value
+GET /registration/attendee/filter/?key=value
 -----------------------------------
 
 Returns the user registrations, filtered with the given key-value pairs

--- a/documentation/docs/reference/services/Registration.md
+++ b/documentation/docs/reference/services/Registration.md
@@ -614,5 +614,36 @@ Response format:
 		}
 	]
 }
+```
+
+GET /registration/mentor/filter/?key=value
+-----------------------------------
+
+Returns the mentor registrations, filtered with the given key-value pairs
+
+Response format:
+```
+{
+	"registrations": [
+		{
+			"id": "github0000001"
+			"firstName": "John",
+			"lastName": "Smith",
+			"email": "john@gmail.com",
+			"shirtSize": "M",
+			"github": "JSmith",
+			"linkedin": "john-smith"
+		},
+		{
+			"id": "github0000002"
+			"firstName": "John",
+			"lastName": "Doe",
+			"email": "jdoe@gmail.com",
+			"shirtSize": "M",
+			"github": "JDoe",
+			"linkedin": "john-doe"
+		}
+	]
+}
 
 ```

--- a/gateway/services/registration.go
+++ b/gateway/services/registration.go
@@ -39,7 +39,7 @@ var RegistrationRoutes = arbor.RouteCollection{
 	arbor.Route{
 		"GetFilteredUserRegistrations",
 		"GET",
-		"/registration/filter/",
+		"/registration/attendee/filter/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(GetRegistration).ServeHTTP,
 	},
 	arbor.Route{

--- a/gateway/services/registration.go
+++ b/gateway/services/registration.go
@@ -61,6 +61,12 @@ var RegistrationRoutes = arbor.RouteCollection{
 		alice.New(middleware.AuthMiddleware([]models.Role{models.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateRegistration).ServeHTTP,
 	},
 	arbor.Route{
+		"GetFilteredMentorRegistrations",
+		"GET",
+		"/registration/mentor/filter/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(GetRegistration).ServeHTTP,
+	},
+	arbor.Route{
 		"GetUserRegistration",
 		"GET",
 		"/registration/attendee/{id}/",

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -25,7 +25,7 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/mentor/", GetCurrentMentorRegistration).Methods("GET")
 	router.HandleFunc("/mentor/", CreateCurrentMentorRegistration).Methods("POST")
 	router.HandleFunc("/mentor/", UpdateCurrentMentorRegistration).Methods("PUT")
-	router.HandleFunc("/mentor/filter/", GetFilteredMentorRegistrations).Methods("GET");
+	router.HandleFunc("/mentor/filter/", GetFilteredMentorRegistrations).Methods("GET")
 
 	router.HandleFunc("/{id}/", GetAllRegistrations).Methods("GET")
 	router.HandleFunc("/attendee/{id}/", GetUserRegistration).Methods("GET")

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -25,6 +25,7 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/mentor/", GetCurrentMentorRegistration).Methods("GET")
 	router.HandleFunc("/mentor/", CreateCurrentMentorRegistration).Methods("POST")
 	router.HandleFunc("/mentor/", UpdateCurrentMentorRegistration).Methods("PUT")
+	router.HandleFunc("/mentor/filter/", GetFilteredMentorRegistrations).Methods("GET");
 
 	router.HandleFunc("/{id}/", GetAllRegistrations).Methods("GET")
 	router.HandleFunc("/attendee/{id}/", GetUserRegistration).Methods("GET")
@@ -241,7 +242,7 @@ func UpdateCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	Endpoint to get registrations based on filters
+	Endpoint to get user registrations based on filters
 */
 func GetFilteredUserRegistrations(w http.ResponseWriter, r *http.Request) {
 	parameters := r.URL.Query()
@@ -389,6 +390,21 @@ func UpdateCurrentMentorRegistration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(updated_registration)
+}
+
+/*
+	Endpoint to get mentor registrations based on filters
+*/
+func GetFilteredMentorRegistrations(w http.ResponseWriter, r *http.Request) {
+	parameters := r.URL.Query()
+	mentor_registrations, err := service.GetFilteredMentorRegistrations(parameters)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get filtered mentor registrations."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(mentor_registrations)
 }
 
 /*

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -20,7 +20,7 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/attendee/", GetCurrentUserRegistration).Methods("GET")
 	router.HandleFunc("/attendee/", CreateCurrentUserRegistration).Methods("POST")
 	router.HandleFunc("/attendee/", UpdateCurrentUserRegistration).Methods("PUT")
-	router.HandleFunc("/filter/", GetFilteredUserRegistrations).Methods("GET")
+	router.HandleFunc("/attendee/filter/", GetFilteredUserRegistrations).Methods("GET")
 
 	router.HandleFunc("/mentor/", GetCurrentMentorRegistration).Methods("GET")
 	router.HandleFunc("/mentor/", CreateCurrentMentorRegistration).Methods("POST")

--- a/services/registration/models/filtered_mentor_registrations.go
+++ b/services/registration/models/filtered_mentor_registrations.go
@@ -1,0 +1,5 @@
+package models
+
+type FilteredMentorRegistrations struct {
+	Registrations []MentorRegistration `json:"registrations"`
+}

--- a/services/registration/models/filtered_user_registrations.go
+++ b/services/registration/models/filtered_user_registrations.go
@@ -1,5 +1,5 @@
 package models
 
-type FilteredRegistrations struct {
+type FilteredUserRegistrations struct {
 	Registrations []UserRegistration `json:"registrations"`
 }

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -90,9 +90,9 @@ func UpdateUserRegistration(id string, user_registration models.UserRegistration
 }
 
 /*
-	Returns the registrations associated with the given parameters
+	Returns db search query based on given parameters
 */
-func GetFilteredUserRegistrations(parameters map[string][]string) (*models.FilteredRegistrations, error) {
+func getFilterQuery(parameters map[string][]string) (map[string]interface{}, error) {
 	query := make(map[string]interface{})
 	for key, values := range parameters {
 		if len(values) == 1 {
@@ -113,8 +113,20 @@ func GetFilteredUserRegistrations(parameters map[string][]string) (*models.Filte
 		}
 	}
 
-	var filtered_registrations models.FilteredRegistrations
-	err := db.FindAll("attendees", query, &filtered_registrations.Registrations)
+	return query, nil
+}
+
+/*
+	Returns the user registrations associated with the given parameters
+*/
+func GetFilteredUserRegistrations(parameters map[string][]string) (*models.FilteredUserRegistrations, error) {
+	query, err := getFilterQuery(parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered_registrations models.FilteredUserRegistrations
+	err = db.FindAll("attendees", query, &filtered_registrations.Registrations)
 	if err != nil {
 		return nil, err
 	}
@@ -200,6 +212,24 @@ func UpdateMentorRegistration(id string, mentor_registration models.MentorRegist
 	err = db.Update("mentors", selector, &mentor_registration)
 
 	return err
+}
+
+/*
+	Returns the mentor registrations associated with the given parameters
+*/
+func GetFilteredMentorRegistrations(parameters map[string][]string) (*models.FilteredMentorRegistrations, error) {
+	query, err := getFilterQuery(parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered_registrations models.FilteredMentorRegistrations
+	err = db.FindAll("mentors", query, &filtered_registrations.Registrations)
+	if err != nil {
+		return nil, err
+	}
+
+	return &filtered_registrations, nil
 }
 
 /*

--- a/services/registration/tests/registration_test.go
+++ b/services/registration/tests/registration_test.go
@@ -276,7 +276,7 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registrations := models.FilteredRegistrations{
+	expected_registrations := models.FilteredUserRegistrations{
 		[]models.UserRegistration{
 			registration_1,
 		},
@@ -299,7 +299,7 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registrations = models.FilteredRegistrations{
+	expected_registrations = models.FilteredUserRegistrations{
 		[]models.UserRegistration{
 			registration_1,
 			registration_2,
@@ -324,7 +324,7 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_registrations = models.FilteredRegistrations{
+	expected_registrations = models.FilteredUserRegistrations{
 		[]models.UserRegistration{
 			registration_1,
 			registration_2,
@@ -337,6 +337,72 @@ func TestGetFilteredUserRegistrationsService(t *testing.T) {
 
 	if !reflect.DeepEqual(user_registrations.Registrations[1].Data["firstName"], expected_registrations.Registrations[1].Data["firstName"]) {
 		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations.Registrations[1].Data["firstName"], user_registrations.Registrations[1].Data["firstName"])
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for filtering mentor registrations in the db
+*/
+func TestGetFilteredMentorRegistrationsService(t *testing.T) {
+	SetupTestDB(t)
+
+	registration_1 := getBaseMentorRegistration()
+
+	registration_2 := getBaseMentorRegistration()
+	registration_2.Data["id"] = "testid2"
+
+	err := service.CreateMentorRegistration(registration_2.Data["id"].(string), registration_2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test single value and one keys
+	parameters := map[string][]string{
+		"id": {"testid"},
+	}
+	mentor_registrations, err := service.GetFilteredMentorRegistrations(parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_registrations := models.FilteredMentorRegistrations{
+		[]models.MentorRegistration{
+			registration_1,
+		},
+	}
+
+	if len(mentor_registrations.Registrations) != len(expected_registrations.Registrations) {
+		t.Errorf("Wrong number of registrations.\nExpected %v\ngot %v\n", len(expected_registrations.Registrations), len(mentor_registrations.Registrations))
+	}
+
+	if !reflect.DeepEqual(mentor_registrations.Registrations[0].Data["firstName"], expected_registrations.Registrations[0].Data["firstName"]) {
+		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations.Registrations[0].Data["firstName"], mentor_registrations.Registrations[0].Data["firstName"])
+	}
+
+	// Test multiple values
+	parameters = map[string][]string{
+		"id": {"testid,testid2"},
+	}
+	mentor_registrations, err = service.GetFilteredMentorRegistrations(parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_registrations = models.FilteredMentorRegistrations{
+		[]models.MentorRegistration{
+			registration_1,
+			registration_2,
+		},
+	}
+
+	if len(mentor_registrations.Registrations) != len(expected_registrations.Registrations) {
+		t.Errorf("Wrong number of registrations.\nExpected %v\ngot %v\n", len(expected_registrations.Registrations), len(mentor_registrations.Registrations))
+	}
+
+	if !reflect.DeepEqual(mentor_registrations.Registrations[1].Data["firstName"], expected_registrations.Registrations[1].Data["firstName"]) {
+		t.Errorf("Wrong user info.\nExpected %v\ngot %v\n", expected_registrations.Registrations[1].Data["firstName"], mentor_registrations.Registrations[1].Data["firstName"])
 	}
 
 	CleanupTestDB(t)

--- a/utilities/admintool/admissiontool.py
+++ b/utilities/admintool/admissiontool.py
@@ -18,7 +18,7 @@ def get_pending_applicants():
 	return [decision['id'] for decision in data['decisions']]
 
 def get_registrations():
-	data, success = api.make_request('GET', '/registration/filter/')
+	data, success = api.make_request('GET', '/registration/attendee/filter/')
 
 	if not success:
 		print('Failed to retreive registrations')

--- a/utilities/admintool/apiregistration.py
+++ b/utilities/admintool/apiregistration.py
@@ -6,7 +6,7 @@ import api
 from helper import options_menu, dict_flatten
 
 def registration_download():
-	data, success = api.make_request('GET', '/registration/filter/')
+	data, success = api.make_request('GET', '/registration/attendee/filter/')
 
 	if not success:
 		print('Failed to download registrations')


### PR DESCRIPTION
Addresses #244 

Summary: divided`/registration/filter/` endpoint to two separate `/registration/attendee/filter/` and `/registration/mentor/filter/` endpoints.

- Moved `/registration/filter/` endpoint to `/registration/attendee/filter/` and updated all references to the endpoint in the docs and admin tools
- Added mentor filter endpoint and added entry in docs
  - Renamed`FilteredRegistrations` model to`FilteredUserRegistrations` and created new  `FilteredMentorRegistrations` model
  - Refactored filter query generation code to method `getFilterQuery()` as attendee and mentor filters are essentially identical except db data source
  - Added unit test for the new mentor filter endpoint (same as attendee filter test except does not test for typecasting, as mentor registrations do not contain queryable fields other than strings)