### PR TITLE
Improve type assertion errors for datastore

### DIFF
--- a/common/datastore/conversions.go
+++ b/common/datastore/conversions.go
@@ -4,7 +4,7 @@ func toInt(raw_data interface{}, definition DataStoreDefinition) (interface{}, e
 	data, ok := raw_data.(float64)
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "float64")
 	}
 
 	return int64(data), nil
@@ -14,7 +14,7 @@ func toFloat(raw_data interface{}, definition DataStoreDefinition) (interface{},
 	data, ok := raw_data.(float64)
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "float64")
 	}
 
 	return data, nil
@@ -24,7 +24,7 @@ func toString(raw_data interface{}, definition DataStoreDefinition) (interface{}
 	data, ok := raw_data.(string)
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "string")
 	}
 
 	return data, nil
@@ -34,7 +34,7 @@ func toBoolean(raw_data interface{}, definition DataStoreDefinition) (interface{
 	data, ok := raw_data.(bool)
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "bool")
 	}
 
 	return data, nil
@@ -44,7 +44,7 @@ func toObject(raw_data interface{}, definition DataStoreDefinition) (interface{}
 	unfiltered_data, ok := raw_data.(map[string]interface{})
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "[]interface{}")
 	}
 
 	data := make(map[string]interface{})
@@ -57,7 +57,7 @@ func toObject(raw_data interface{}, definition DataStoreDefinition) (interface{}
 			data[field.Name], err = buildDataFromDefinition(unfiltered_fields, field)
 
 			if err != nil {
-				return nil, err
+				return nil, NewErrInField(field.Name, err)
 			}
 		} else {
 			data[field.Name] = getDefaultValue(field.Type)
@@ -71,7 +71,7 @@ func toIntArray(raw_data interface{}, definition DataStoreDefinition) (interface
 	data, ok := raw_data.([]interface{})
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "[]interface{}")
 	}
 
 	int_data := make([]int64, len(data))
@@ -80,7 +80,7 @@ func toIntArray(raw_data interface{}, definition DataStoreDefinition) (interface
 		element, ok := data[i].(float64)
 
 		if !ok {
-			return nil, ErrTypeMismatch
+			return nil, NewErrTypeMismatch(raw_data, "float64")
 		}
 
 		int_data[i] = int64(element)
@@ -93,7 +93,7 @@ func toFloatArray(raw_data interface{}, definition DataStoreDefinition) (interfa
 	data, ok := raw_data.([]interface{})
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "[]interface{}")
 	}
 
 	float_data := make([]float64, len(data))
@@ -102,7 +102,7 @@ func toFloatArray(raw_data interface{}, definition DataStoreDefinition) (interfa
 		element, ok := data[i].(float64)
 
 		if !ok {
-			return nil, ErrTypeMismatch
+			return nil, NewErrTypeMismatch(raw_data, "float64")
 		}
 
 		float_data[i] = element
@@ -115,7 +115,7 @@ func toStringArray(raw_data interface{}, definition DataStoreDefinition) (interf
 	data, ok := raw_data.([]interface{})
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "[]interface{}")
 	}
 
 	string_data := make([]string, len(data))
@@ -124,7 +124,7 @@ func toStringArray(raw_data interface{}, definition DataStoreDefinition) (interf
 		element, ok := data[i].(string)
 
 		if !ok {
-			return nil, ErrTypeMismatch
+			return nil, NewErrTypeMismatch(raw_data, "string")
 		}
 
 		string_data[i] = element
@@ -137,7 +137,7 @@ func toBooleanArray(raw_data interface{}, definition DataStoreDefinition) (inter
 	data, ok := raw_data.([]interface{})
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "[]interface{}")
 	}
 
 	bool_data := make([]bool, len(data))
