### PR TITLE
Add helper code to create db queries from URL parameters

### DIFF
--- a/common/database/filter.go
+++ b/common/database/filter.go
@@ -11,7 +11,7 @@ import (
 	Returns a map for the given model, where each key is the JSON field name and
 	each value is a string representation of that field's type.
 
-	For example, a struct which holds a string Name value has types["nane"] = "string"
+	For example, a struct which holds a string Name value has types["name"] = "string"
 */
 func GetFieldTypes(model interface{}) map[string]string {
 	expected_types := make(map[string]string)

--- a/common/database/filter.go
+++ b/common/database/filter.go
@@ -1,0 +1,82 @@
+package database
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+/*
+	Returns a map for the given model, where each key is the JSON field name and
+	each value is a string representation of that field's type.
+
+	For example, a struct which holds a string Name value has types["nane"] = "string"
+*/
+func GetFieldTypes(model interface{}) map[string]string {
+	expected_types := make(map[string]string)
+
+	v := reflect.ValueOf(model).Type()
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+
+		json_name := strings.ToLower(field.Tag.Get("json"))
+		expected_types[json_name] = field.Type.Name()
+	}
+
+	return expected_types
+}
+
+/*
+	Turns a series of string URL parameters into a query for a particular data type
+	Returns a map of generated QuerySelectors
+*/
+func CreateFilterQuery(
+	parameters map[string][]string, model interface{}) (map[string]interface{}, error) {
+
+	expected_types := GetFieldTypes(model)
+
+	query := make(map[string]interface{})
+
+	for key, values := range parameters {
+		if len(values) > 1 {
+			return nil, errors.New("Multiple usage of key " + key)
+		}
+
+		key = strings.ToLower(key)
+		values := strings.Split(values[0], ",")
+
+		to_type, ok := expected_types[key]
+		if !ok {
+			return nil, errors.New("Invalid key " + key)
+		}
+
+		// We must specifically handle each data type
+		switch to_type {
+		case "string":
+			query[key] = QuerySelector{"$in": values}
+		case "int64":
+			cast_values := make([]int64, len(values))
+			for i, value := range values {
+				value_int, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				cast_values[i] = value_int
+			}
+			query[key] = QuerySelector{"$in": cast_values}
+		case "bool":
+			cast_values := make([]bool, len(values))
+			for i, value := range values {
+				value_int, err := strconv.ParseBool(value)
+				if err != nil {
+					return nil, err
+				}
+				cast_values[i] = value_int
+			}
+			query[key] = QuerySelector{"$in": cast_values}
+		}
+	}
+
+	return query, nil
+}

--- a/common/tests/filter_test.go
+++ b/common/tests/filter_test.go
@@ -43,7 +43,7 @@ type TestStruct2 struct {
 func TestFilterCasting(t *testing.T) {
 
 	params := map[string][]string{
-		"hackValue":   {"foo,bar"},
+		"hackValue":     {"foo,bar"},
 		"illinoisValue": {"55,63"},
 		"testValue":     {"true,false,true"},
 	}

--- a/common/tests/filter_test.go
+++ b/common/tests/filter_test.go
@@ -30,7 +30,28 @@ func TestFilterBasic(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(query, expected_query) {
-		t.Errorf("Wrong order.\nExpected %v\ngot %v\n", expected_query, query)
+		t.Errorf("Incorrect query.\nExpected %v\ngot %v\n", expected_query, query)
+	}
+}
+
+func TestFilterMissing(t *testing.T) {
+
+	// value2 missing
+	params := map[string][]string{
+		"value1": {"test1,test2,test3"},
+	}
+
+	expected_query := map[string]interface{}{
+		"value1": database.QuerySelector{"$in": []string{"test1", "test2", "test3"}},
+	}
+
+	query, err := database.CreateFilterQuery(params, TestStruct{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(query, expected_query) {
+		t.Errorf("Incorrect query.\nExpected %v\ngot %v\n", expected_query, query)
 	}
 }
 
@@ -60,6 +81,6 @@ func TestFilterCasting(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(query, expected_query) {
-		t.Errorf("Wrong order.\nExpected %v\ngot %v\n", expected_query, query)
+		t.Errorf("Incorrect query.\nExpected %v\ngot %v\n", expected_query, query)
 	}
 }

--- a/common/tests/filter_test.go
+++ b/common/tests/filter_test.go
@@ -43,7 +43,7 @@ type TestStruct2 struct {
 func TestFilterCasting(t *testing.T) {
 
 	params := map[string][]string{
-		"hackValueLt":   {"foo,bar"},
+		"hackValue":   {"foo,bar"},
 		"illinoisValue": {"55,63"},
 		"testValue":     {"true,false,true"},
 	}

--- a/common/tests/filter_test.go
+++ b/common/tests/filter_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/HackIllinois/api/common/database"
+)
+
+type TestStruct struct {
+	Value1 string `json:"value1"`
+	Value2 string `json:"value2"`
+}
+
+func TestFilterBasic(t *testing.T) {
+
+	params := map[string][]string{
+		"value1": {"test"},
+		"value2": {"foo,bar"},
+	}
+
+	expected_query := map[string]interface{}{
+		"value1": database.QuerySelector{"$in": []string{"test"}},
+		"value2": database.QuerySelector{"$in": []string{"foo", "bar"}},
+	}
+
+	query, err := database.CreateFilterQuery(params, TestStruct{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(query, expected_query) {
+		t.Errorf("Wrong order.\nExpected %v\ngot %v\n", expected_query, query)
+	}
+}
+
+type TestStruct2 struct {
+	Hack     string `json:"hackValue"`
+	Illinois int64  `json:"illinoisValue"`
+	Test     bool   `json:"testValue"`
+}
+
+func TestFilterCasting(t *testing.T) {
+
+	params := map[string][]string{
+		"hackValueLt":   {"foo,bar"},
+		"illinoisValue": {"55,63"},
+		"testValue":     {"true,false,true"},
+	}
+
+	expected_query := map[string]interface{}{
+		"hackvalue":     database.QuerySelector{"$in": []string{"foo", "bar"}},
+		"illinoisvalue": database.QuerySelector{"$in": []int64{55, 63}},
+		"testvalue":     database.QuerySelector{"$in": []bool{true, false, true}},
+	}
+
+	query, err := database.CreateFilterQuery(params, TestStruct2{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(query, expected_query) {
+		t.Errorf("Wrong order.\nExpected %v\ngot %v\n", expected_query, query)
+	}
+}


### PR DESCRIPTION
Our filtering endpoints (`/event/filter` and `/user/filter`) interpret all URL parameters as strings, and as such filtering on fields which hold integers (such as start times) doesn't work as expected.

This PR introduces a helper function to the `database` package which correctly casts parameters to the expected type. It does this by taking in a copy of the struct which models the table we're querying, and uses go's `reflection` package to figure out what each field's type is and what its name is in the database.

A later PR will actually switch over existing filtering endpoints to use this function, and can introduce additional functionality (pagination, range queries, sorting).

I was a bit concerned about `reflection`'s impact on performance - there might be a better way to do this, let me know if so. Below are some benchmarks which compare how `/event/filter` compares using old filtering and the new method. There's only a ~3% performance hit. 

![image](https://user-images.githubusercontent.com/10215173/69296203-3d231080-0bd1-11ea-8136-461ef43f430f.png)

Currently, this code supports `string` (unchanged), `int64`, and `bool`.