### PR TITLE
Track number of intended recipients for each notification order

### DIFF
--- a/documentation/docs/reference/services/Notifications.md
+++ b/documentation/docs/reference/services/Notifications.md
@@ -119,6 +119,7 @@ Response format:
 ```
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"numRecipients": 5,
 	"success": 0,
 	"failure": 0,
 	"time": 1553564589
@@ -203,6 +204,7 @@ Response format:
 ```
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"numRecipients": 5,
 	"success": 5,
 	"failure": 0,
 	"time": 1553564589

--- a/services/notifications/models/notification_order.go
+++ b/services/notifications/models/notification_order.go
@@ -1,8 +1,9 @@
 package models
 
 type NotificationOrder struct {
-	ID      string `json:"id"`
-	Success int    `json:"success"`
-	Failure int    `json:"failure"`
-	Time    int64  `json:"time"`
+	ID            string `json:"id"`
+	NumRecipients int    `json:"numRecipients"`
+	Success       int    `json:"success"`
+	Failure       int    `json:"failure"`
+	Time          int64  `json:"time"`
 }

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -447,10 +447,11 @@ func PublishNotificationToTopic(notification models.Notification) (*models.Notif
 	}
 
 	order := models.NotificationOrder{
-		ID:      notification.ID,
-		Success: 0,
-		Failure: 0,
-		Time:    notification.Time,
+		ID:            notification.ID,
+		NumRecipients: len(device_arns),
+		Success:       0,
+		Failure:       0,
+		Time:          notification.Time,
 	}
 
 	err = db.Insert("orders", &order)

--- a/services/notifications/tests/notifications_test.go
+++ b/services/notifications/tests/notifications_test.go
@@ -437,21 +437,58 @@ func TestPublishNotificationToTopic(t *testing.T) {
 		Time:  3000,
 	}
 
+	// Send notification to one user w/ one device
 	order, err := service.PublishNotificationToTopic(notification)
-
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expected_order := models.NotificationOrder{
-		ID:      "test_id2",
-		Success: 0,
-		Failure: 0,
-		Time:    3000,
+		ID:            "test_id2",
+		NumRecipients: 1,
+		Success:       0,
+		Failure:       0,
+		Time:          3000,
+	}
+	if !reflect.DeepEqual(order, &expected_order) {
+		t.Errorf("Wrong order.\nExpected %v\ngot %v\n", &expected_order, order)
+	}
+
+	// Add additional user w/ two devices
+	user := models.User{
+		ID:      "test_user_2",
+		Devices: []string{"test_arn2", "test_arn3"},
+	}
+	err = db.Insert("users", &user)
+
+	selector := database.QuerySelector{
+		"id": "User",
+	}
+	topic := models.Topic{
+		ID:      "User",
+		UserIDs: []string{"test_user", "test_user_2"},
+	}
+	err = db.Update("topics", selector, &topic)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send notification to two users w/ three total devices
+	order, err = service.PublishNotificationToTopic(notification)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_order = models.NotificationOrder{
+		ID:            "test_id2",
+		NumRecipients: 3,
+		Success:       0,
+		Failure:       0,
+		Time:          3000,
 	}
 
 	if !reflect.DeepEqual(order, &expected_order) {
-		t.Errorf("Wrong topics.\nExpected %v\ngot %v\n", &expected_order, order)
+		t.Errorf("Wrong order.\nExpected %v\ngot %v\n", &expected_order, order)
 	}
 
 	CleanupTestDB(t)


### PR DESCRIPTION
Resolves #268. Adds a new field, `numRecipients`, to each notification order, which tracks the number of devices the notification is intended to be sent to.