### PR TITLE
Add projects service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 # SERVICES is the list services to test, services are located at $(REPO_ROOT)/service/<service_name>
 # GATEWAYS is the list of top level directories to test, gateways are located at $(REPO_ROOT)/<gateway_name>
 # Add new services or top level directories to test here
-SERVICES := auth user registration decision rsvp checkin upload mail event stat notifications
+SERVICES := auth user registration decision rsvp checkin upload mail event stat notifications project
 GATEWAYS := gateway common
 
 # UTILITIES is the list of utilities to build, utilities are located at $(REPO_ROOT)/utilities/<utility_name>

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -10,6 +10,7 @@
 	"EVENT_SERVICE": "http://localhost:8010",
 	"STAT_SERVICE": "http://localhost:8011",
 	"NOTIFICATIONS_SERVICE": "http://localhost:8012",
+	"PROJECT_SERVICE": "http://localhost:8013",
 
 	"GATEWAY_PORT": "8000",
 	"AUTH_PORT": ":8002",
@@ -23,6 +24,7 @@
 	"EVENT_PORT": ":8010",
 	"STAT_PORT": ":8011",
 	"NOTIFICATIONS_PORT": ":8012",
+	"PROJECT_PORT": ":8013",
 
 	"AUTH_DB_HOST": "localhost",
 	"USER_DB_HOST": "localhost",
@@ -35,6 +37,7 @@
 	"EVENT_DB_HOST": "localhost",
 	"STAT_DB_HOST": "localhost",
 	"NOTIFICATIONS_DB_HOST": "localhost",
+	"PROJECT_DB_HOST": "localhost",
 
 	"AUTH_DB_NAME": "auth",
 	"USER_DB_NAME": "user",
@@ -47,6 +50,7 @@
 	"EVENT_DB_NAME": "event",
 	"STAT_DB_NAME": "stat",
 	"NOTIFICATIONS_DB_NAME": "notifications",
+	"PROJECT_DB_NAME": "project",
 
 	"S3_REGION": "us-east-1",
 	"S3_BUCKET": "hackillinois-upload-2019",

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -10,6 +10,7 @@
 	"EVENT_SERVICE": "http://event.api.:8010",
 	"STAT_SERVICE": "http://stat.api.:8011",
 	"NOTIFICATIONS_SERVICE": "http://notifications.api.:8012",
+	"PROJECT_SERVICE": "http://notifications.api.:8013",
 
 	"GATEWAY_PORT": "8000",
 	"AUTH_PORT": ":8002",
@@ -23,6 +24,7 @@
 	"EVENT_PORT": ":8010",
 	"STAT_PORT": ":8011",
 	"NOTIFICATIONS_PORT": ":8012",
+	"PROJECT_PORT": ":8013",
 
 	"AUTH_DB_NAME": "auth",
 	"USER_DB_NAME": "user",
@@ -35,6 +37,7 @@
 	"EVENT_DB_NAME": "event",
 	"STAT_DB_NAME": "stat",
 	"NOTIFICATIONS_DB_NAME": "notifications",
+	"PROJECT_DB_NAME": "project",
 
 	"S3_REGION": "us-east-1",
 	"S3_BUCKET": "hackillinois-upload",

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -10,6 +10,7 @@
 	"EVENT_SERVICE": "http://localhost:8010",
 	"STAT_SERVICE": "http://localhost:8011",
 	"NOTIFICATIONS_SERVICE": "http://localhost:8012",
+	"PROJECT_SERVICE": "http://localhost:8013",
 
 	"GATEWAY_PORT": "8000",
 	"AUTH_PORT": ":8002",
@@ -23,6 +24,7 @@
 	"EVENT_PORT": ":8010",
 	"STAT_PORT": ":8011",
 	"NOTIFICATIONS_PORT": ":8012",
+	"PROJECT_PORT": ":8013",
 
 	"AUTH_DB_HOST": "localhost",
 	"USER_DB_HOST": "localhost",
@@ -35,6 +37,7 @@
 	"EVENT_DB_HOST": "localhost",
 	"STAT_DB_HOST": "localhost",
 	"NOTIFICATIONS_DB_HOST": "localhost",
+	"PROJECT_DB_HOST": "localhost",
 
 	"AUTH_DB_NAME": "test-auth",
 	"USER_DB_NAME": "test-user",
@@ -47,6 +50,7 @@
 	"EVENT_DB_NAME": "test-event",
 	"STAT_DB_NAME": "test-stat",
 	"NOTIFICATIONS_DB_NAME": "test-notifications",
+	"PROJECT_DB_NAME": "test-project",
 
 	"S3_REGION": "us-east-1",
 	"S3_BUCKET": "hackillinois-upload-2019",

--- a/documentation/docs/reference/services/Project.md
+++ b/documentation/docs/reference/services/Project.md
@@ -11,14 +11,11 @@ Response format:
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Project 10",
+	"description": "Example Project Description",
 	"mentors": ["Jane Doe", "John Smith"],
-	"location": {
-		"description": "Example Location",
-		"latitude": 40.1138,
-		"longitude": -88.2249
-	}
+	"room": "Siebel 1440",
 	"tags": ["BACKEND", "FRONTEND"],
