### PR TITLE
Fix missing requirements for make docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ script:
     - "[ $(make fmt | wc -l) == 0 ]"
     - make all
     - make test
-    - make docs
 before_deploy:
     - make docs
     - make container TAG=$TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
     - docker
 install:
     - sudo apt-get -y install python3 python3-pip
-    - sudo pip3 install setuptools
+    - sudo pip3 install setuptools wheel
 script:
     - "[ $(make fmt | wc -l) == 0 ]"
     - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
     - docker
 install:
     - sudo apt-get -y install python3 python3-pip
+    - sudo pip3 install setuptools
 script:
     - "[ $(make fmt | wc -l) == 0 ]"
     - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
     - "[ $(make fmt | wc -l) == 0 ]"
     - make all
     - make test
+    - make docs
 before_deploy:
     - make docs
     - make container TAG=$TRAVIS_TAG


### PR DESCRIPTION
We previously didn't install `setuptools` and `wheel`, which cased some issues when running `make docs` on Travis at deploy-time.