### PR TITLE
Allow events to be created without a sponsor

### DIFF
--- a/services/event/models/event.go
+++ b/services/event/models/event.go
@@ -7,7 +7,7 @@ type Event struct {
 	StartTime   int64           `json:"startTime"           validate:"required"`
 	EndTime     int64           `json:"endTime"             validate:"required"`
 	Locations   []EventLocation `json:"locations"           validate:"required,dive,required"`
-	Sponsor     string          `json:"sponsor"             validate:"required"`
+	Sponsor     string          `json:"sponsor"`
 	EventType   string          `json:"eventType"           validate:"required,oneof=MEAL SPEAKER WORKSHOP MINIEVENT OTHER"`
 }
 


### PR DESCRIPTION
The `sponsor` field will remain empty if not provided. Resolves #295.