-	"code": "A1"
+	"number": "23"
 }
 ```
 
@@ -34,26 +31,20 @@ Response format:
 		{
 			"id": "52fdfc072182654f163f5f0f9a621d72",
 			"name": "Example Project 10",
+			"description": "Example Project Description",
 			"mentors": ["Jane Doe", "John Smith"],
-			"location": {
-				"description": "Example Location",
-				"latitude": 40.1138,
-				"longitude": -88.2249
-			}
+			"room": "Siebel 1440",
 			"tags": ["BACKEND", "FRONTEND"],
-			"code": "A1"
+			"number": "23"
 		},
 		{
 			"id": "52fdfcab71282654f163f5f0f9a621d72",
 			"name": "Example Project 11",
+			"description": "Example Project Description",
 			"mentors": ["Ann O. Nymous", "Joe Bloggs"],
-			"location": {
-				"description": "Example Location",
-				"latitude": 77.1238,
-				"longitude": -84.3249
-			}
+			"room": "Siebel 1310",
 			"tags": ["SYSTEMS"],
-			"code": "B2"
+			"number": "33"
 		}
 	]
 }
@@ -71,26 +62,20 @@ Response format:
 		{
 			"id": "52fdfc072182654f163f5f0f9a621d72",
 			"name": "Example Project 10",
+			"description": "Example Project Description",
 			"mentors": ["Jane Doe", "John Smith"],
-			"location": {
-				"description": "Example Location",
-				"latitude": 40.1138,
-				"longitude": -88.2249
-			}
+			"room": "Siebel 1440",
 			"tags": ["BACKEND", "FRONTEND"],
-			"code": "A1"
+			"number": "23"
 		},
 		{
 			"id": "52fdfcab71282654f163f5f0f9a621d72",
 			"name": "Example Project 11",
+			"description": "Example Project Description",
 			"mentors": ["Ann O. Nymous", "Joe Bloggs"],
-			"location": {
-				"description": "Example Location",
-				"latitude": 77.1238,
-				"longitude": -84.3249
-			}
+			"room": "Siebel 1310",
 			"tags": ["SYSTEMS"],
-			"code": "B2"
+			"number": "33"
 		}
 	]
 }
@@ -105,14 +90,11 @@ Request format:
 ```
 {
 	"name": "Example Project 10",
+	"description": "Example Project Description",
 	"mentors": ["Jane Doe", "John Smith"],
-	"location": {
-		"description": "Example Location",
-		"latitude": 40.1138,
-		"longitude": -88.2249
-	}
+	"room": "Siebel 1440",
 	"tags": ["BACKEND", "FRONTEND"],
-	"code": "A1"
+	"number": "23"
 }
 ```
 
@@ -121,14 +103,11 @@ Response format:
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Project 10",
+	"description": "Example Project Description",
 	"mentors": ["Jane Doe", "John Smith"],
-	"location": {
-		"description": "Example Location",
-		"latitude": 40.1138,
-		"longitude": -88.2249
-	}
+	"room": "Siebel 1440",
 	"tags": ["BACKEND", "FRONTEND"],
-	"code": "A1"
+	"number": "23"
 }
 ```
 
@@ -142,14 +121,11 @@ Response format:
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Project 10",
+	"description": "Example Project Description",
 	"mentors": ["Jane Doe", "John Smith"],
-	"location": {
-		"description": "Example Location",
-		"latitude": 40.1138,
-		"longitude": -88.2249
-	}
+	"room": "Siebel 1440",
 	"tags": ["BACKEND", "FRONTEND"],
-	"code": "A1"
+	"number": "23"
 }
 ```
 
@@ -163,14 +139,11 @@ Request format:
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Project 10",
+	"description": "Example Project Description",
 	"mentors": ["Jane Doe", "John Smith"],
-	"location": {
-		"description": "Example Location",
-		"latitude": 40.1138,
-		"longitude": -88.2249
-	}
+	"room": "Siebel 1440",
 	"tags": ["BACKEND", "FRONTEND"],
-	"code": "A1"
+	"number": "23"
 }
 ```
 
