### PR TITLE
Rename numRecipients to Recipients

### DIFF
--- a/documentation/docs/reference/services/Notifications.md
+++ b/documentation/docs/reference/services/Notifications.md
@@ -119,7 +119,7 @@ Response format:
 ```
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
-	"numRecipients": 5,
+	"recipients": 5,
 	"success": 0,
 	"failure": 0,
 	"time": 1553564589
@@ -204,7 +204,7 @@ Response format:
 ```
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
-	"numRecipients": 5,
+	"recipients": 5,
 	"success": 5,
 	"failure": 0,
 	"time": 1553564589

--- a/services/notifications/models/notification_order.go
+++ b/services/notifications/models/notification_order.go
@@ -1,9 +1,9 @@
 package models
 
 type NotificationOrder struct {
-	ID            string `json:"id"`
-	NumRecipients int    `json:"numRecipients"`
-	Success       int    `json:"success"`
-	Failure       int    `json:"failure"`
-	Time          int64  `json:"time"`
+	ID         string `json:"id"`
+	Recipients int    `json:"recipients"`
+	Success    int    `json:"success"`
+	Failure    int    `json:"failure"`
+	Time       int64  `json:"time"`
 }

--- a/services/notifications/service/notifications_service.go
+++ b/services/notifications/service/notifications_service.go
@@ -447,11 +447,11 @@ func PublishNotificationToTopic(notification models.Notification) (*models.Notif
 	}
 
 	order := models.NotificationOrder{
-		ID:            notification.ID,
-		NumRecipients: len(device_arns),
-		Success:       0,
-		Failure:       0,
-		Time:          notification.Time,
+		ID:         notification.ID,
+		Recipients: len(device_arns),
+		Success:    0,
+		Failure:    0,
+		Time:       notification.Time,
 	}
 
 	err = db.Insert("orders", &order)

--- a/services/notifications/tests/notifications_test.go
+++ b/services/notifications/tests/notifications_test.go
@@ -444,11 +444,11 @@ func TestPublishNotificationToTopic(t *testing.T) {
 	}
 
 	expected_order := models.NotificationOrder{
-		ID:            "test_id2",
-		NumRecipients: 1,
-		Success:       0,
-		Failure:       0,
-		Time:          3000,
+		ID:         "test_id2",
+		Recipients: 1,
+		Success:    0,
+		Failure:    0,
+		Time:       3000,
 	}
 	if !reflect.DeepEqual(order, &expected_order) {
 		t.Errorf("Wrong order.\nExpected %v\ngot %v\n", &expected_order, order)
@@ -480,11 +480,11 @@ func TestPublishNotificationToTopic(t *testing.T) {
 	}
 
 	expected_order = models.NotificationOrder{
-		ID:            "test_id2",
-		NumRecipients: 3,
-		Success:       0,
-		Failure:       0,
-		Time:          3000,
+		ID:         "test_id2",
+		Recipients: 3,
+		Success:    0,
+		Failure:    0,
+		Time:       3000,
 	}
 
 	if !reflect.DeepEqual(order, &expected_order) {


### PR DESCRIPTION
Follow-up to comments on #269. Renames a field in the notification order struct to match up better with other fields.