### PR TITLE
Update checkin failure error messages

### DIFF
--- a/services/checkin/controller/controller.go
+++ b/services/checkin/controller/controller.go
@@ -64,7 +64,11 @@ func CreateUserCheckin(w http.ResponseWriter, r *http.Request) {
 	can_user_checkin, err := service.CanUserCheckin(user_checkin.ID, user_checkin.Override)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.InternalError(err.Error(), "Unable to determine user's check-in permissions."))
+		if err.Error() == "User is not registered." {
+			errors.WriteError(w, r, errors.AttributeMismatchError("User is not registered.", "User is not registered."))
+		} else {
+			errors.WriteError(w, r, errors.InternalError(err.Error(), "Unable to determine user's check-in permissions."))
+		}
 		return
 	}
 

--- a/services/checkin/controller/controller.go
+++ b/services/checkin/controller/controller.go
@@ -86,7 +86,7 @@ func CreateUserCheckin(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		if err.Error() == "Checkin already exists" {
-			errors.WriteError(w, r, errors.AttributeMismatchError("", "User has already checked in."))
+			errors.WriteError(w, r, errors.AttributeMismatchError("User has already checked in.", "User has already checked in."))
 		} else {
 			errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not create user check-in."))
 		}

--- a/services/checkin/controller/controller.go
+++ b/services/checkin/controller/controller.go
@@ -2,11 +2,12 @@ package controller
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/HackIllinois/api/common/errors"
 	"github.com/HackIllinois/api/services/checkin/models"
 	"github.com/HackIllinois/api/services/checkin/service"
 	"github.com/gorilla/mux"
-	"net/http"
 )
 
 func SetupController(route *mux.Route) {
@@ -68,7 +69,7 @@ func CreateUserCheckin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !can_user_checkin {
-		errors.WriteError(w, r, errors.AttributeMismatchError("Reasons for not being able to check-in include: no RSVP, no staff override (in case of no RSVP), or check-ins are not allowed at this time.", "Attendee is not allowed to check-in."))
+		errors.WriteError(w, r, errors.AttributeMismatchError("Reasons for not being able to check-in include: no RSVP, no staff override (in case of no RSVP), or check-ins are not allowed at this time.", "Attendee has not RSVPed."))
 		return
 	}
 
@@ -84,7 +85,11 @@ func CreateUserCheckin(w http.ResponseWriter, r *http.Request) {
 	err = service.CreateUserCheckin(user_checkin.ID, user_checkin)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not create user check-in."))
+		if err.Error() == "Checkin already exists" {
+			errors.WriteError(w, r, errors.AttributeMismatchError("", "User has already checked in."))
+		} else {
+			errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not create user check-in."))
+		}
 		return
 	}
 

--- a/services/event/controller/controller.go
+++ b/services/event/controller/controller.go
@@ -199,7 +199,13 @@ func MarkUserAsAttendingEvent(w http.ResponseWriter, r *http.Request) {
 	err = service.MarkUserAsAttendingEvent(tracking_info.EventID, tracking_info.UserID)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.InternalError(err.Error(), "Could not mark user as attending the event."))
+		if err.Error() == "User has already been marked as attending" {
+			errors.WriteError(w, r, errors.AttributeMismatchError("User has already checked in.", "User has already checked in."))
+		} else if err.Error() == "People cannot be checked-in for the event at this time." {
+			errors.WriteError(w, r, errors.AttributeMismatchError("Event is not open for check-in at this time.", "Event is not open for check-in at this time."))
+		} else {
+			errors.WriteError(w, r, errors.InternalError(err.Error(), "Could not mark user as attending the event."))
+		}
 		return
 	}
 


### PR DESCRIPTION
Updates checkin failure error messages to be more descriptive. Now, for both HackIllinois check-in and event check-in, attempts to check-in a user with an invalid state (ie, not RSVPed) will result in an `AttributeMismatchError` with a more clear error message.