### PR TITLE
Add config option to disable time window for event checkin

### DIFF
--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -82,6 +82,8 @@
 
 	"DECISION_EXPIRATION_HOURS": "48",
 
+	"EVENT_CHECKIN_TIME_RESTRICTED": "true",
+
 	"STAT_ENDPOINTS": {
 		"registration": "http://localhost:8004/registration/internal/stats/",
 		"decision": "http://localhost:8005/decision/internal/stats/",

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -56,6 +56,8 @@
 
 	"DECISION_EXPIRATION_HOURS": "48",
 
+	"EVENT_CHECKIN_TIME_RESTRICTED": "true",
+
 	"STAT_ENDPOINTS": {
 		"registration": "http://registration.api.:8004/registration/internal/stats/",
 		"decision": "http://decision.api.:8005/decision/internal/stats/",

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -82,6 +82,8 @@
 
 	"DECISION_EXPIRATION_HOURS": "48",
 
+	"EVENT_CHECKIN_TIME_RESTRICTED": "true",
+
 	"STAT_ENDPOINTS": {
 		"registration": "http://localhost:8004/registration/internal/stats/"
 	},

--- a/services/event/config/config.go
+++ b/services/event/config/config.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/HackIllinois/api/common/configloader"
 	"os"
+
+	"github.com/HackIllinois/api/common/configloader"
 )
 
 var EVENT_DB_HOST string
@@ -11,6 +12,8 @@ var EVENT_DB_NAME string
 var EVENT_PORT string
 
 var CHECKIN_SERVICE string
+
+var EVENT_CHECKIN_TIME_RESTRICTED bool
 
 func Initialize() error {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
@@ -42,6 +45,14 @@ func Initialize() error {
 	if err != nil {
 		return err
 	}
+
+	checkin_time_res_str, err := cfg_loader.Get("EVENT_CHECKIN_TIME_RESTRICTED")
+
+	if err != nil {
+		return err
+	}
+
+	EVENT_CHECKIN_TIME_RESTRICTED = (checkin_time_res_str == "true")
 
 	return nil
 }

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -275,14 +275,16 @@ func MarkUserAsAttendingEvent(event_id string, user_id string) error {
 		return errors.New("User has already been marked as attending")
 	}
 
-	is_event_active, err := IsEventActive(event_id)
+	if config.EVENT_CHECKIN_TIME_RESTRICTED {
+		is_event_active, err := IsEventActive(event_id)
 
-	if err != nil {
-		return err
-	}
+		if err != nil {
+			return err
+		}
 
-	if !is_event_active {
-		return errors.New("People cannot be checked-in for the event at this time.")
+		if !is_event_active {
+			return errors.New("People cannot be checked-in for the event at this time.")
+		}
 	}
 
 	event_selector := database.QuerySelector{


### PR DESCRIPTION
Adds a config option to selectively disable the [start time - 15 mins, end time] checkin window for events. Meals may run late and other unexpected issues might occur, so we may prefer to disable this functionality.