### PR TITLE
Add support for string lists/slices to filter

### DIFF
--- a/common/database/filter.go
+++ b/common/database/filter.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+type QueryType string
+
+const (
+	LessThan    QueryType = "LessThan"
+	In          QueryType = "In"
+	GreaterThan QueryType = "GreaterThan"
+	NotIn       QueryType = "NotIn"
+)
+
 /*
 	Returns a map for the given model, where each key is the JSON field name and
 	each value is a string representation of that field's type.
@@ -27,6 +36,66 @@ func GetFieldTypes(model interface{}) map[string]string {
 	return expected_types
 }
 
+func UpdateQuerySelectorInt64(qs QuerySelector, query_type QueryType, cast_values []int64) (QuerySelector, error) {
+	switch query_type {
+	case LessThan:
+		qs["$lt"] = cast_values[0]
+	case In:
+		qs["$in"] = cast_values
+	case GreaterThan:
+		qs["$gt"] = cast_values[0]
+	case NotIn:
+		qs["$nin"] = cast_values
+	default:
+		return nil, errors.New("Invalid operation on integers")
+	}
+	return qs, nil
+}
+
+func UpdateQuerySelectorString(qs QuerySelector, query_type QueryType, cast_values []string) (QuerySelector, error) {
+	switch query_type {
+	case LessThan:
+		qs["$lt"] = cast_values[0]
+	case In:
+		qs["$in"] = cast_values
+	case GreaterThan:
+		qs["$gt"] = cast_values[0]
+	case NotIn:
+		qs["$nin"] = cast_values
+	default:
+		return nil, errors.New("Invalid operation on strings")
+	}
+	return qs, nil
+}
+
+func UpdateQuerySelectorBool(qs QuerySelector, query_type QueryType, cast_values []bool) (QuerySelector, error) {
+	switch query_type {
+	case In:
+		qs["$in"] = cast_values
+	case NotIn:
+		qs["$nin"] = cast_values
+	default:
+		return nil, errors.New("Invalid operation on booleans")
+	}
+	return qs, nil
+}
+
+func ParseQueryType(key string) (QueryType, string) {
+	query_type := In
+
+	if strings.HasSuffix(key, "Lt") {
+		key = key[0 : len(key)-2]
+		query_type = LessThan
+	} else if strings.HasSuffix(key, "Gt") {
+		key = key[0 : len(key)-2]
+		query_type = GreaterThan
+	} else if strings.HasSuffix(key, "Not") {
+		key = key[0 : len(key)-3]
+		query_type = NotIn
+	}
+	return query_type, key
+}
+
 /*
 	Turns a series of string URL parameters into a query for a particular data type
 	Returns a map of generated QuerySelectors
@@ -43,18 +112,30 @@ func CreateFilterQuery(
 			return nil, errors.New("Multiple usage of key " + key)
 		}
 
+		query_type, key := ParseQueryType(key)
 		key = strings.ToLower(key)
-		values := strings.Split(values[0], ",")
 
 		to_type, ok := expected_types[key]
 		if !ok {
 			return nil, errors.New("Invalid key " + key)
 		}
 
+		values := strings.Split(values[0], ",")
+
+		// Each query selector might have several entries
+		// ie less than 10, greater than 2, not 4
+		qs, ok := query[key].(QuerySelector)
+		if qs == nil {
+			qs = QuerySelector{}
+		}
+
+		var err error
+
 		// We must specifically handle each data type
 		switch to_type {
 		case "string":
-			query[key] = QuerySelector{"$in": values}
+			qs, err = UpdateQuerySelectorString(qs, query_type, values)
+			query[key] = qs
 		case "int64":
 			cast_values := make([]int64, len(values))
 			for i, value := range values {
@@ -64,7 +145,8 @@ func CreateFilterQuery(
 				}
 				cast_values[i] = value_int
 			}
-			query[key] = QuerySelector{"$in": cast_values}
+			qs, err = UpdateQuerySelectorInt64(qs, query_type, cast_values)
+			query[key] = qs
 		case "bool":
 			cast_values := make([]bool, len(values))
 			for i, value := range values {
@@ -74,7 +156,12 @@ func CreateFilterQuery(
 				}
 				cast_values[i] = value_int
 			}
-			query[key] = QuerySelector{"$in": cast_values}
+			qs, err = UpdateQuerySelectorBool(qs, query_type, cast_values)
+			query[key] = qs
+		}
+
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/common/database/filter.go
+++ b/common/database/filter.go
@@ -30,7 +30,7 @@ func GetFieldTypes(model interface{}) map[string]string {
 		field := v.Field(i)
 
 		json_name := strings.ToLower(field.Tag.Get("json"))
-		expected_types[json_name] = field.Type.Name()
+		expected_types[json_name] = field.Type.String()
 	}
 
 	return expected_types
@@ -79,6 +79,17 @@ func UpdateQuerySelectorBool(qs QuerySelector, query_type QueryType, cast_values
 	}
 	return qs, nil
 }
+
+func UpdateQuerySelectorStringSlice(qs QuerySelector, query_type QueryType, cast_values []string) (QuerySelector, error) {
+	switch query_type {
+	case In:
+		qs["$all"] = cast_values
+	default:
+		return nil, errors.New("Invalid operation on string slices")
+	}
+	return qs, nil
+}
+
 
 func ParseQueryType(key string) (QueryType, string) {
 	query_type := In
@@ -133,6 +144,9 @@ func CreateFilterQuery(
 
 		// We must specifically handle each data type
 		switch to_type {
+		case "[]string":
+			qs, err = UpdateQuerySelectorStringSlice(qs, query_type, values)
+			query[key] = qs
 		case "string":
 			qs, err = UpdateQuerySelectorString(qs, query_type, values)
 			query[key] = qs

--- a/common/database/filter.go
+++ b/common/database/filter.go
@@ -90,7 +90,6 @@ func UpdateQuerySelectorStringSlice(qs QuerySelector, query_type QueryType, cast
 	return qs, nil
 }
 
-
 func ParseQueryType(key string) (QueryType, string) {
 	query_type := In
 

--- a/common/tests/filter_test.go
+++ b/common/tests/filter_test.go
@@ -118,3 +118,36 @@ func TestFilterCasting(t *testing.T) {
 		t.Errorf("Expected less than operation to fail on boolean value")
 	}
 }
+
+type TestStruct3 struct {
+	Tags []string `json:"tags"`
+}
+
+func TestFilterSliceQuery(t *testing.T) {
+	params := map[string][]string{
+		"tags": {"foo,bar,baz"},
+	}
+
+	expected_query := map[string]interface{}{
+		"tags": database.QuerySelector{"$all": []string{"foo", "bar", "baz"}},
+	}
+
+	query, err := database.CreateFilterQuery(params, TestStruct3{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(query, expected_query) {
+		t.Errorf("Incorrect query.\nExpected %v\ngot %v\n", expected_query, query)
+	}
+
+	params = map[string][]string{
+		"tagsLt": {"foo"},
+	}
+
+	_, err = database.CreateFilterQuery(params, TestStruct3{})
+
+	if err == nil {
+		t.Errorf("Expected less than operation to fail on slice value")
+	}
+}


### PR DESCRIPTION
[Built on #298]

Adds support for filtering by fields which are string lists. For example, to get all projects with tags `SYSTEMS` and `PL`, you could call `/project/filter/?tags=SYSTEMS,PL`.