### PR TITLE
Migrate to LinkedIn API v2 #224

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	gopkg.in/go-playground/validator.v9 v9.25.0
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,3 @@ require (
 	gopkg.in/go-playground/validator.v9 v9.25.0
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
 )
-
-go 1.13

--- a/services/auth/models/linkedin_email.go
+++ b/services/auth/models/linkedin_email.go
@@ -1,0 +1,11 @@
+package models
+
+type LinkedinEmail struct {
+	Elements []LinkedinEmailElement `json:"elements"`
+}
+
+type LinkedinEmailElement struct {
+	Handle struct {
+		Email string `json:"emailAddress"`
+	} `json:"handle~"`
+}

--- a/services/auth/models/linkedin_user_info.go
+++ b/services/auth/models/linkedin_user_info.go
@@ -1,9 +1,30 @@
 package models
 
+// ISSUE: formattedName no longer available in API v2
 type LinkedinUserInfo struct {
 	ID        string `json:"id"`
-	Username  string `json:"formattedName"`
 	Email     string `json:"emailAddress"`
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
+	FirstName struct {
+		Localized       map[string]string `json:"localized"`
+		PreferredLocale struct {
+			Country  string `json:"country"`
+			Language string `json:"language"`
+		} `json:"preferredLocale"`
+	} `json:"firstName"`
+	LastName struct {
+		Localized       map[string]string `json:"localized"`
+		PreferredLocale struct {
+			Country  string `json:"country"`
+			Language string `json:"language"`
+		} `json:"preferredLocale"`
+	} `json:"lastName"`
 }
+
+// Response format for FirstName and LastName is in MultiLocaleString
+// "localized":{
+// 	"en_US":"2029 Stierlin Ct, Mountain View, CA 94043"
+// },
+// "preferredLocale":{
+// 	"country":"US",
+// 	"language":"en"
+// }

--- a/services/auth/models/linkedin_user_info.go
+++ b/services/auth/models/linkedin_user_info.go
@@ -1,6 +1,5 @@
 package models
 
-// ISSUE: formattedName no longer available in API v2
 type LinkedinUserInfo struct {
 	ID        string `json:"id"`
 	Email     string `json:"emailAddress"`
@@ -19,12 +18,3 @@ type LinkedinUserInfo struct {
 		} `json:"preferredLocale"`
 	} `json:"lastName"`
 }
-
-// Response format for FirstName and LastName is in MultiLocaleString
-// "localized":{
-// 	"en_US":"2029 Stierlin Ct, Mountain View, CA 94043"
-// },
-// "preferredLocale":{
-// 	"country":"US",
-// 	"language":"en"
-// }

