### PR TITLE
Add stats data for /auth/roles #287

### DIFF
--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -88,7 +88,8 @@
 		"rsvp": "http://localhost:8006/rsvp/internal/stats/",
 		"checkin": "http://localhost:8007/checkin/internal/stats/",
 		"user": "http://localhost:8003/user/internal/stats/",
-		"event": "http://localhost:8010/event/internal/stats/"
+		"event": "http://localhost:8010/event/internal/stats/",
+		"roles": "http://localhost:8002/auth/roles/stats/"
 	},
 
         "GROUP_TOPIC_MAP": {

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -89,7 +89,7 @@
 		"checkin": "http://localhost:8007/checkin/internal/stats/",
 		"user": "http://localhost:8003/user/internal/stats/",
 		"event": "http://localhost:8010/event/internal/stats/",
-		"roles": "http://localhost:8002/auth/roles/stats/"
+		"roles": "http://localhost:8002/auth/roles/internal/stats/"
 	},
 
         "GROUP_TOPIC_MAP": {

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -89,7 +89,7 @@
 		"checkin": "http://localhost:8007/checkin/internal/stats/",
 		"user": "http://localhost:8003/user/internal/stats/",
 		"event": "http://localhost:8010/event/internal/stats/",
-		"roles": "http://localhost:8002/auth/roles/internal/stats/"
+		"auth": "http://localhost:8002/auth/internal/stats/"
 	},
 
         "GROUP_TOPIC_MAP": {

--- a/services/auth/controller/controller.go
+++ b/services/auth/controller/controller.go
@@ -17,7 +17,7 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/roles/", GetCurrentUserRoles).Methods("GET")
 	router.HandleFunc("/roles/list/", GetRolesLists).Methods("GET")
 	router.HandleFunc("/roles/list/{role}/", GetUserListByRole).Methods("GET")
-	router.HandleFunc("/roles/stats/", GetStats).Methods("GET")
+	router.HandleFunc("/roles/internal/stats/", GetStats).Methods("GET")
 	router.HandleFunc("/{provider}/", Authorize).Methods("GET")
 	router.HandleFunc("/code/{provider}/", Login).Methods("POST")
 	router.HandleFunc("/roles/{id}/", GetRoles).Methods("GET")

--- a/services/auth/controller/controller.go
+++ b/services/auth/controller/controller.go
@@ -17,6 +17,7 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/roles/", GetCurrentUserRoles).Methods("GET")
 	router.HandleFunc("/roles/list/", GetRolesLists).Methods("GET")
 	router.HandleFunc("/roles/list/{role}/", GetUserListByRole).Methods("GET")
+	router.HandleFunc("/roles/stats/", GetStats).Methods("GET")
 	router.HandleFunc("/{provider}/", Authorize).Methods("GET")
 	router.HandleFunc("/code/{provider}/", Login).Methods("POST")
 	router.HandleFunc("/roles/{id}/", GetRoles).Methods("GET")
@@ -327,4 +328,18 @@ func GetUserListByRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(user_list)
+}
+
+/*
+	Endpoint to get role stats
+*/
+func GetStats(w http.ResponseWriter, r *http.Request) {
+	stats, err := service.GetStats()
+
+	if err != nil {
+		errors.WriteError(w, r, errors.InternalError(err.Error(), "Could not fetch registration service statistics."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(stats)
 }

--- a/services/auth/controller/controller.go
+++ b/services/auth/controller/controller.go
@@ -17,13 +17,13 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/roles/", GetCurrentUserRoles).Methods("GET")
 	router.HandleFunc("/roles/list/", GetRolesLists).Methods("GET")
 	router.HandleFunc("/roles/list/{role}/", GetUserListByRole).Methods("GET")
-	router.HandleFunc("/roles/internal/stats/", GetStats).Methods("GET")
 	router.HandleFunc("/{provider}/", Authorize).Methods("GET")
 	router.HandleFunc("/code/{provider}/", Login).Methods("POST")
 	router.HandleFunc("/roles/{id}/", GetRoles).Methods("GET")
 	router.HandleFunc("/roles/add/", AddRole).Methods("PUT")
 	router.HandleFunc("/roles/remove/", RemoveRole).Methods("PUT")
 	router.HandleFunc("/token/refresh/", RefreshToken).Methods("GET")
+	router.HandleFunc("/internal/stats/", GetStats).Methods("GET")
 }
 
 /*

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -189,5 +189,5 @@ func GetStats() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return stats, err
+	return stats, nil
 }

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -185,16 +185,9 @@ func GetUsersByRole(role models.Role) ([]string, error) {
 	Returns role stats
 */
 func GetStats() (map[string]interface{}, error) {
-	stats := make(map[string]interface{})
-	roles := GetValidRoles()
-	for _, role := range roles {
-		users_with_role, err := GetUsersByRole(role)
-		if err != nil {
-			return nil, err
-		}
-
-		stats[role] = map[string]int{"count": len(users_with_role)}
+	stats, err := db.GetStats("roles", []string{"roles"})
+	if err != nil {
+		return nil, err
 	}
-
-	return stats, nil
+	return stats, err
 }

--- a/services/auth/service/role_service.go
+++ b/services/auth/service/role_service.go
@@ -180,3 +180,21 @@ func GetUsersByRole(role models.Role) ([]string, error) {
 
 	return userids, nil
 }
+
+/*
+	Returns role stats
+*/
+func GetStats() (map[string]interface{}, error) {
+	stats := make(map[string]interface{})
+	roles := GetValidRoles()
+	for _, role := range roles {
+		users_with_role, err := GetUsersByRole(role)
+		if err != nil {
+			return nil, err
+		}
+
+		stats[role] = map[string]int{"count": len(users_with_role)}
+	}
+
+	return stats, nil
+}


### PR DESCRIPTION
Adds counts for each roles (User, Admin, Mentor...) to the stats, which can be accessed through `GET /stat/`.
Example response format:
```json
"auth": {
        "count": 5,
        "roles": {
            "Admin": 10,
            "Applicant": 850,
            "Attendee": 800,
            "Mentor": 40,
            "Staff": 50,
            "Sponsor": 50,
            "User": 1000
        }
}
```
