### PR TITLE
Add database function to find and sort matching entries

### DIFF
--- a/common/database/database.go
+++ b/common/database/database.go
@@ -8,6 +8,7 @@ type Database interface {
 	Close()
 	FindOne(collection_name string, query interface{}, result interface{}) error
 	FindAll(collection_name string, query interface{}, result interface{}) error
+	FindAllSorted(collection_name string, query interface{}, sort_fields []SortField, result interface{}) error
 	RemoveOne(collection_name string, query interface{}) error
 	RemoveAll(collection_name string, query interface{}) (*ChangeResults, error)
 	Insert(collection_name string, item interface{}) error
@@ -22,6 +23,14 @@ type Database interface {
 	An alias of a string -> interface{} map used for database queries and selectors
 */
 type QuerySelector map[string]interface{}
+
+/*
+   Represents a single field to sort by, including the name and whether the sort should be reversed
+*/
+type SortField struct {
+	Name     string
+	Reversed bool
+}
 
 /*
 	Used to store information about the changes made by a database operation

--- a/common/database/mongo_database.go
+++ b/common/database/mongo_database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"time"
 
@@ -101,6 +102,29 @@ func (db *MongoDatabase) FindAll(collection_name string, query interface{}, resu
 	collection := current_session.DB(db.name).C(collection_name)
 
 	err := collection.Find(query).All(result)
+
+	return convertMgoError(err)
+}
+
+/*
+	Find all elements matching the given query parameters
+*/
+func (db *MongoDatabase) FindAllSorted(collection_name string, query interface{}, sort_fields []SortField, result interface{}) error {
+	current_session := db.GetSession()
+	defer current_session.Close()
+
+	sort_fields_mgo := make([]string, len(sort_fields))
+	for i, field := range sort_fields {
+		if field.Reversed {
+			sort_fields_mgo[i] = fmt.Sprintf("-%s", field.Name)
+		} else {
+			sort_fields_mgo[i] = field.Name
+		}
+	}
+
+	collection := current_session.DB(db.name).C(collection_name)
+
+	err := collection.Find(query).Sort(sort_fields_mgo...).All(result)
 
 	return convertMgoError(err)
 }

--- a/common/database/mongo_database.go
+++ b/common/database/mongo_database.go
@@ -107,7 +107,8 @@ func (db *MongoDatabase) FindAll(collection_name string, query interface{}, resu
 }
 
 /*
-	Find all elements matching the given query parameters
+	Find all elements matching the given query parameters, and sorts them based on given sort fields
+        The first sort field is highest priority, each subsequent field breaks ties
 */
 func (db *MongoDatabase) FindAllSorted(collection_name string, query interface{}, sort_fields []SortField, result interface{}) error {
 	current_session := db.GetSession()


### PR DESCRIPTION
It would be nice to be able to sort database query results easily (for example, for #261). This PR adds a new function to the database interface which allows the caller to pass in a list of `SortField`s. Each `SortField` consists of a name of a field to sort on, as well as whether the sort direction for that field is reversed.

Usage would look something like the following:
```
err := db.FindAllSorted("events", nil, []database.SortField{
        {
                Name:     "startTime",
                Reversed: false,
        },
        {
                Name:     "name",
                Reversed: false,
        },
}, &events)
```

Tested locally by subbing in FindAllSorted in existing services and ensuring they work as expected. Once we have services which use this call (ie adding sort functionality to filter endpoints), we can implement more formal testing.