### PR TITLE
Add tags field to event locations

### DIFF
--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -17,6 +17,7 @@ Response format:
 	"locations": [
 		{
 			"description": "Example Location",
+			"tags": ["SIEBEL0", "ECEB1"],
 			"latitude": 40.1138,
 			"longitude": -88.2249
 		}
@@ -44,6 +45,7 @@ Response format:
 			"locations": [
 				{
 					"description": "Example Location",
+					"tags": ["SIEBEL0", "ECEB1"],
 					"latitude": 40.1138,
 					"longitude": -88.2249
 				}
@@ -60,6 +62,7 @@ Response format:
 			"locations": [
 				{
 					"description": "Example Location",
+					"tags": ["SIEBEL3"],
 					"latitude": 40.1138,
 					"longitude": -88.2249
 				}
@@ -89,6 +92,7 @@ Response format:
             "locations": [
                 {
                     "description": "Example Location",
+					"tags": ["SIEBEL0", "ECEB1"],
                     "latitude": 40.1138,
                     "longitude": -88.2249
                 }
@@ -105,6 +109,7 @@ Response format:
             "locations": [
                 {
                     "description": "Example Location",
+					"tags": ["SIEBEL3"],
                     "latitude": 40.1138,
                     "longitude": -88.2249
                 }
@@ -133,6 +138,7 @@ Request format:
 	"locations": [
 		{
 			"description": "Example Location",
+			"tags": ["SIEBEL0", "ECEB1"],
 			"latitude": 40.1138,
 			"longitude": -88.2249
 		}
@@ -151,6 +157,7 @@ Response format:
 	"locations": [
 		{
 			"description": "Example Location",
+			"tags": ["SIEBEL0", "ECEB1"],
 			"latitude": 40.1138,
 			"longitude": -88.2249
 		}
@@ -176,6 +183,7 @@ Response format:
 	"locations": [
 		{
 			"description": "Example Location",
+			"tags": ["SIEBEL0", "ECEB1"],
 			"latitude": 40.1138,
 			"longitude": -88.2249
 		}
@@ -203,6 +211,7 @@ Request format:
 	"locations": [
 		{
 			"description": "Example Location",
+			"tags": ["SIEBEL0", "ECEB1"],
 			"latitude": 40.1138,
 			"longitude": -88.2249
 		}
@@ -221,6 +230,7 @@ Response format:
 	"locations": [
 		{
 			"description": "Example Location",
+			"tags": ["SIEBEL0", "ECEB1"],
 			"latitude": 40.1138,
 			"longitude": -88.2249
 		}

--- a/services/event/models/event.go
+++ b/services/event/models/event.go
@@ -13,7 +13,7 @@ type Event struct {
 
 type EventLocation struct {
 	Description string   `json:"description" validate:"required"`
-	Tags        []string `json:"tags"        validate:"required,dive,oneof=SIEBEL0 SIEBEL1 SIEBEL2 SIEBEL3 SIEBEL4 ECEB1 ECEB2 ECEB3 ECEB4 ECEB5 KENNEY DCL"`
+	Tags        []string `json:"tags"        validate:"required"`
 	Latitude    float64  `json:"latitude"    validate:"required"`
 	Longitude   float64  `json:"longitude"   validate:"required"`
 }

--- a/services/event/models/event.go
+++ b/services/event/models/event.go
@@ -12,7 +12,8 @@ type Event struct {
 }
 
 type EventLocation struct {
-	Description string  `json:"description" validate:"required"`
-	Latitude    float64 `json:"latitude"    validate:"required"`
-	Longitude   float64 `json:"longitude"   validate:"required"`
+	Description string   `json:"description" validate:"required"`
+	Tags        []string `json:"tags"        validate:"required,dive,oneof=SIEBEL0 SIEBEL1 SIEBEL2 SIEBEL3 SIEBEL4 ECEB1 ECEB2 ECEB3 ECEB4 ECEB5 KENNEY DCL"`
+	Latitude    float64  `json:"latitude"    validate:"required"`
+	Longitude   float64  `json:"longitude"   validate:"required"`
 }

--- a/services/event/tests/event_test.go
+++ b/services/event/tests/event_test.go
@@ -2,15 +2,16 @@ package tests
 
 import (
 	"fmt"
-	"github.com/HackIllinois/api/common/database"
-	"github.com/HackIllinois/api/services/event/config"
-	"github.com/HackIllinois/api/services/event/models"
-	"github.com/HackIllinois/api/services/event/service"
 	"math"
 	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/services/event/config"
+	"github.com/HackIllinois/api/services/event/models"
+	"github.com/HackIllinois/api/services/event/service"
 )
 
 var db database.Database
@@ -60,6 +61,7 @@ func SetupTestDB(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
+				Tags:        []string{"ECEB1"},
 				Latitude:    123.456,
 				Longitude:   123.456,
 			},
@@ -112,6 +114,7 @@ func TestGetAllEventsService(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
+				Tags:        []string{"SIEBEL0", "ECEB1"},
 				Latitude:    123.456,
 				Longitude:   123.456,
 			},
@@ -143,8 +146,10 @@ func TestGetAllEventsService(t *testing.T) {
 				Locations: []models.EventLocation{
 					{
 						Description: "testlocationdescription",
-						Latitude:    123.456,
-						Longitude:   123.456,
+						Tags:        []string{"ECEB1"},
+
+						Latitude:  123.456,
+						Longitude: 123.456,
 					},
 				},
 			},
@@ -159,8 +164,10 @@ func TestGetAllEventsService(t *testing.T) {
 				Locations: []models.EventLocation{
 					{
 						Description: "testlocationdescription",
-						Latitude:    123.456,
-						Longitude:   123.456,
+						Tags:        []string{"SIEBEL0", "ECEB1"},
+
+						Latitude:  123.456,
+						Longitude: 123.456,
 					},
 				},
 			},
@@ -208,8 +215,10 @@ func TestGetFilteredEventsService(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
-				Latitude:    123.456,
-				Longitude:   123.456,
+				Tags:        []string{"SIEBEL0", "ECEB1"},
+
+				Latitude:  123.456,
+				Longitude: 123.456,
 			},
 		},
 	}
@@ -243,8 +252,10 @@ func TestGetFilteredEventsService(t *testing.T) {
 				Locations: []models.EventLocation{
 					{
 						Description: "testlocationdescription",
-						Latitude:    123.456,
-						Longitude:   123.456,
+						Tags:        []string{"SIEBEL0", "ECEB1"},
+
+						Latitude:  123.456,
+						Longitude: 123.456,
 					},
 				},
 			},
@@ -278,8 +289,10 @@ func TestGetFilteredEventsService(t *testing.T) {
 				Locations: []models.EventLocation{
 					{
 						Description: "testlocationdescription",
-						Latitude:    123.456,
-						Longitude:   123.456,
+						Tags:        []string{"ECEB1"},
+
+						Latitude:  123.456,
+						Longitude: 123.456,
 					},
 				},
 			},
@@ -294,8 +307,10 @@ func TestGetFilteredEventsService(t *testing.T) {
 				Locations: []models.EventLocation{
 					{
 						Description: "testlocationdescription",
-						Latitude:    123.456,
-						Longitude:   123.456,
+						Tags:        []string{"SIEBEL0", "ECEB1"},
+
+						Latitude:  123.456,
+						Longitude: 123.456,
 					},
 				},
 			},
@@ -350,6 +365,7 @@ func TestGetEventService(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
+				Tags:        []string{"ECEB1"},
 				Latitude:    123.456,
 				Longitude:   123.456,
 			},
@@ -380,6 +396,7 @@ func TestCreateEventService(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
+				Tags:        []string{"SIEBEL0", "ECEB1"},
 				Latitude:    123.456,
 				Longitude:   123.456,
 			},
@@ -409,6 +426,7 @@ func TestCreateEventService(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
+				Tags:        []string{"SIEBEL0", "ECEB1"},
 				Latitude:    123.456,
 				Longitude:   123.456,
 			},
@@ -504,6 +522,7 @@ func TestUpdateEventService(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
+				Tags:        []string{"SIEBEL3", "ECEB2"},
 				Latitude:    123.456,
 				Longitude:   123.456,
 			},
@@ -533,6 +552,7 @@ func TestUpdateEventService(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
+				Tags:        []string{"SIEBEL3", "ECEB2"},
 				Latitude:    123.456,
 				Longitude:   123.456,
 			},
@@ -662,6 +682,7 @@ func TestIsEventActive(t *testing.T) {
 		Locations: []models.EventLocation{
 			{
 				Description: "testlocationdescription",
+				Tags:        []string{"SIEBEL3", "ECEB2"},
 				Latitude:    123.456,
 				Longitude:   123.456,
 			},


### PR DESCRIPTION
Adds a `tags` field to event locations, which contains information about building/floor which can be used to display the proper map for each event.

Tags can be any of the following: `SIEBEL0`, `SIEBEL1`, `SIEBEL2`, `SIEBEL3`, `SIEBEL4`, `ECEB1`, `ECEB2`, `ECEB3`, `ECEB4`, `ECEB5`, `KENNEY`, `DCL`

Some of these might be unnecessary, unsure how much of each building we host events in