### PR TITLE
Added Patch method for the database.

### DIFF
--- a/common/database/database.go
+++ b/common/database/database.go
@@ -14,6 +14,7 @@ type Database interface {
 	Upsert(collection_name string, selector interface{}, update interface{}) (*ChangeResults, error)
 	Update(collection_name string, selector interface{}, update interface{}) error
 	UpdateAll(collection_name string, selector interface{}, update interface{}) (*ChangeResults, error)
+	Patch(collection_name string, selector interface{}, update *map[string]interface{}) error
 	DropDatabase() error
 	GetStats(collection_name string, fields []string) (map[string]interface{}, error)
 }

--- a/common/database/mongo_database.go
+++ b/common/database/mongo_database.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/HackIllinois/api/common/config"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 /*
@@ -203,6 +204,20 @@ func (db *MongoDatabase) UpdateAll(collection_name string, selector interface{},
 	}
 
 	return &change_results, convertMgoError(err)
+}
+
+/*
+	Finds an item based on the given selector and patches it with the data in update
+*/
+func (db *MongoDatabase) Patch(collection_name string, selector interface{}, update *map[string]interface{}) error {
+	current_session := db.GetSession()
+	defer current_session.Close()
+
+	collection := current_session.DB(db.name).C(collection_name)
+
+	// Use mongodb set operator to update only the provided fields.
+	err := collection.Update(selector, bson.M{"$set": update})
+	return convertMgoError(err)
 }
 
 /*


### PR DESCRIPTION
I added `Patch` method in `mongo_database.go` to enable updates of only the selected fields in an entry.
This method can be used by the patch methods in endpoints such as registration, blobstore, etc.
I also modified the `Database interface` in `database.go` to reflect the change.