### PR TITLE
Add endpoint to patch user registration #234

### DIFF
--- a/common/database/database.go
+++ b/common/database/database.go
@@ -14,6 +14,7 @@ type Database interface {
 	Upsert(collection_name string, selector interface{}, update interface{}) (*ChangeResults, error)
 	Update(collection_name string, selector interface{}, update interface{}) error
 	UpdateAll(collection_name string, selector interface{}, update interface{}) (*ChangeResults, error)
+	Patch(collection_name string, selector interface{}, update *map[string]interface{}) error
 	DropDatabase() error
 	GetStats(collection_name string, fields []string) (map[string]interface{}, error)
 }

--- a/common/database/mongo_database.go
+++ b/common/database/mongo_database.go
@@ -2,7 +2,9 @@ package database
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
+	"reflect"
 	"time"
 
 	"github.com/HackIllinois/api/common/config"
@@ -176,12 +178,19 @@ func (db *MongoDatabase) Upsert(collection_name string, selector interface{}, up
 	Finds an item based on the given selector and updates it with the data in update
 */
 func (db *MongoDatabase) Update(collection_name string, selector interface{}, update interface{}) error {
+	// DEBUG
+	fmt.Println("db.Update gets called!")
 	current_session := db.GetSession()
 	defer current_session.Close()
 
 	collection := current_session.DB(db.name).C(collection_name)
 
+	fmt.Println("About to set new firstName")
+	fmt.Println("type of update: ", reflect.TypeOf(update))
+	fmt.Println("Update: ", update)
 	err := collection.Update(selector, update)
+	// Not working
+	// err := collection.Update(selector, "{ $set: { firstName: \"NewName!!!\" }}")
 
 	return convertMgoError(err)
 }

--- a/common/database/mongo_database.go
+++ b/common/database/mongo_database.go
@@ -173,6 +173,29 @@ func (db *MongoDatabase) Upsert(collection_name string, selector interface{}, up
 	return &change_results, convertMgoError(err)
 }
 
+// /*
+// 	Finds an item based on the given selector and updates it with the data in update
+// */
+// func (db *MongoDatabase) Update(collection_name string, selector interface{}, update interface{}) error {
+// 	current_session := db.GetSession()
+// 	defer current_session.Close()
+
+// 	collection := current_session.DB(db.name).C(collection_name)
+
+// 	// Check the variable type of update .
+// 	// If it's a map, it's passed by the patch method, so we only update certain fields.
+// 	// If it's not a map, it's passed by other methods, and we update all fields.
+// 	update_as_map, ok := update.(*map[string]interface{})
+// 	if ok {
+// 		// Use the mongodb set operation to update only given fields.
+// 		err := collection.Update(selector, bson.M{"$set": update_as_map})
+// 		return convertMgoError(err)
+// 	} else {
+// 		err := collection.Update(selector, update)
+// 		return convertMgoError(err)
+// 	}
+// }
+
 /*
 	Finds an item based on the given selector and updates it with the data in update
 */
@@ -182,18 +205,23 @@ func (db *MongoDatabase) Update(collection_name string, selector interface{}, up
 
 	collection := current_session.DB(db.name).C(collection_name)
 
-	// Check the variable type of update .
-	// If it's a map, it's passed by the patch method, so we only update certain fields.
-	// If it's not a map, it's passed by other methods, and we update all fields.
-	update_as_map, ok := update.(*map[string]interface{})
-	if ok {
-		// Use the mongodb set operation to update only given fields.
-		err := collection.Update(selector, bson.M{"$set": update_as_map})
-		return convertMgoError(err)
-	} else {
-		err := collection.Update(selector, update)
-		return convertMgoError(err)
-	}
+	err := collection.Update(selector, update)
+
+	return convertMgoError(err)
+}
+
+/*
+	Finds an item based on the given selector and patches it with the data in update
+*/
+func (db *MongoDatabase) Patch(collection_name string, selector interface{}, update *map[string]interface{}) error {
+	current_session := db.GetSession()
+	defer current_session.Close()
+
+	collection := current_session.DB(db.name).C(collection_name)
+
+	// Use the mongodb set operation to update only the given fields.
+	err := collection.Update(selector, bson.M{"$set": update})
+	return convertMgoError(err)
 }
 
 /*

--- a/common/datastore/conversions.go
+++ b/common/datastore/conversions.go
@@ -1,5 +1,9 @@
 package datastore
 
+import (
+	"fmt"
+)
+
 func toInt(raw_data interface{}, definition DataStoreDefinition) (interface{}, error) {
 	data, ok := raw_data.(float64)
 
@@ -60,7 +64,12 @@ func toObject(raw_data interface{}, definition DataStoreDefinition) (interface{}
 				return nil, err
 			}
 		} else {
-			data[field.Name] = getDefaultValue(field.Type)
+			if len(field.Fields) == 0 {
+				fmt.Print("Omitting ", field.Name, " field")
+			} else {
+				fmt.Printf("field name: %s type: %s content: %s len is 0:%t\n", field.Name, field.Type, field.Fields, len(field.Fields) == 0)
+				data[field.Name] = getDefaultValue(field.Type)
+			}
 		}
 	}
 

--- a/common/datastore/datastore.go
+++ b/common/datastore/datastore.go
@@ -5,10 +5,10 @@ import (
 )
 
 type DataStoreDefinition struct {
-	Name        string                `json:"name"`
-	Type        string                `json:"type"`
-	Validations string                `json:"validations"`
-	Fields      []DataStoreDefinition `json:"fields"`
+	Name        string                `json:"name,omitempty"`
+	Type        string                `json:"type,omitempty"`
+	Validations string                `json:"validations,omitempty"`
+	Fields      []DataStoreDefinition `json:"fields,omitempty"`
 }
 
 type DataStore struct {

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -118,6 +118,12 @@
 		"validations": "required",
 		"fields": [
 			{
+				"name": "id",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
 				"name": "firstName",
 				"type": "string",
 				"validations": "",
@@ -136,9 +142,154 @@
 				"fields": []
 			},
 			{
+				"name": "shirtSize",
+				"type": "string",
+				"validations": "required,oneof=S M L XL",
+				"fields": []
+			},
+			{
+				"name": "diet",
+				"type": "[]string",
+				"validations": "required,dive,oneof=NONE VEGAN VEGETARIAN NOPEANUT NOGLUTEN",
+				"fields": []
+			},
+			{
+				"name": "age",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "graduationYear",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "transportation",
+				"type": "string",
+				"validations": "required,oneof=NONE BUS",
+				"fields": []
+			},
+			{
+				"name": "school",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "major",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "gender",
+				"type": "string",
+				"validations": "required,oneof=MALE FEMALE NONBINARY OTHER NOANSWER",
+				"fields": []
+			},
+			{
+				"name": "interests",
+				"type": "[]string",
+				"validations": "dive,oneof=INTERNSHIP FULLTIME",
+				"fields": []
+			},
+			{
 				"name": "github",
 				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "linkedin",
+				"type": "string",
 				"validations": "",
+				"fields": []
+			},
+			{
+				"name": "isBeginner",
+				"type": "boolean",
+				"validations": "required|isdefault",
+				"fields": []
+			},
+			{
+				"name": "priorAttendance",
+				"type": "boolean",
+				"validations": "required|isdefault",
+				"fields": []
+			},
+			{
+				"name": "phone",
+				"type": "string",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "skills",
+				"type": "[]string",
+				"validations": "",
+				"fields": []
+			},
+			{
+				"name": "extraInfo",
+				"type": "string",
+				"validations": "",
+				"fields": []
+			},
+			{
+				"name": "teamMembers",
+				"type": "[]string",
+				"validations": "",
+				"fields": []
+			},
+			{
+				"name": "createdAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "updatedAt",
+				"type": "int",
+				"validations": "required",
+				"fields": []
+			},
+			{
+				"name": "beginnerInfo",
+				"type": "object",
+				"validations": "required",
+				"fields": [
+					{
+						"name": "versionControl",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "pullRequest",
+						"type": "int",
+						"validations": "required",
+						"fields": []
+					},
+					{
+						"name": "yearsExperience",
+						"type": "int",
+						"validations": "",
+						"fields": []
+					},
+					{
+						"name": "technicalSkills",
+						"type": "[]string",
+						"validations": "",
+						"fields": []
+					}
+				]
+			},
+			{
+				"name": "isOSContributor",
+				"type": "boolean",
+				"validations": "required|isdefault",
 				"fields": []
 			}
 		]

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -118,12 +118,6 @@
 		"validations": "required",
 		"fields": [
 			{
-				"name": "id",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
 				"name": "firstName",
 				"type": "string",
 				"validations": "",
@@ -142,154 +136,9 @@
 				"fields": []
 			},
 			{
-				"name": "shirtSize",
-				"type": "string",
-				"validations": "required,oneof=S M L XL",
-				"fields": []
-			},
-			{
-				"name": "diet",
-				"type": "[]string",
-				"validations": "required,dive,oneof=NONE VEGAN VEGETARIAN NOPEANUT NOGLUTEN",
-				"fields": []
-			},
-			{
-				"name": "age",
-				"type": "int",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "graduationYear",
-				"type": "int",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "transportation",
-				"type": "string",
-				"validations": "required,oneof=NONE BUS",
-				"fields": []
-			},
-			{
-				"name": "school",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "major",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "gender",
-				"type": "string",
-				"validations": "required,oneof=MALE FEMALE NONBINARY OTHER NOANSWER",
-				"fields": []
-			},
-			{
-				"name": "interests",
-				"type": "[]string",
-				"validations": "dive,oneof=INTERNSHIP FULLTIME",
-				"fields": []
-			},
-			{
 				"name": "github",
 				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "linkedin",
-				"type": "string",
 				"validations": "",
-				"fields": []
-			},
-			{
-				"name": "isBeginner",
-				"type": "boolean",
-				"validations": "required|isdefault",
-				"fields": []
-			},
-			{
-				"name": "priorAttendance",
-				"type": "boolean",
-				"validations": "required|isdefault",
-				"fields": []
-			},
-			{
-				"name": "phone",
-				"type": "string",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "skills",
-				"type": "[]string",
-				"validations": "",
-				"fields": []
-			},
-			{
-				"name": "extraInfo",
-				"type": "string",
-				"validations": "",
-				"fields": []
-			},
-			{
-				"name": "teamMembers",
-				"type": "[]string",
-				"validations": "",
-				"fields": []
-			},
-			{
-				"name": "createdAt",
-				"type": "int",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "updatedAt",
-				"type": "int",
-				"validations": "required",
-				"fields": []
-			},
-			{
-				"name": "beginnerInfo",
-				"type": "object",
-				"validations": "required",
-				"fields": [
-					{
-						"name": "versionControl",
-						"type": "int",
-						"validations": "required",
-						"fields": []
-					},
-					{
-						"name": "pullRequest",
-						"type": "int",
-						"validations": "required",
-						"fields": []
-					},
-					{
-						"name": "yearsExperience",
-						"type": "int",
-						"validations": "",
-						"fields": []
-					},
-					{
-						"name": "technicalSkills",
-						"type": "[]string",
-						"validations": "",
-						"fields": []
-					}
-				]
-			},
-			{
-				"name": "isOSContributor",
-				"type": "boolean",
-				"validations": "required|isdefault",
 				"fields": []
 			}
 		]

--- a/documentation/docs/reference/services/Registration.md
+++ b/documentation/docs/reference/services/Registration.md
@@ -423,6 +423,102 @@ Response format:
 }
 ```
 
+PATCH /registration/attendee/
+------------------
+
+Updates only the provided fields the registration for the user with the `id` in the JWT token provided in the Authorization header.
+
+Request format:
+```
+{
+	"firstName": "John",
+	"lastName": "Smith",
+	"email": "john@gmail.com",
+	"shirtSize": "M",
+	"diet": "NONE",
+	"age": 19,
+	"graduationYear": 2019,
+	"transportation": "NONE",
+	"school": "University of Illinois at Urbana-Champaign",
+	"major": "Computer Science",
+	"gender": "MALE",
+	"professionalInterest": "INTERNSHIP",
+	"github": "JSmith",
+	"linkedin": "john-smith",
+	"interests": "Software",
+	"isNovice": false,
+	"isPrivate": false,
+	"phoneNumber": "555-555-5555",
+	"longforms": [
+		{
+			"response": "This is a longform."
+		}
+	],
+	"extraInfos": [
+		{
+			"response": "This is an extra info."
+		}
+	],
+	"osContributors": [
+		{
+			"name": "Tom",
+			"contactInfo": "tom@gmail.com"
+		}
+	],
+	"collaborators": [
+		{
+			"github": "collabgithub"
+		}
+	]
+}
+```
+
+Response format:
+```
+{
+	"id": "github0000001"
+	"firstName": "John",
+	"lastName": "Smith",
+	"email": "john@gmail.com",
+	"shirtSize": "M",
+	"diet": "NONE",
+	"age": 19,
+	"graduationYear": 2019,
+	"transportation": "NONE",
+	"school": "University of Illinois at Urbana-Champaign",
+	"major": "Computer Science",
+	"gender": "MALE",
+	"professionalInterest": "INTERNSHIP",
+	"github": "JSmith",
+	"linkedin": "john-smith",
+	"interests": "Software",
+	"isNovice": false,
+	"isPrivate": false,
+	"phoneNumber": "555-555-5555",
+	"longforms": [
+		{
+			"response": "This is a longform."
+		}
+	],
+	"extraInfos": [
+		{
+			"response": "This is an extra info."
+		}
+	],
+	"osContributors": [
+		{
+			"name": "Tom",
+			"contactInfo": "tom@gmail.com"
+		}
+	],
+	"collaborators": [
+		{
+			"github": "collabgithub"
+		}
+	]
+}
+```
+
 GET /registration/mentor/USERID/
 -------------------------
 

--- a/gateway/services/registration.go
+++ b/gateway/services/registration.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/HackIllinois/api/gateway/config"
@@ -100,8 +99,6 @@ func UpdateRegistration(w http.ResponseWriter, r *http.Request) {
 	arbor.PUT(w, config.REGISTRATION_SERVICE+r.URL.String(), RegistrationFormat, "", r)
 }
 
-// ADDED THIS
 func PatchRegistration(w http.ResponseWriter, r *http.Request) {
-	fmt.Printf("Made it to gateway")
 	arbor.PATCH(w, config.REGISTRATION_SERVICE+r.URL.String(), RegistrationFormat, "", r)
 }

--- a/gateway/services/registration.go
+++ b/gateway/services/registration.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/HackIllinois/api/gateway/config"
 	"github.com/HackIllinois/api/gateway/middleware"
 	"github.com/HackIllinois/api/gateway/models"
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
-	"net/http"
 )
 
 const RegistrationFormat string = "JSON"
@@ -29,6 +31,12 @@ var RegistrationRoutes = arbor.RouteCollection{
 		"POST",
 		"/registration/attendee/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(CreateRegistration).ServeHTTP,
+	},
+	arbor.Route{
+		"PatchCurrentUserRegistration",
+		"PATCH",
+		"/registration/attendee/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(PatchRegistration).ServeHTTP,
 	},
 	arbor.Route{
 		"UpdateCurrentUserRegistration",
@@ -90,4 +98,10 @@ func CreateRegistration(w http.ResponseWriter, r *http.Request) {
 
 func UpdateRegistration(w http.ResponseWriter, r *http.Request) {
 	arbor.PUT(w, config.REGISTRATION_SERVICE+r.URL.String(), RegistrationFormat, "", r)
+}
+
+// ADDED THIS
+func PatchRegistration(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("Made it to gateway")
+	arbor.PATCH(w, config.REGISTRATION_SERVICE+r.URL.String(), RegistrationFormat, "", r)
 }

--- a/gateway/services/services.go
+++ b/gateway/services/services.go
@@ -2,10 +2,11 @@ package services
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/HackIllinois/api/gateway/config"
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
-	"net/http"
 )
 
 var ServiceLocations map[string]string
@@ -38,7 +39,7 @@ var Routes = arbor.RouteCollection{
 }
 
 func Gateway(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "The API Gateway Lives")
+	fmt.Fprintf(w, "The API Gateway is Working Well!!!")
 }
 
 func RegisterAPIs() arbor.RouteCollection {

--- a/gateway/services/services.go
+++ b/gateway/services/services.go
@@ -39,7 +39,7 @@ var Routes = arbor.RouteCollection{
 }
 
 func Gateway(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "The API Gateway is Working Well!!!")
+	fmt.Fprintf(w, "The API Gateway Lives!")
 }
 
 func RegisterAPIs() arbor.RouteCollection {

--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	gopkg.in/go-playground/validator.v9 v9.25.0
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/levigross/grequests v0.0.0-20181123014746-f3f67e7783bb
 	github.com/thoas/stats v0.0.0-20181218120333-e97827ebd7ca
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.25.0
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/thoas/stats v0.0.0-20181218120333-e97827ebd7ca h1:Ju3LQGLQHCUv1yB2WwB
 github.com/thoas/stats v0.0.0-20181218120333-e97827ebd7ca/go.mod h1:GkZsNBOco11YY68OnXUARbSl26IOXXAeYf6ZKmSZR2M=
 golang.org/x/net v0.0.0-20171004034648-a04bdaca5b32 h1:NjAulLPqFTaOxQu5S4qUMqscSu+mQdu+wMY0nfqSkuk=
 golang.org/x/net v0.0.0-20171004034648-a04bdaca5b32/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
+gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.25.0 h1:Q3c4LgUofOEtz0wCE18Q2qwDkATLHLBUOmTvqjNCWkM=
 gopkg.in/go-playground/validator.v9 v9.25.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/jarcoal/httpmock.v1 v1.0.0-20180719183105-8007e27cdb32/go.mod h1:d3R+NllX3X5e0zlG1Rful3uLvsGC/Q3OHut5464DEQw=

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -245,7 +245,7 @@ func UpdateCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 }
 
 func PatchCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
-	fmt.Printf("Testing !")
+	fmt.Printf("Gets to the controller")
 	id := r.Header.Get("HackIllinois-Identity")
 
 	if id == "" {

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -2,9 +2,7 @@ package controller
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"reflect"
 	"time"
 
 	"github.com/HackIllinois/api/common/datastore"
@@ -245,8 +243,11 @@ func UpdateCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(updated_registration)
 }
 
+/*
+	Endpoint to patch the registration for the current user.
+	On successful patch, sends the user a confirmation mail.
+*/
 func PatchCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
-	fmt.Printf("Gets to the controller")
 	id := r.Header.Get("HackIllinois-Identity")
 
 	if id == "" {
@@ -254,24 +255,10 @@ func PatchCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create variable where user data are to be stored.
 	user_registration := datastore.NewDataStore(config.REGISTRATION_DEFINITION)
 
 	// Decode http request and write into user_registration
 	err := json.NewDecoder(r.Body).Decode(&user_registration)
-
-	// DEBUG Print out decoded values.
-	fmt.Printf("\nuser_registration: %+v\n", user_registration.Data)
-	fmt.Println()
-
-	fmt.Printf("NAME: %v\n", user_registration.Data["firstName"])
-
-	fmt.Printf("type of github entry: %v\n", reflect.TypeOf(user_registration.Data["github"]))
-	if len(user_registration.Data["github"].(string)) > 0 {
-		fmt.Printf("GITHUB: %v\n", user_registration.Data["github"])
-	} else {
-		fmt.Printf("Github entry string has length 0!\n")
-	}
 
 	if err != nil {
 		errors.WriteError(w, r, errors.InternalError(err.Error(), "Could not decode user registration information. Possible failure in JSON validation, or invalid registration format."))
@@ -280,30 +267,6 @@ func PatchCurrentUserRegistration(w http.ResponseWriter, r *http.Request) {
 
 	user_registration.Data["id"] = id
 
-	// I think the following lines are not required for our patch method.
-	// user_info, err := service.GetUserInfo(id)
-
-	// // DEBUG: Print out user info
-	// fmt.Printf("\nuser_info: %+v\n", user_info)
-
-	// if err != nil {
-	// 	errors.WriteError(w, r, errors.InternalError(err.Error(), "Could not get user info."))
-	// 	return
-	// }
-
-	// original_registration, err := service.GetUserRegistration(id)
-
-	// if err != nil {
-	// 	errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get user's original registration."))
-	// 	return
-	// }
-
-	// user_registration.Data["github"] = user_info.Username
-	// user_registration.Data["email"] = user_info.Email
-	// user_registration.Data["firstName"] = user_info.FirstName
-	// user_registration.Data["lastName"] = user_info.LastName
-
-	// user_registration.Data["createdAt"] = original_registration.Data["createdAt"]
 	user_registration.Data["updatedAt"] = time.Now().Unix()
 
 	err = service.PatchUserRegistration(id, user_registration)

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -2,12 +2,13 @@ package service
 
 import (
 	"errors"
+	"strconv"
+	"strings"
+
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
 	"gopkg.in/go-playground/validator.v9"
-	"strconv"
-	"strings"
 )
 
 var validate *validator.Validate
@@ -84,6 +85,21 @@ func UpdateUserRegistration(id string, user_registration models.UserRegistration
 
 	selector := database.QuerySelector{"id": id}
 
+	err = db.Update("attendees", selector, &user_registration)
+
+	return err
+}
+
+// ADDED, gets called by the controller.
+func PatchUserRegistration(id string, user_registration models.UserRegistration) error {
+	err := user_registration.Validate()
+
+	if err != nil {
+		return err
+	}
+
+	selector := database.QuerySelector{"id": id}
+	// ?? Is it correct to use Update to update only some of the fields
 	err = db.Update("attendees", selector, &user_registration)
 
 	return err

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -99,7 +100,31 @@ func PatchUserRegistration(id string, user_registration models.UserRegistration)
 	}
 
 	selector := database.QuerySelector{"id": id}
-	// ?? Is it correct to use Update to update only some of the fields
+
+	fmt.Println("Before deleting: ")
+	for k, v := range user_registration.Data {
+		fmt.Println("k:", k, " v:", v)
+	}
+
+	for k, v := range user_registration.Data {
+		v_as_string, ok := v.(string)
+		if ok && len(v_as_string) == 0 {
+			delete(user_registration.Data, k)
+		}
+	}
+	fmt.Println("After deleting empty entries: ")
+	for k, v := range user_registration.Data {
+		fmt.Println("k:", k, " v:", v)
+	}
+
+	// jsonString, err := json.Marshal(user_registration.Data)
+	// if err != nil {
+	// 	fmt.Println("Cannot convert registration info into json string.")
+	// } else {
+	// 	fmt.Println("jsonString:", string(jsonString))
+	// }
+	// jsonString_string := string(jsonString)
+
 	err = db.Update("attendees", selector, &user_registration)
 
 	return err

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -91,7 +90,9 @@ func UpdateUserRegistration(id string, user_registration models.UserRegistration
 	return err
 }
 
-// ADDED, gets called by the controller.
+/*
+	Patches the registration associated with the given user id
+*/
 func PatchUserRegistration(id string, user_registration models.UserRegistration) error {
 	err := user_registration.Validate()
 
@@ -101,31 +102,15 @@ func PatchUserRegistration(id string, user_registration models.UserRegistration)
 
 	selector := database.QuerySelector{"id": id}
 
-	fmt.Println("Before deleting: ")
-	for k, v := range user_registration.Data {
-		fmt.Println("k:", k, " v:", v)
-	}
-
+	// Delete fields the user didn't fill in.
 	for k, v := range user_registration.Data {
 		v_as_string, ok := v.(string)
 		if ok && len(v_as_string) == 0 {
 			delete(user_registration.Data, k)
 		}
 	}
-	fmt.Println("After deleting empty entries: ")
-	for k, v := range user_registration.Data {
-		fmt.Println("k:", k, " v:", v)
-	}
 
-	// jsonString, err := json.Marshal(user_registration.Data)
-	// if err != nil {
-	// 	fmt.Println("Cannot convert registration info into json string.")
-	// } else {
-	// 	fmt.Println("jsonString:", string(jsonString))
-	// }
-	// jsonString_string := string(jsonString)
-
-	err = db.Update("attendees", selector, &user_registration)
+	err = db.Update("attendees", selector, &user_registration.Data)
 
 	return err
 }

--- a/services/registration/service/registration_service.go
+++ b/services/registration/service/registration_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -94,23 +95,31 @@ func UpdateUserRegistration(id string, user_registration models.UserRegistration
 	Patches the registration associated with the given user id
 */
 func PatchUserRegistration(id string, user_registration models.UserRegistration) error {
-	err := user_registration.Validate()
+	// err := user_registration.Validate()
 
-	if err != nil {
-		return err
-	}
+	// if err != nil {
+	// 	return err
+	// }
 
 	selector := database.QuerySelector{"id": id}
 
 	// Delete fields the user didn't fill in.
 	for k, v := range user_registration.Data {
-		v_as_string, ok := v.(string)
-		if ok && len(v_as_string) == 0 {
+		// v_as_string, ok := v.(string)
+		// if (ok && len(v_as_string) == 0) || v == nil {
+		if v == nil {
+			fmt.Printf("Deleting empty fields: %s\n", k)
 			delete(user_registration.Data, k)
+		} else {
+			// fmt.Printf("Not deleting the field, the key is: %s the value is: %s\n", k, v_as_string)
 		}
+		// if v == nil {
+		// 	fmt.Printf("Deleting empty fields, key: %s, value: %s\n", k, v)
+		// 	delete(user_registration.Data, k)
+		// }
 	}
 
-	err = db.Update("attendees", selector, &user_registration.Data)
+	err := db.Patch("attendees", selector, &user_registration.Data)
 
 	return err
 }


### PR DESCRIPTION
I added the `PatchUserRegistration` endpoint that allows the user to update only certain fields of their registration. This feature relies on the `Patch` method in `mongo_database.go` that I added in my previous pull request.

The method `toObject` in `conversions.go` is modified to omit fields that are not provided in 
 raw_data, instead of filling them up with default values. This ensures that the patch method does not overwrite fields that should be omitted with default values.

Also, tests and docs are updated for this endpoint.