@@ -179,13 +152,71 @@ Response format:
 {
 	"id": "52fdfc072182654f163f5f0f9a621d72",
 	"name": "Example Project 10",
+	"description": "Example Project Description",
 	"mentors": ["Jane Doe", "John Smith"],
-	"location": {
-		"description": "Example Location",
-		"latitude": 40.1138,
-		"longitude": -88.2249
-	}
+	"room": "Siebel 1440",
 	"tags": ["BACKEND", "FRONTEND"],
-	"code": "A1"
+	"number": "23"
+}
+```
+
+GET /project/favorite/
+--------------------
+
+Returns the project favorites for the current user.
+
+Response format:
+```
+{
+	"id": "github001",
+	"projects": [
+		"52fdfc072182654f163f5f0f9a621d72",
+		"34edfc072182654f163f5f0f9a621d72"
+	]
+}
+```
+
+POST /project/favorite/add/
+-------------------------
+
+Adds the given project to the favorites for the current user.
+
+Request format:
+```
+{
+	"projectId": "52fdfc072182654f163f5f0f9a621d72"
+}
+```
+
+Response format:
+```
+{
+	"id": "github001",
+	"projects": [
+		"52fdfc072182654f163f5f0f9a621d72",
+		"34dffc072182654f163f5f0f9a621d72"
+	]
+}
+```
+
+POST /project/favorite/remove/
+----------------------------
+
+Removes the given project from the favorites for the current user.
+
+Request format:
+```
+{
+	"projectId": "52fdfc072182654f163f5f0f9a621d72",
+}
+```
+
+Response format:
+```
+{
+	"id": "github001",
+	"projects": [
+		"52fdfc072182654f163f5f0f9a621d72"
+	]
 }
 ```

--- a/documentation/docs/reference/services/Project.md
+++ b/documentation/docs/reference/services/Project.md
@@ -1,0 +1,191 @@
+Project
+=====
+
+GET /project/PROJECTID/
+---------------------
+
+Returns the project with the id of `PROJECTID`.
+
+Response format:
+```
+{
+	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"name": "Example Project 10",
+	"mentors": ["Jane Doe", "John Smith"],
+	"location": {
+		"description": "Example Location",
+		"latitude": 40.1138,
+		"longitude": -88.2249
+	}
+	"tags": ["BACKEND", "FRONTEND"],
+	"code": "A1"
+}
+```
+
+GET /project/
+---------------------
+
+Returns a list of all projects.
+
+Response format:
+```
+{
+	"projects": [
+		{
+			"id": "52fdfc072182654f163f5f0f9a621d72",
+			"name": "Example Project 10",
+			"mentors": ["Jane Doe", "John Smith"],
+			"location": {
+				"description": "Example Location",
+				"latitude": 40.1138,
+				"longitude": -88.2249
+			}
+			"tags": ["BACKEND", "FRONTEND"],
+			"code": "A1"
+		},
+		{
+			"id": "52fdfcab71282654f163f5f0f9a621d72",
+			"name": "Example Project 11",
+			"mentors": ["Ann O. Nymous", "Joe Bloggs"],
+			"location": {
+				"description": "Example Location",
+				"latitude": 77.1238,
+				"longitude": -84.3249
+			}
+			"tags": ["SYSTEMS"],
+			"code": "B2"
+		}
+	]
+}
+```
+
+GET /project/filter/?key=value
+---------------------
+
+Returns all projects, filtered with the given key-value pairs.
+
+Response format:
+```
+{
+	"projects": [
+		{
+			"id": "52fdfc072182654f163f5f0f9a621d72",
+			"name": "Example Project 10",
+			"mentors": ["Jane Doe", "John Smith"],
+			"location": {
+				"description": "Example Location",
+				"latitude": 40.1138,
+				"longitude": -88.2249
+			}
+			"tags": ["BACKEND", "FRONTEND"],
+			"code": "A1"
+		},
+		{
+			"id": "52fdfcab71282654f163f5f0f9a621d72",
+			"name": "Example Project 11",
+			"mentors": ["Ann O. Nymous", "Joe Bloggs"],
+			"location": {
+				"description": "Example Location",
+				"latitude": 77.1238,
+				"longitude": -84.3249
+			}
+			"tags": ["SYSTEMS"],
+			"code": "B2"
+		}
+	]
+}
+```
+
+POST /project/
+-----------
+
+Creates a project with the requested fields. Returns the created project.
+
+Request format:
+```
+{
+	"name": "Example Project 10",
+	"mentors": ["Jane Doe", "John Smith"],
+	"location": {
+		"description": "Example Location",
+		"latitude": 40.1138,
+		"longitude": -88.2249
+	}
+	"tags": ["BACKEND", "FRONTEND"],
+	"code": "A1"
+}
+```
+
+Response format:
+```
+{
+	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"name": "Example Project 10",
+	"mentors": ["Jane Doe", "John Smith"],
+	"location": {
+		"description": "Example Location",
+		"latitude": 40.1138,
+		"longitude": -88.2249
+	}
+	"tags": ["BACKEND", "FRONTEND"],
+	"code": "A1"
+}
+```
+
+DELETE /project/PROJECTID/
+-----------
+
+Endpoint to delete a project with name `PROJECTID`.
+
+Response format:
+```
+{
+	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"name": "Example Project 10",
+	"mentors": ["Jane Doe", "John Smith"],
+	"location": {
+		"description": "Example Location",
+		"latitude": 40.1138,
+		"longitude": -88.2249
+	}
+	"tags": ["BACKEND", "FRONTEND"],
+	"code": "A1"
+}
+```
+
+PUT /project/
+----------
+
+Updates the project with the id specified in the `id` field of the request. Returns the updated project.
+
+Request format:
+```
+{
+	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"name": "Example Project 10",
+	"mentors": ["Jane Doe", "John Smith"],
+	"location": {
+		"description": "Example Location",
+		"latitude": 40.1138,
+		"longitude": -88.2249
+	}
+	"tags": ["BACKEND", "FRONTEND"],
+	"code": "A1"
+}
+```
+
+Response format:
+```
+{
+	"id": "52fdfc072182654f163f5f0f9a621d72",
+	"name": "Example Project 10",
+	"mentors": ["Jane Doe", "John Smith"],
+	"location": {
+		"description": "Example Location",
+		"latitude": 40.1138,
+		"longitude": -88.2249
+	}
+	"tags": ["BACKEND", "FRONTEND"],
+	"code": "A1"
+}
+```

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - 'Event': 'reference/services/Event.md'
       - 'Mail': 'reference/services/Mail.md'
       - 'Notifications': 'reference/services/Notifications.md'
+      - 'Project': 'reference/services/Project.md'
       - 'RSVP': 'reference/services/RSVP.md'
       - 'Registration': 'reference/services/Registration.md'
       - 'Statistics': 'reference/services/Statistics.md'

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -23,6 +23,7 @@ var MAIL_SERVICE string
 var EVENT_SERVICE string
 var STAT_SERVICE string
 var NOTIFICATIONS_SERVICE string
+var PROJECT_SERVICE string
 
 func Initialize() error {
 
@@ -99,6 +100,12 @@ func Initialize() error {
 	}
 
 	NOTIFICATIONS_SERVICE, err = cfg_loader.Get("NOTIFICATIONS_SERVICE")
+
+	if err != nil {
+		return err
+	}
+
+	PROJECT_SERVICE, err = cfg_loader.Get("PROJECT_SERVICE")
 
 	if err != nil {
 		return err

--- a/gateway/services/project.go
+++ b/gateway/services/project.go
@@ -1,0 +1,72 @@
+package services
+
+import (
+	"net/http"
+
+	"github.com/HackIllinois/api/gateway/config"
+	"github.com/HackIllinois/api/gateway/middleware"
+	"github.com/HackIllinois/api/gateway/models"
+	"github.com/arbor-dev/arbor"
+	"github.com/justinas/alice"
+)
+
+const ProjectFormat string = "JSON"
+
+var ProjectRoutes = arbor.RouteCollection{
+	arbor.Route{
+		"GetFilteredProjects",
+		"GET",
+		"/project/filter/",
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetFilteredProjects).ServeHTTP,
+	},
+	arbor.Route{
+		"GetProject",
+		"GET",
+		"/project/{name}/",
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetProject).ServeHTTP,
+	},
+	arbor.Route{
+		"DeleteProject",
+		"DELETE",
+		"/project/{name}/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(DeleteProject).ServeHTTP,
+	},
+	arbor.Route{
+		"GetAllProjects",
+		"GET",
+		"/project/",
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetProject).ServeHTTP,
+	},
+	arbor.Route{
+		"CreateProject",
+		"POST",
+		"/project/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(CreateProject).ServeHTTP,
+	},
+	arbor.Route{
+		"UpdateProject",
+		"PUT",
+		"/project/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateProject).ServeHTTP,
+	},
+}
+
+func GetProject(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+}
+
+func GetFilteredProjects(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+}
+
+func DeleteProject(w http.ResponseWriter, r *http.Request) {
+	arbor.DELETE(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+}
+
+func CreateProject(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+}
+
+func UpdateProject(w http.ResponseWriter, r *http.Request) {
+	arbor.PUT(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+}

--- a/gateway/services/project.go
+++ b/gateway/services/project.go
@@ -14,6 +14,24 @@ const ProjectFormat string = "JSON"
 
 var ProjectRoutes = arbor.RouteCollection{
 	arbor.Route{
+		"GetProjectFavorites",
+		"GET",
+		"/project/favorite/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(GetProjectFavorites).ServeHTTP,
+	},
+	arbor.Route{
+		"AddProjectFavorite",
+		"POST",
+		"/project/favorite/add/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(AddProjectFavorite).ServeHTTP,
+	},
+	arbor.Route{
+		"RemoveProjectFavorite",
+		"POST",
+		"/project/favorite/remove/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveProjectFavorite).ServeHTTP,
+	},
+	arbor.Route{
 		"GetFilteredProjects",
 		"GET",
 		"/project/filter/",
@@ -69,4 +87,16 @@ func CreateProject(w http.ResponseWriter, r *http.Request) {
 
 func UpdateProject(w http.ResponseWriter, r *http.Request) {
 	arbor.PUT(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+}
+
+func GetProjectFavorites(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+}
+
+func AddProjectFavorite(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+}
+
+func RemoveProjectFavorite(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
 }

--- a/gateway/services/services.go
+++ b/gateway/services/services.go
@@ -23,6 +23,7 @@ func Initialize() error {
 		"event":         config.EVENT_SERVICE,
 		"stat":          config.STAT_SERVICE,
 		"notifications": config.NOTIFICATIONS_SERVICE,
+		"project":       config.PROJECT_SERVICE,
 	}
 
 	return nil
@@ -63,6 +64,7 @@ func RegisterAPIs() arbor.RouteCollection {
 	Routes = append(Routes, EventRoutes...)
 	Routes = append(Routes, StatRoutes...)
 	Routes = append(Routes, NotificationsRoutes...)
+	Routes = append(Routes, ProjectRoutes...)
 	Routes = append(Routes, HealthRoutes...)
 	Routes = append(Routes, ReloadRoutes...)
 	return Routes

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/HackIllinois/api/services/event"
 	"github.com/HackIllinois/api/services/mail"
 	"github.com/HackIllinois/api/services/notifications"
+	"github.com/HackIllinois/api/services/project"
 	"github.com/HackIllinois/api/services/registration"
 	"github.com/HackIllinois/api/services/rsvp"
 	"github.com/HackIllinois/api/services/stat"
@@ -32,6 +33,7 @@ var SERVICE_ENTRYPOINTS = map[string](func()){
 	"event":         event.Entry,
 	"stat":          stat.Entry,
 	"notifications": notifications.Entry,
+	"project":       project.Entry,
 }
 
 func StartAll() {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,6 +27,7 @@ $REPO_ROOT/bin/hackillinois-api --service mail &
 $REPO_ROOT/bin/hackillinois-api --service event &
 $REPO_ROOT/bin/hackillinois-api --service stat &
 $REPO_ROOT/bin/hackillinois-api --service notifications &
+$REPO_ROOT/bin/hackillinois-api --service project &
 
 $REPO_ROOT/bin/hackillinois-api --service gateway &
 

--- a/services/project/README.md
+++ b/services/project/README.md
@@ -1,0 +1,4 @@
+Project
+=====
+
+This is the project microservice supporting hackillinois. This service allows Mentors' projects to be created, deleted, and updated.

--- a/services/project/config/config.go
+++ b/services/project/config/config.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"github.com/HackIllinois/api/common/configloader"
+	"os"
+)
+
+var PROJECT_DB_HOST string
+var PROJECT_DB_NAME string
+
+var PROJECT_PORT string
+
+func Initialize() error {
+	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
+
+	if err != nil {
+		return err
+	}
+
+	PROJECT_DB_HOST, err = cfg_loader.Get("PROJECT_DB_HOST")
+
+	if err != nil {
+		return err
+	}
+
+	PROJECT_DB_NAME, err = cfg_loader.Get("PROJECT_DB_NAME")
+
+	if err != nil {
+		return err
+	}
+
+	PROJECT_PORT, err = cfg_loader.Get("PROJECT_PORT")
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/services/project/controller/controller.go
+++ b/services/project/controller/controller.go
@@ -1,0 +1,136 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/HackIllinois/api/common/errors"
+	"github.com/HackIllinois/api/common/utils"
+	"github.com/HackIllinois/api/services/project/models"
+	"github.com/HackIllinois/api/services/project/service"
+	"github.com/gorilla/mux"
+)
+
+func SetupController(route *mux.Route) {
+	router := route.Subrouter()
+
+	router.HandleFunc("/filter/", GetFilteredProjects).Methods("GET")
+	router.HandleFunc("/{id}/", GetProject).Methods("GET")
+	router.HandleFunc("/{id}/", DeleteProject).Methods("DELETE")
+	router.HandleFunc("/", CreateProject).Methods("POST")
+	router.HandleFunc("/", UpdateProject).Methods("PUT")
+	router.HandleFunc("/", GetAllProjects).Methods("GET")
+}
+
+/*
+	Endpoint to get the project with the specified id
+*/
+func GetProject(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+
+	project, err := service.GetProject(id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch the project details."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(project)
+}
+
+/*
+	Endpoint to delete a project with the specified id.
+	It removes the project from the project trackers, and every user's tracker.
+	On successful deletion, it returns the project that was deleted.
+*/
+func DeleteProject(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+
+	project, err := service.DeleteProject(id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.InternalError(err.Error(), "Could not delete either the project, project trackers, or user trackers, or an intermediary subroutine failed."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(project)
+}
+
+/*
+	Endpoint to get all projects
+*/
+func GetAllProjects(w http.ResponseWriter, r *http.Request) {
+	project_list, err := service.GetAllProjects()
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get all projects."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(project_list)
+}
+
+/*
+	Endpoint to get projects based on filters
+*/
+func GetFilteredProjects(w http.ResponseWriter, r *http.Request) {
+	parameters := r.URL.Query()
+	project, err := service.GetFilteredProjects(parameters)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch filtered list of projects."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(project)
+}
+
+/*
+	Endpoint to create a project
+*/
+func CreateProject(w http.ResponseWriter, r *http.Request) {
+	var project models.Project
+	json.NewDecoder(r.Body).Decode(&project)
+
+	project.ID = utils.GenerateUniqueID()
+
+	err := service.CreateProject(project.ID, project)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not create new project."))
+		return
+	}
+
+	updated_project, err := service.GetProject(project.ID)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated project."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(updated_project)
+}
+
+/*
+	Endpoint to update a project
+*/
+func UpdateProject(w http.ResponseWriter, r *http.Request) {
+	var project models.Project
+	json.NewDecoder(r.Body).Decode(&project)
+
+	err := service.UpdateProject(project.ID, project)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not update the project."))
+		return
+	}
+
+	updated_project, err := service.GetProject(project.ID)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated project details."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(updated_project)
+}

--- a/services/project/main.go
+++ b/services/project/main.go
@@ -1,0 +1,40 @@
+package project
+
+import (
+	"github.com/HackIllinois/api/common/apiserver"
+	"github.com/HackIllinois/api/services/project/config"
+	"github.com/HackIllinois/api/services/project/controller"
+	"github.com/HackIllinois/api/services/project/service"
+	"github.com/gorilla/mux"
+	"log"
+)
+
+func Initialize() error {
+	err := config.Initialize()
+
+	if err != nil {
+		return err
+
+	}
+
+	err = service.Initialize()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	router := mux.NewRouter()
+	controller.SetupController(router.PathPrefix("/project"))
+
+	log.Fatal(apiserver.StartServer(config.PROJECT_PORT, router, "project", Initialize))
+}

--- a/services/project/models/project.go
+++ b/services/project/models/project.go
@@ -1,16 +1,11 @@
 package models
 
 type Project struct {
-	ID       string          `json:"id"`
-	Name     string          `json:"name"`
-	Mentors  []string        `json:"mentors"`
-	Location ProjectLocation `json:"location"`
-	Tags     []string        `json:"tags"`
-	Code     string          `json:"code"`
-}
-
-type ProjectLocation struct {
-	Description string  `json:"description"`
-	Latitude    float64 `json:"latitude"`
-	Longitude   float64 `json:"longitude"`
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Mentors     []string `json:"mentors"`
+	Room        string   `json:"room"`
+	Tags        []string `json:"tags"`
+	Number      int32    `json:"number"`
 }

--- a/services/project/models/project.go
+++ b/services/project/models/project.go
@@ -1,0 +1,16 @@
+package models
+
+type Project struct {
+	ID       string          `json:"id"`
+	Name     string          `json:"name"`
+	Mentors  []string        `json:"mentors"`
+	Location ProjectLocation `json:"location"`
+	Tags     []string        `json:"tags"`
+	Code     string          `json:"code"`
+}
+
+type ProjectLocation struct {
+	Description string  `json:"description"`
+	Latitude    float64 `json:"latitude"`
+	Longitude   float64 `json:"longitude"`
+}

--- a/services/project/models/project_favorite_modification.go
+++ b/services/project/models/project_favorite_modification.go
@@ -1,0 +1,5 @@
+package models
+
+type ProjectFavoriteModification struct {
+	ProjectID string `json:"projectId"`
+}

--- a/services/project/models/project_favorites.go
+++ b/services/project/models/project_favorites.go
@@ -1,0 +1,6 @@
+package models
+
+type ProjectFavorites struct {
+	ID       string   `json:"id"`
+	Projects []string `json:"projects"`
+}

--- a/services/project/models/project_list.go
+++ b/services/project/models/project_list.go
@@ -1,0 +1,5 @@
+package models
+
+type ProjectList struct {
+	Projects []Project `json:"projects"`
+}

--- a/services/project/service/project_service.go
+++ b/services/project/service/project_service.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/services/project/config"
+	"github.com/HackIllinois/api/services/project/models"
+	"gopkg.in/go-playground/validator.v9"
+)
+
+var validate *validator.Validate
+
+var db database.Database
+
+func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
+	var err error
+	db, err = database.InitDatabase(config.PROJECT_DB_HOST, config.PROJECT_DB_NAME)
+
+	if err != nil {
+		return err
+	}
+
+	validate = validator.New()
+
+	return nil
+}
+
+/*
+	Returns the project with the given id
+*/
+func GetProject(id string) (*models.Project, error) {
+	query := database.QuerySelector{
+		"id": id,
+	}
+
+	var project models.Project
+	err := db.FindOne("projects", query, &project)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &project, nil
+}
+
+/*
+	Deletes the project with the given id.
+	Removes the project from project trackers and every user's tracker.
+	Returns the project that was deleted.
+*/
+func DeleteProject(id string) (*models.Project, error) {
+
+	// Gets project to be able to return it later
+
+	project, err := GetProject(id)
+
+	if err != nil {
+		return nil, err
+	}
+
+	query := database.QuerySelector{
+		"id": id,
+	}
+
+	// Remove project from projects database
+
+	err = db.RemoveOne("projects", query)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return project, err
+}
+
+/*
+	Returns all the projects
+*/
+func GetAllProjects() (*models.ProjectList, error) {
+	projects := []models.Project{}
+	// nil implies there are no filters on the query, therefore everything in the "projects" collection is returned.
+	err := db.FindAll("projects", nil, &projects)
+
+	if err != nil {
+		return nil, err
+	}
+
+	project_list := models.ProjectList{
+		Projects: projects,
+	}
+
+	return &project_list, nil
+}
+
+/*
+	Returns all the projects
+*/
+func GetFilteredProjects(parameters map[string][]string) (*models.ProjectList, error) {
+	query := make(map[string]interface{})
+
+	for key, values := range parameters {
+		if len(values) > 1 {
+			return nil, errors.New("Multiple usage of key " + key)
+		}
+
+		key = strings.ToLower(key)
+		query[key] = database.QuerySelector{"$in": strings.Split(values[0], ",")}
+	}
+
+	projects := []models.Project{}
+	filtered_projects := models.ProjectList{Projects: projects}
+	err := db.FindAll("projects", query, &filtered_projects.Projects)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &filtered_projects, nil
+}
+
+/*
+	Creates a project with the given id
+*/
+func CreateProject(id string, project models.Project) error {
+	err := validate.Struct(project)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = GetProject(id)
+
+	if err != database.ErrNotFound {
+		if err != nil {
+			return err
+		}
+		return errors.New("Project already exists")
+	}
+
+	err = db.Insert("projects", &project)
+
+	return err
+}
+
+/*
+	Updates the project with the given id
+*/
+func UpdateProject(id string, project models.Project) error {
+	err := validate.Struct(project)
+
+	if err != nil {
+		return err
+	}
+
+	selector := database.QuerySelector{
+		"id": id,
+	}
+
+	err = db.Update("projects", selector, &project)
+
+	return err
+}

--- a/services/project/tests/project_test.go
+++ b/services/project/tests/project_test.go
@@ -1,0 +1,442 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/services/project/config"
+	"github.com/HackIllinois/api/services/project/models"
+	"github.com/HackIllinois/api/services/project/service"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var db database.Database
+
+func TestMain(m *testing.M) {
+	err := config.Initialize()
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+
+	}
+
+	err = service.Initialize()
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	db, err = database.InitDatabase(config.PROJECT_DB_HOST, config.PROJECT_DB_NAME)
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	return_code := m.Run()
+
+	os.Exit(return_code)
+}
+
+var TestTime = time.Now().Unix()
+
+/*
+	Initialize db with a test project
+*/
+func SetupTestDB(t *testing.T) {
+	project := models.Project{
+		ID:      "testid",
+		Name:    "testname",
+		Mentors: []string{"testmentor"},
+		Code:    "testcode",
+		Tags:    []string{"tag1", "tag2"},
+		Location: models.ProjectLocation{
+			Description: "testlocationdescription",
+			Latitude:    123.456,
+			Longitude:   123.456,
+		},
+	}
+
+	err := db.Insert("projects", &project)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+	Drop test db
+*/
+func CleanupTestDB(t *testing.T) {
+	err := db.DropDatabase()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+	Service level test for getting all projects from db
+*/
+func TestGetAllProjectsService(t *testing.T) {
+	SetupTestDB(t)
+
+	project := models.Project{
+		ID:      "testid2",
+		Name:    "testname2",
+		Mentors: []string{"testmentor2"},
+		Code:    "testcode2",
+		Tags:    []string{"tag2"},
+		Location: models.ProjectLocation{
+			Description: "testlocationdescription2",
+			Latitude:    423.456,
+			Longitude:   777.777,
+		},
+	}
+
+	err := db.Insert("projects", &project)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual_project_list, err := service.GetAllProjects()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_list := models.ProjectList{
+		Projects: []models.Project{
+			{
+				ID:      "testid",
+				Name:    "testname",
+				Mentors: []string{"testmentor"},
+				Code:    "testcode",
+				Tags:    []string{"tag1", "tag2"},
+				Location: models.ProjectLocation{
+					Description: "testlocationdescription",
+					Latitude:    123.456,
+					Longitude:   123.456,
+				},
+			},
+			{
+				ID:      "testid2",
+				Name:    "testname2",
+				Mentors: []string{"testmentor2"},
+				Code:    "testcode2",
+				Tags:    []string{"tag2"},
+				Location: models.ProjectLocation{
+					Description: "testlocationdescription2",
+					Latitude:    423.456,
+					Longitude:   777.777,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(actual_project_list, &expected_project_list) {
+		t.Errorf("Wrong project list. Expected %v, got %v", expected_project_list, actual_project_list)
+	}
+
+	db.RemoveAll("projects", nil)
+
+	actual_project_list, err = service.GetAllProjects()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_list = models.ProjectList{
+		Projects: []models.Project{},
+	}
+
+	if !reflect.DeepEqual(actual_project_list, &expected_project_list) {
+		t.Errorf("Wrong project list. Expected %v, got %v", expected_project_list, actual_project_list)
+	}
+
+	CleanupTestDB(t)
+
+}
+
+/*
+	Service level test for getting a filtered list of projects from the db
+*/
+func TestGetFilteredProjectsService(t *testing.T) {
+	SetupTestDB(t)
+
+	project := models.Project{
+		ID:      "testid2",
+		Name:    "testname2",
+		Mentors: []string{"testmentor2"},
+		Code:    "testcode2",
+		Tags:    []string{"tag2"},
+		Location: models.ProjectLocation{
+			Description: "testlocationdescription2",
+			Latitude:    423.456,
+			Longitude:   777.777,
+		},
+	}
+
+	err := db.Insert("projects", &project)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Filter to one project
+	parameters := map[string][]string{
+		"name": {"testname2"},
+	}
+	actual_project_list, err := service.GetFilteredProjects(parameters)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_list := models.ProjectList{
+		Projects: []models.Project{
+			{
+				ID:      "testid2",
+				Name:    "testname2",
+				Mentors: []string{"testmentor2"},
+				Code:    "testcode2",
+				Tags:    []string{"tag2"},
+				Location: models.ProjectLocation{
+					Description: "testlocationdescription2",
+					Latitude:    423.456,
+					Longitude:   777.777,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(actual_project_list, &expected_project_list) {
+		t.Errorf("Wrong project list. Expected %v, got %v", expected_project_list, actual_project_list)
+	}
+
+	// Filter to multiple (all) projects
+	parameters = map[string][]string{}
+	actual_project_list, err = service.GetFilteredProjects(parameters)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_list = models.ProjectList{
+		Projects: []models.Project{
+			{
+				ID:      "testid",
+				Name:    "testname",
+				Mentors: []string{"testmentor"},
+				Code:    "testcode",
+				Tags:    []string{"tag1", "tag2"},
+				Location: models.ProjectLocation{
+					Description: "testlocationdescription",
+					Latitude:    123.456,
+					Longitude:   123.456,
+				},
+			},
+			{
+				ID:      "testid2",
+				Name:    "testname2",
+				Mentors: []string{"testmentor2"},
+				Code:    "testcode2",
+				Tags:    []string{"tag2"},
+				Location: models.ProjectLocation{
+					Description: "testlocationdescription2",
+					Latitude:    423.456,
+					Longitude:   777.777,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(actual_project_list, &expected_project_list) {
+		t.Errorf("Wrong project list. Expected %v, got %v", expected_project_list, actual_project_list)
+	}
+
+	db.RemoveAll("projects", nil)
+
+	// Filter again, with no projects remaining
+	actual_project_list, err = service.GetFilteredProjects(parameters)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_list = models.ProjectList{
+		Projects: []models.Project{},
+	}
+
+	if !reflect.DeepEqual(actual_project_list, &expected_project_list) {
+		t.Errorf("Wrong project list. Expected %v, got %v", expected_project_list, actual_project_list)
+	}
+
+	CleanupTestDB(t)
+
+}
+
+/*
+	Service level test for getting project from db
+*/
+func TestGetProjectService(t *testing.T) {
+	SetupTestDB(t)
+
+	project, err := service.GetProject("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project := models.Project{
+		ID:      "testid",
+		Name:    "testname",
+		Mentors: []string{"testmentor"},
+		Code:    "testcode",
+		Tags:    []string{"tag1", "tag2"},
+		Location: models.ProjectLocation{
+			Description: "testlocationdescription",
+			Latitude:    123.456,
+			Longitude:   123.456,
+		},
+	}
+
+	if !reflect.DeepEqual(project, &expected_project) {
+		t.Errorf("Wrong project info. Expected %v, got %v", &expected_project, project)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for creating a project in the db
+*/
+func TestCreateProjectService(t *testing.T) {
+	SetupTestDB(t)
+
+	new_project := models.Project{
+		ID:      "testid2",
+		Name:    "testname2",
+		Mentors: []string{"testmentor2"},
+		Code:    "testcode2",
+		Tags:    []string{"tag2"},
+		Location: models.ProjectLocation{
+			Description: "testlocationdescription2",
+			Latitude:    423.456,
+			Longitude:   777.777,
+		},
+	}
+
+	err := service.CreateProject("testid2", new_project)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project, err := service.GetProject("testid2")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project := models.Project{
+		ID:      "testid2",
+		Name:    "testname2",
+		Mentors: []string{"testmentor2"},
+		Code:    "testcode2",
+		Tags:    []string{"tag2"},
+		Location: models.ProjectLocation{
+			Description: "testlocationdescription2",
+			Latitude:    423.456,
+			Longitude:   777.777,
+		},
+	}
+
+	if !reflect.DeepEqual(project, &expected_project) {
+		t.Errorf("Wrong user info. Expected %v, got %v", expected_project, project)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for deleting a project in the db
+*/
+func TestDeleteProjectService(t *testing.T) {
+	SetupTestDB(t)
+
+	project_id := "testid"
+
+	// Try to delete the project
+
+	_, err := service.DeleteProject(project_id)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to find the project in the projects db
+	project, err := service.GetProject(project_id)
+
+	if err == nil {
+		t.Errorf("Found project %v in projects database.", project)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for updating a project in the db
+*/
+func TestUpdateProjectService(t *testing.T) {
+	SetupTestDB(t)
+
+	project := models.Project{
+		ID:      "testid",
+		Name:    "testname2",
+		Mentors: []string{"testmentor", "testmentor2"},
+		Code:    "testcode2",
+		Tags:    []string{"tag1", "tag3"},
+		Location: models.ProjectLocation{
+			Description: "testlocationdescription2",
+			Latitude:    444.456,
+			Longitude:   123.456,
+		},
+	}
+
+	err := service.UpdateProject("testid", project)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updated_project, err := service.GetProject("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project := models.Project{
+		ID:      "testid",
+		Name:    "testname2",
+		Mentors: []string{"testmentor", "testmentor2"},
+		Code:    "testcode2",
+		Tags:    []string{"tag1", "tag3"},
+		Location: models.ProjectLocation{
+			Description: "testlocationdescription2",
+			Latitude:    444.456,
+			Longitude:   123.456,
+		},
+	}
+
+	if !reflect.DeepEqual(updated_project, &expected_project) {
+		t.Errorf("Wrong user info. Expected %v, got %v", expected_project, updated_project)
+	}
+
+	CleanupTestDB(t)
+}

--- a/services/project/tests/project_test.go
+++ b/services/project/tests/project_test.go
@@ -2,14 +2,15 @@ package tests
 
 import (
 	"fmt"
-	"github.com/HackIllinois/api/common/database"
-	"github.com/HackIllinois/api/services/project/config"
-	"github.com/HackIllinois/api/services/project/models"
-	"github.com/HackIllinois/api/services/project/service"
 	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/services/project/config"
+	"github.com/HackIllinois/api/services/project/models"
+	"github.com/HackIllinois/api/services/project/service"
 )
 
 var db database.Database
@@ -49,16 +50,13 @@ var TestTime = time.Now().Unix()
 */
 func SetupTestDB(t *testing.T) {
 	project := models.Project{
-		ID:      "testid",
-		Name:    "testname",
-		Mentors: []string{"testmentor"},
-		Code:    "testcode",
-		Tags:    []string{"tag1", "tag2"},
-		Location: models.ProjectLocation{
-			Description: "testlocationdescription",
-			Latitude:    123.456,
-			Longitude:   123.456,
-		},
+		ID:          "testid",
+		Name:        "testname",
+		Description: "testdesc",
+		Mentors:     []string{"testmentor"},
+		Number:      1,
+		Tags:        []string{"tag1", "tag2"},
+		Room:        "testroom",
 	}
 
 	err := db.Insert("projects", &project)
@@ -86,16 +84,13 @@ func TestGetAllProjectsService(t *testing.T) {
 	SetupTestDB(t)
 
 	project := models.Project{
-		ID:      "testid2",
-		Name:    "testname2",
-		Mentors: []string{"testmentor2"},
-		Code:    "testcode2",
-		Tags:    []string{"tag2"},
-		Location: models.ProjectLocation{
-			Description: "testlocationdescription2",
-			Latitude:    423.456,
-			Longitude:   777.777,
-		},
+		ID:          "testid2",
+		Name:        "testname2",
+		Description: "testdesc2",
+		Mentors:     []string{"testmentor2"},
+		Number:      2,
+		Tags:        []string{"tag2"},
+		Room:        "testroom2",
 	}
 
 	err := db.Insert("projects", &project)
@@ -113,28 +108,22 @@ func TestGetAllProjectsService(t *testing.T) {
 	expected_project_list := models.ProjectList{
 		Projects: []models.Project{
 			{
-				ID:      "testid",
-				Name:    "testname",
-				Mentors: []string{"testmentor"},
-				Code:    "testcode",
-				Tags:    []string{"tag1", "tag2"},
-				Location: models.ProjectLocation{
-					Description: "testlocationdescription",
-					Latitude:    123.456,
-					Longitude:   123.456,
-				},
+				ID:          "testid",
+				Name:        "testname",
+				Description: "testdesc",
+				Mentors:     []string{"testmentor"},
+				Number:      1,
+				Tags:        []string{"tag1", "tag2"},
+				Room:        "testroom",
 			},
 			{
-				ID:      "testid2",
-				Name:    "testname2",
-				Mentors: []string{"testmentor2"},
-				Code:    "testcode2",
-				Tags:    []string{"tag2"},
-				Location: models.ProjectLocation{
-					Description: "testlocationdescription2",
-					Latitude:    423.456,
-					Longitude:   777.777,
-				},
+				ID:          "testid2",
+				Name:        "testname2",
+				Description: "testdesc2",
+				Mentors:     []string{"testmentor2"},
+				Number:      2,
+				Tags:        []string{"tag2"},
+				Room:        "testroom2",
 			},
 		},
 	}
@@ -170,16 +159,13 @@ func TestGetFilteredProjectsService(t *testing.T) {
 	SetupTestDB(t)
 
 	project := models.Project{
-		ID:      "testid2",
-		Name:    "testname2",
-		Mentors: []string{"testmentor2"},
-		Code:    "testcode2",
-		Tags:    []string{"tag2"},
-		Location: models.ProjectLocation{
-			Description: "testlocationdescription2",
-			Latitude:    423.456,
-			Longitude:   777.777,
-		},
+		ID:          "testid2",
+		Name:        "testname2",
+		Description: "testdesc2",
+		Mentors:     []string{"testmentor2"},
+		Number:      2,
+		Tags:        []string{"tag2"},
+		Room:        "testroom2",
 	}
 
 	err := db.Insert("projects", &project)
@@ -201,16 +187,13 @@ func TestGetFilteredProjectsService(t *testing.T) {
 	expected_project_list := models.ProjectList{
 		Projects: []models.Project{
 			{
-				ID:      "testid2",
-				Name:    "testname2",
-				Mentors: []string{"testmentor2"},
-				Code:    "testcode2",
-				Tags:    []string{"tag2"},
-				Location: models.ProjectLocation{
-					Description: "testlocationdescription2",
-					Latitude:    423.456,
-					Longitude:   777.777,
-				},
+				ID:          "testid2",
+				Name:        "testname2",
+				Description: "testdesc2",
+				Mentors:     []string{"testmentor2"},
+				Number:      2,
+				Tags:        []string{"tag2"},
+				Room:        "testroom2",
 			},
 		},
 	}
@@ -230,28 +213,22 @@ func TestGetFilteredProjectsService(t *testing.T) {
 	expected_project_list = models.ProjectList{
 		Projects: []models.Project{
 			{
-				ID:      "testid",
-				Name:    "testname",
-				Mentors: []string{"testmentor"},
-				Code:    "testcode",
-				Tags:    []string{"tag1", "tag2"},
-				Location: models.ProjectLocation{
-					Description: "testlocationdescription",
-					Latitude:    123.456,
-					Longitude:   123.456,
-				},
+				ID:          "testid",
+				Name:        "testname",
+				Description: "testdesc",
+				Mentors:     []string{"testmentor"},
+				Number:      1,
+				Tags:        []string{"tag1", "tag2"},
+				Room:        "testroom",
 			},
 			{
-				ID:      "testid2",
-				Name:    "testname2",
-				Mentors: []string{"testmentor2"},
-				Code:    "testcode2",
-				Tags:    []string{"tag2"},
-				Location: models.ProjectLocation{
-					Description: "testlocationdescription2",
-					Latitude:    423.456,
-					Longitude:   777.777,
-				},
+				ID:          "testid2",
+				Name:        "testname2",
+				Description: "testdesc2",
+				Mentors:     []string{"testmentor2"},
+				Number:      2,
+				Tags:        []string{"tag2"},
+				Room:        "testroom2",
 			},
 		},
 	}
@@ -294,16 +271,13 @@ func TestGetProjectService(t *testing.T) {
 	}
 
 	expected_project := models.Project{
-		ID:      "testid",
-		Name:    "testname",
-		Mentors: []string{"testmentor"},
-		Code:    "testcode",
-		Tags:    []string{"tag1", "tag2"},
-		Location: models.ProjectLocation{
-			Description: "testlocationdescription",
-			Latitude:    123.456,
-			Longitude:   123.456,
-		},
+		ID:          "testid",
+		Name:        "testname",
+		Description: "testdesc",
+		Mentors:     []string{"testmentor"},
+		Number:      1,
+		Tags:        []string{"tag1", "tag2"},
+		Room:        "testroom",
 	}
 
 	if !reflect.DeepEqual(project, &expected_project) {
@@ -320,16 +294,13 @@ func TestCreateProjectService(t *testing.T) {
 	SetupTestDB(t)
 
 	new_project := models.Project{
-		ID:      "testid2",
-		Name:    "testname2",
-		Mentors: []string{"testmentor2"},
-		Code:    "testcode2",
-		Tags:    []string{"tag2"},
-		Location: models.ProjectLocation{
-			Description: "testlocationdescription2",
-			Latitude:    423.456,
-			Longitude:   777.777,
-		},
+		ID:          "testid2",
+		Name:        "testname2",
+		Description: "testdesc2",
+		Mentors:     []string{"testmentor2"},
+		Number:      5,
+		Tags:        []string{"tag2"},
+		Room:        "testroom2",
 	}
 
 	err := service.CreateProject("testid2", new_project)
@@ -345,16 +316,13 @@ func TestCreateProjectService(t *testing.T) {
 	}
 
 	expected_project := models.Project{
-		ID:      "testid2",
-		Name:    "testname2",
-		Mentors: []string{"testmentor2"},
-		Code:    "testcode2",
-		Tags:    []string{"tag2"},
-		Location: models.ProjectLocation{
-			Description: "testlocationdescription2",
-			Latitude:    423.456,
-			Longitude:   777.777,
-		},
+		ID:          "testid2",
+		Name:        "testname2",
+		Description: "testdesc2",
+		Mentors:     []string{"testmentor2"},
+		Number:      5,
+		Tags:        []string{"tag2"},
+		Room:        "testroom2",
 	}
 
 	if !reflect.DeepEqual(project, &expected_project) {
@@ -397,16 +365,13 @@ func TestUpdateProjectService(t *testing.T) {
 	SetupTestDB(t)
 
 	project := models.Project{
-		ID:      "testid",
-		Name:    "testname2",
-		Mentors: []string{"testmentor", "testmentor2"},
-		Code:    "testcode2",
-		Tags:    []string{"tag1", "tag3"},
-		Location: models.ProjectLocation{
-			Description: "testlocationdescription2",
-			Latitude:    444.456,
-			Longitude:   123.456,
-		},
+		ID:          "testid",
+		Name:        "testname2",
+		Description: "testdesc2",
+		Mentors:     []string{"testmentor", "testmentor2"},
+		Number:      3,
+		Tags:        []string{"tag1", "tag3"},
+		Room:        "testroom2",
 	}
 
 	err := service.UpdateProject("testid", project)
@@ -422,20 +387,107 @@ func TestUpdateProjectService(t *testing.T) {
 	}
 
 	expected_project := models.Project{
-		ID:      "testid",
-		Name:    "testname2",
-		Mentors: []string{"testmentor", "testmentor2"},
-		Code:    "testcode2",
-		Tags:    []string{"tag1", "tag3"},
-		Location: models.ProjectLocation{
-			Description: "testlocationdescription2",
-			Latitude:    444.456,
-			Longitude:   123.456,
-		},
+		ID:          "testid",
+		Name:        "testname2",
+		Description: "testdesc2",
+		Mentors:     []string{"testmentor", "testmentor2"},
+		Number:      3,
+		Tags:        []string{"tag1", "tag3"},
+		Room:        "testroom2",
 	}
 
 	if !reflect.DeepEqual(updated_project, &expected_project) {
 		t.Errorf("Wrong user info. Expected %v, got %v", expected_project, updated_project)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Tests that getting project favorites works correctly at the service level
+*/
+func TestGetProjectFavorites(t *testing.T) {
+	SetupTestDB(t)
+
+	project_favorites, err := service.GetProjectFavorites("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_favorites := models.ProjectFavorites{
+		ID:       "testid",
+		Projects: []string{},
+	}
+
+	if !reflect.DeepEqual(project_favorites, &expected_project_favorites) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", &expected_project_favorites, project_favorites)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Tests that adding project favorites works correctly at the service level
+*/
+func TestAddProjectFavorite(t *testing.T) {
+	SetupTestDB(t)
+
+	err := service.AddProjectFavorite("testid", "testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project_favorites, err := service.GetProjectFavorites("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_favorites := models.ProjectFavorites{
+		ID:       "testid",
+		Projects: []string{"testid"},
+	}
+
+	if !reflect.DeepEqual(project_favorites, &expected_project_favorites) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", &expected_project_favorites, project_favorites)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Tests that removing project favorites works correctly at the service level
+*/
+func TestRemoveProjectFavorite(t *testing.T) {
+	SetupTestDB(t)
+
+	err := service.AddProjectFavorite("testid", "testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = service.RemoveProjectFavorite("testid", "testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project_favorites, err := service.GetProjectFavorites("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_favorites := models.ProjectFavorites{
+		ID:       "testid",
+		Projects: []string{},
+	}
+
+	if !reflect.DeepEqual(project_favorites, &expected_project_favorites) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", &expected_project_favorites, project_favorites)
 	}
 
 	CleanupTestDB(t)


### PR DESCRIPTION
Addresses #267. Adds a `project` service available at /project/ that allows for basic CRUD operations for projects.

Endpoints are:
`GET /project/`: Returns a list of all projects
`POST /project/`: Creates a new project
`GET /project/PROJECTID/`: Returns information for the project with id `PROJECTID`
`GET /project/filter/?key=value`: Filters projects by given key-value pairs
`DELETE /project/PROJECTID/`: Deletes the project with id `PROJECTID`
`PUT /project/`: Updates a project with the given `id`

Also includes relevant docs/tests for each endpoint.