### PR TITLE
Add endpoint to unregister a given device for a user #235

### DIFF
--- a/documentation/docs/reference/services/Notifications.md
+++ b/documentation/docs/reference/services/Notifications.md
@@ -194,6 +194,26 @@ Response format:
 }
 ```
 
+DELETE /notifications/device/
+---------------------------
+
+Unregisters the specified device token from the current user.
+
+Request format:
+```
+{
+	"token": "example_token",
+	"platform": "android"
+}
+```
+
+Response format:
+```
+{
+	"devices": []
+}
+```
+
 GET /notifications/order/ID/
 ----------------------------
 

--- a/gateway/services/notifications.go
+++ b/gateway/services/notifications.go
@@ -5,9 +5,10 @@ import (
 	"github.com/HackIllinois/api/gateway/middleware"
 	"github.com/HackIllinois/api/gateway/models"
 
+	"net/http"
+
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
-	"net/http"
 )
 
 const NotificationsFormat string = "JSON"
@@ -74,6 +75,12 @@ var NotificationsRoutes = arbor.RouteCollection{
 		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.UserRole})).ThenFunc(RegisterDeviceToUser).ServeHTTP,
 	},
 	arbor.Route{
+		"UnregisterDeviceToUser",
+		"DELETE",
+		"/notifications/device/",
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.UserRole})).ThenFunc(UnregisterDeviceToUser).ServeHTTP,
+	},
+	arbor.Route{
 		"GetNotificationOrder",
 		"GET",
 		"/notifications/order/{id}/",
@@ -118,6 +125,10 @@ func UnsubscribeToTopic(w http.ResponseWriter, r *http.Request) {
 }
 
 func RegisterDeviceToUser(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, config.NOTIFICATIONS_SERVICE+r.URL.String(), NotificationsFormat, "", r)
+}
+
+func UnregisterDeviceToUser(w http.ResponseWriter, r *http.Request) {
 	arbor.POST(w, config.NOTIFICATIONS_SERVICE+r.URL.String(), NotificationsFormat, "", r)
 }
 

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -3,13 +3,15 @@ package service
 import (
 	"encoding/json"
 	"errors"
+	"strings"
+
 	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/common/utils"
 	"github.com/HackIllinois/api/services/notifications/config"
 	"github.com/HackIllinois/api/services/notifications/models"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"strings"
 )
 
 var SNS_MESSAGE_STRUCTURE string = "json"
@@ -345,6 +347,70 @@ func RegisterDeviceToUser(token string, platform string, id string) error {
 	}
 
 	devices = append(devices, device_arn)
+
+	err = SetUserDevices(id, devices)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*
+	Unregisters the device token with SNS and remove the arn from the associated user
+*/
+func UnregisterDeviceFromUser(token string, platform string, id string) error {
+	var platform_arn string
+
+	switch strings.ToLower(platform) {
+	case "android":
+		platform_arn = config.ANDROID_PLATFORM_ARN
+	case "ios":
+		platform_arn = config.IOS_PLATFORM_ARN
+	default:
+		return errors.New("Invalid platform")
+	}
+
+	var device_arn string
+
+	if config.IS_PRODUCTION {
+		response, err := client.CreatePlatformEndpoint(
+			&sns.CreatePlatformEndpointInput{
+				CustomUserData:         &id,
+				Token:                  &token,
+				PlatformApplicationArn: &platform_arn,
+			},
+		)
+
+		if err != nil {
+			return err
+		}
+
+		device_arn = *response.EndpointArn
+
+		_, err = client.DeleteEndpoint(
+			&sns.DeleteEndpointInput{
+				EndpointArn: &device_arn,
+			},
+		)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	devices, err := GetUserDevices(id)
+
+	if err != nil {
+		return err
+	}
+
+	devices, err = utils.RemoveString(devices, device_arn)
+
+	if err != nil {
+		return err
+	}
 
 	err = SetUserDevices(id, devices)
 


### PR DESCRIPTION
This PR should solve the issue (#235 )

It provides an API endpoint` DELETE /notifications/device/` for removing the device associated to a token and platform.