### PR TITLE
Replace service filtering code with common database filter query generator

### DIFF
--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/HackIllinois/api/common/database"
@@ -128,20 +127,15 @@ func GetAllEvents() (*models.EventList, error) {
 	Returns all the events
 */
 func GetFilteredEvents(parameters map[string][]string) (*models.EventList, error) {
-	query := make(map[string]interface{})
+	query, err := database.CreateFilterQuery(parameters, models.Event{})
 
-	for key, values := range parameters {
-		if len(values) > 1 {
-			return nil, errors.New("Multiple usage of key " + key)
-		}
-
-		key = strings.ToLower(key)
-		query[key] = database.QuerySelector{"$in": strings.Split(values[0], ",")}
+	if err != nil {
+		return nil, err
 	}
 
 	events := []models.Event{}
 	filtered_events := models.EventList{Events: events}
-	err := db.FindAll("events", query, &filtered_events.Events)
+	err = db.FindAll("events", query, &filtered_events.Events)
 
 	if err != nil {
 		return nil, err

--- a/services/project/models/project.go
+++ b/services/project/models/project.go
@@ -7,5 +7,5 @@ type Project struct {
 	Mentors     []string `json:"mentors"`
 	Room        string   `json:"room"`
 	Tags        []string `json:"tags"`
-	Number      int32    `json:"number"`
+	Number      int64    `json:"number"`
 }

--- a/services/project/service/project_service.go
+++ b/services/project/service/project_service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/common/utils"
@@ -104,20 +103,15 @@ func GetAllProjects() (*models.ProjectList, error) {
 	Returns all the projects
 */
 func GetFilteredProjects(parameters map[string][]string) (*models.ProjectList, error) {
-	query := make(map[string]interface{})
+	query, err := database.CreateFilterQuery(parameters, models.Project{})
 
-	for key, values := range parameters {
-		if len(values) > 1 {
-			return nil, errors.New("Multiple usage of key " + key)
-		}
-
-		key = strings.ToLower(key)
-		query[key] = database.QuerySelector{"$in": strings.Split(values[0], ",")}
+	if err != nil {
+		return nil, err
 	}
 
 	projects := []models.Project{}
 	filtered_projects := models.ProjectList{Projects: projects}
-	err := db.FindAll("projects", query, &filtered_projects.Projects)
+	err = db.FindAll("projects", query, &filtered_projects.Projects)
 
 	if err != nil {
 		return nil, err

--- a/services/project/tests/project_test.go
+++ b/services/project/tests/project_test.go
@@ -202,6 +202,34 @@ func TestGetFilteredProjectsService(t *testing.T) {
 		t.Errorf("Wrong project list. Expected %v, got %v", expected_project_list, actual_project_list)
 	}
 
+	// Filter to one project using number
+	parameters = map[string][]string{
+		"number": {"2"},
+	}
+	actual_project_list, err = service.GetFilteredProjects(parameters)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_project_list = models.ProjectList{
+		Projects: []models.Project{
+			{
+				ID:          "testid2",
+				Name:        "testname2",
+				Description: "testdesc2",
+				Mentors:     []string{"testmentor2"},
+				Number:      2,
+				Tags:        []string{"tag2"},
+				Room:        "testroom2",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(actual_project_list, &expected_project_list) {
+		t.Errorf("Wrong project list. Expected %v, got %v", expected_project_list, actual_project_list)
+	}
+
 	// Filter to multiple (all) projects
 	parameters = map[string][]string{}
 	actual_project_list, err = service.GetFilteredProjects(parameters)

--- a/services/rsvp/service/rsvp_service.go
+++ b/services/rsvp/service/rsvp_service.go
@@ -2,10 +2,10 @@ package service
 
 import (
 	"errors"
+
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/services/rsvp/config"
 	"github.com/HackIllinois/api/services/rsvp/models"
-	"strings"
 )
 
 var db database.Database
@@ -107,19 +107,14 @@ func UpdateUserRsvp(id string, rsvp models.UserRsvp) error {
 	Returns the rsvps associated with the given parameters
 */
 func GetFilteredRsvps(parameters map[string][]string) (*models.FilteredRsvps, error) {
-	query := make(map[string]interface{})
+	query, err := database.CreateFilterQuery(parameters, models.UserRsvp{})
 
-	for key, values := range parameters {
-		if len(values) > 1 {
-			return nil, errors.New("Multiple usage of key " + key)
-		}
-
-		key = strings.ToLower(key)
-		query[key] = database.QuerySelector{"$in": strings.Split(values[0], ",")}
+	if err != nil {
+		return nil, err
 	}
 
 	var filtered_rsvps models.FilteredRsvps
-	err := db.FindAll("rsvps", query, &filtered_rsvps.Rsvps)
+	err = db.FindAll("rsvps", query, &filtered_rsvps.Rsvps)
 
 	if err != nil {
 		return nil, err

--- a/services/user/service/user_service.go
+++ b/services/user/service/user_service.go
@@ -2,11 +2,11 @@ package service
 
 import (
 	"errors"
+	"net/url"
+
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/services/user/config"
 	"github.com/HackIllinois/api/services/user/models"
-	"net/url"
-	"strings"
 )
 
 var db database.Database
@@ -67,19 +67,14 @@ func SetUserInfo(id string, user_info models.UserInfo) error {
 	Returns the users associated with the given parameters
 */
 func GetFilteredUserInfo(parameters map[string][]string) (*models.FilteredUsers, error) {
-	query := make(map[string]interface{})
+	query, err := database.CreateFilterQuery(parameters, models.UserInfo{})
 
-	for key, values := range parameters {
-		if len(values) > 1 {
-			return nil, errors.New("Multiple usage of key " + key)
-		}
-
-		key = strings.ToLower(key)
-		query[key] = database.QuerySelector{"$in": strings.Split(values[0], ",")}
+	if err != nil {
+		return nil, err
 	}
 
 	var filtered_users models.FilteredUsers
-	err := db.FindAll("info", query, &filtered_users.Users)
+	err = db.FindAll("info", query, &filtered_users.Users)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Replaces the duplicated filtering code in the `decision`, `event`, `user`, `rsvp`, and `project` services with the helper code from #273. Also modifies the project model to use `int64` instead of `int32` since the helper code only supports the former.