--- a/services/auth/models/linkedin_user_info.go
+++ b/services/auth/models/linkedin_user_info.go
@@ -2,7 +2,6 @@ package models
 
 type LinkedinUserInfo struct {
 	ID        string `json:"id"`
-	Email     string `json:"emailAddress"`
 	FirstName struct {
 		Localized       map[string]string `json:"localized"`
 		PreferredLocale struct {

--- a/services/auth/service/linkedin_service.go
+++ b/services/auth/service/linkedin_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+
 	"github.com/HackIllinois/api/services/auth/config"
 	"github.com/HackIllinois/api/services/auth/models"
 	"github.com/levigross/grequests"
@@ -26,7 +27,7 @@ func (provider *LinkedInOAuthProvider) GetAuthorizationRedirect(redirect_uri str
 	return ConstructSafeURL("https", "www.linkedin.com", "oauth/v2/authorization",
 		map[string]string{
 			"client_id":     config.LINKEDIN_CLIENT_ID,
-			"scope":         "r_basicprofile r_emailaddress",
+			"scope":         "r_liteprofile r_emailaddress", // changed from r_basicprofile to r_liteprofile
 			"response_type": "code",
 			"redirect_uri":  redirect_uri,
 		},
@@ -78,7 +79,16 @@ func (provider *LinkedInOAuthProvider) Authorize(code string, redirect_uri strin
 func (provider *LinkedInOAuthProvider) GetUserInfo() (*models.UserInfo, error) {
 	var user_info models.UserInfo
 
-	request, err := grequests.Get("https://api.linkedin.com/v1/people/~:(id,formatted-name,email-address,first-name,last-name)", &grequests.RequestOptions{
+	// request, err := grequests.Get("https://api.linkedin.com/v1/people/~:(id,formatted-name,email-address,first-name,last-name)", &grequests.RequestOptions{
+	// 	Headers: map[string]string{
+	// 		"Authorization": "Bearer " + provider.token,
+	// 		"Content-Type":  "application/json",
+	// 		"x-li-format":   "json",
+	// 	},
+	// })
+
+	// ISSUE: The formatted-name field is no longer available
+	request, err := grequests.Get("https://api.linkedin.com/v2/me?projection=(id,firstName?fields=id,bar,baz,lastName)", &grequests.RequestOptions{
 		Headers: map[string]string{
 			"Authorization": "Bearer " + provider.token,
 			"Content-Type":  "application/json",
@@ -102,10 +112,49 @@ func (provider *LinkedInOAuthProvider) GetUserInfo() (*models.UserInfo, error) {
 	}
 
 	user_info.ID = "linkedin" + linkedin_user_info.ID
-	user_info.Username = linkedin_user_info.Username
-	user_info.Email = linkedin_user_info.Email
-	user_info.FirstName = linkedin_user_info.FirstName
-	user_info.LastName = linkedin_user_info.LastName
+
+	preferred_country := linkedin_user_info.FirstName.PreferredLocale.Country
+	preferred_language := linkedin_user_info.FirstName.PreferredLocale.Language
+	if preferred_country != "" && preferred_language != "" {
+		// preferred local is provided
+		preferred_locale := preferred_language + "_" + preferred_country
+		user_info.FirstName = linkedin_user_info.FirstName.Localized[preferred_locale]
+		user_info.LastName = linkedin_user_info.LastName.Localized[preferred_locale]
+		user_info.Username = linkedin_user_info.FirstName.Localized[preferred_locale] + " " + linkedin_user_info.LastName.Localized[preferred_locale]
+	} else {
+		// preferred local is not provided, try getting en_US first, if failed, pick an arbitrary one
+		if linkedin_user_info.FirstName.Localized["en_US"] != "" && linkedin_user_info.LastName.Localized["en_US"] != "" {
+			user_info.FirstName = linkedin_user_info.FirstName.Localized["en_US"]
+			user_info.LastName = linkedin_user_info.LastName.Localized["en_US"]
+			user_info.Username = linkedin_user_info.FirstName.Localized["en_US"] + "_" + linkedin_user_info.LastName.Localized["en_US"]
+		} else {
+			for locale, _ := range linkedin_user_info.FirstName.Localized {
+				arbitrary_locale := locale
+				user_info.FirstName = linkedin_user_info.FirstName.Localized[arbitrary_locale]
+				user_info.LastName = linkedin_user_info.LastName.Localized[arbitrary_locale]
+				user_info.Username = linkedin_user_info.FirstName.Localized[arbitrary_locale] + "_" + linkedin_user_info.LastName.Localized[arbitrary_locale]
+				break
+			}
+		}
+	}
+
+	// In API v2, a seperate request is required to retrieve the email address
+	request, err = grequests.Get("https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))", &grequests.RequestOptions{
+		Headers: map[string]string{
+			"Authorization": "Bearer " + provider.token,
+			"Content-Type":  "application/json",
+			"x-li-format":   "json",
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var email models.LinkedinEmail
+	err = request.JSON(&email)
+
+	user_info.Email = email.Email
 
 	provider.isVerifiedUser = true
 

--- a/services/auth/service/linkedin_service.go
+++ b/services/auth/service/linkedin_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+
 	"github.com/HackIllinois/api/services/auth/config"
 	"github.com/HackIllinois/api/services/auth/models"
 	"github.com/levigross/grequests"
@@ -111,13 +112,13 @@ func (provider *LinkedInOAuthProvider) GetUserInfo() (*models.UserInfo, error) {
 		user_info.LastName = linkedin_user_info.LastName.Localized[preferred_locale]
 		user_info.Username = linkedin_user_info.FirstName.Localized[preferred_locale] + " " + linkedin_user_info.LastName.Localized[preferred_locale]
 	} else {
-		// preferred locale is not provided, try en_US first. If failed, pick an arbitrary locale.
+		// Preferred locale is not provided, try en_US first. If failed, pick an arbitrary locale.
 		if linkedin_user_info.FirstName.Localized["en_US"] != "" && linkedin_user_info.LastName.Localized["en_US"] != "" {
 			user_info.FirstName = linkedin_user_info.FirstName.Localized["en_US"]
 			user_info.LastName = linkedin_user_info.LastName.Localized["en_US"]
 			user_info.Username = linkedin_user_info.FirstName.Localized["en_US"] + " " + linkedin_user_info.LastName.Localized["en_US"]
 		} else {
-			for locale, _ := range linkedin_user_info.FirstName.Localized {
+			for locale := range linkedin_user_info.FirstName.Localized {
 				arbitrary_locale := locale
 				user_info.FirstName = linkedin_user_info.FirstName.Localized[arbitrary_locale]
 				user_info.LastName = linkedin_user_info.LastName.Localized[arbitrary_locale]

--- a/services/auth/service/linkedin_service.go
+++ b/services/auth/service/linkedin_service.go
@@ -142,7 +142,12 @@ func (provider *LinkedInOAuthProvider) GetUserInfo() (*models.UserInfo, error) {
 	var email models.LinkedinEmail
 	err = request.JSON(&email)
 
+	if err != nil {
+		return nil, err
+	}
+
 	user_info.Email = email.Elements[0].Handle.Email
+
 	provider.isVerifiedUser = true
 
 	return &user_info, nil

--- a/services/auth/service/linkedin_service.go
+++ b/services/auth/service/linkedin_service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"errors"
-
 	"github.com/HackIllinois/api/services/auth/config"
 	"github.com/HackIllinois/api/services/auth/models"
 	"github.com/levigross/grequests"


### PR DESCRIPTION
I mainly modified the `getUserInfo` function, which is responsible for retrieving user's name, id, and email address. Now a separate request is required to get the email address. Some models are added according to the new API response format. In `GetAuthorizationRedirect` function, I changed the scope from `r_basicprofile` to `r_liteprofile` since basic profile access is now restricted to their enterprise plan users.