@@ -146,7 +146,7 @@ func toBooleanArray(raw_data interface{}, definition DataStoreDefinition) (inter
 		element, ok := data[i].(bool)
 
 		if !ok {
-			return nil, ErrTypeMismatch
+			return nil, NewErrTypeMismatch(raw_data, "bool")
 		}
 
 		bool_data[i] = element
@@ -159,7 +159,7 @@ func toObjectArray(raw_data interface{}, definition DataStoreDefinition) (interf
 	unfiltered_data, ok := raw_data.([]interface{})
 
 	if !ok {
-		return nil, ErrTypeMismatch
+		return nil, NewErrTypeMismatch(raw_data, "[]interface{}")
 	}
 
 	data := make([]map[string]interface{}, len(unfiltered_data))

--- a/common/datastore/conversions.go
+++ b/common/datastore/conversions.go
@@ -44,7 +44,7 @@ func toObject(raw_data interface{}, definition DataStoreDefinition) (interface{}
 	unfiltered_data, ok := raw_data.(map[string]interface{})
 
 	if !ok {
-		return nil, NewErrTypeMismatch(raw_data, "[]interface{}")
+		return nil, NewErrTypeMismatch(raw_data, "map[string]interface{}")
 	}
 
 	data := make(map[string]interface{})

--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"errors"
+	"fmt"
 )
 
 type DataStoreDefinition struct {
@@ -24,7 +25,33 @@ func NewDataStore(definition DataStoreDefinition) DataStore {
 
 var ErrInvalidDefinition = errors.New("DataStore definition is invalid")
 var ErrInvalidData = errors.New("Invalid data unmarshalled")
-var ErrTypeMismatch = errors.New("Type mismatch in data and definition")
+
+func NewErrTypeMismatch(raw_data interface{}, expected string) error {
+	return fmt.Errorf("Type mismatch in data and definition. Expected %s, got %T", expected, raw_data)
+}
+
+type ErrorInField struct {
+	FieldName string
+	Err       error
+}
+
+func (e ErrorInField) Error() string {
+	return fmt.Sprintf("Error in field %s: %s", e.FieldName, e.Err)
+}
+
+/*
+	Wraps the given error, to indicate which field it comes from
+	If the provided error is of type ErrorInField, this function prepends the field name instead
+	For example, an error 'Error in field: name: xyz' becomes 'Error in field: user.name: xyz'
+*/
+func NewErrInField(field_name string, err error) error {
+	old_err_in_field, ok := err.(ErrorInField)
+	if ok {
+		field_name = fmt.Sprintf("%s.%s", field_name, old_err_in_field.FieldName)
+		err = old_err_in_field.Err
+	}
+	return ErrorInField{FieldName: field_name, Err: err}
+}
 
 var conversionFuncs map[string](func(interface{}, DataStoreDefinition) (interface{}, error))
 var defaultValues map[string]interface{}

--- a/common/datastore/validation.go
+++ b/common/datastore/validation.go
@@ -23,7 +23,7 @@ func validateField(data interface{}, definition DataStoreDefinition, validate *v
 		mapped_data, ok := data.(map[string]interface{})
 
 		if !ok {
-			return ErrTypeMismatch
+			return NewErrTypeMismatch(data, "map[string]interface{}")
 		}
 
 		return validateFieldArray(mapped_data, definition, validate)
@@ -31,7 +31,7 @@ func validateField(data interface{}, definition DataStoreDefinition, validate *v
 		data_array, ok := data.([]map[string]interface{})
 
 		if !ok {
-			return ErrTypeMismatch
+			return NewErrTypeMismatch(data, "[]map[string]interface{}")
 		}
 
 		for _, mapped_data := range data_array {


### PR DESCRIPTION
Addresses #240. If decomposing JSON/BSON into a datastore fails because the input data doesn't match the types specified by the definition, the returned error messages will specify which field failed, which type was expected, and the type provided.

Adds a small test.

Example output:
```
{
    "status": 500,
    "type": "INTERNAL_ERROR",
    "message": "Could not decode user registration information. Possible failure in JSON validation, or invalid registration format.",
    "raw_error": "Error in field firstName: Type mismatch in data and definition. Expected string, got float64"
}
```