### PR TITLE
Add blobstore role with access to POST and PUT

### DIFF
--- a/gateway/models/roles.go
+++ b/gateway/models/roles.go
@@ -9,4 +9,5 @@ const (
 	ApplicantRole = "Applicant"
 	AttendeeRole  = "Attendee"
 	UserRole      = "User"
+	BlobstoreRole = "Blobstore"
 )

--- a/gateway/services/upload.go
+++ b/gateway/services/upload.go
@@ -53,13 +53,13 @@ var UploadRoutes = arbor.RouteCollection{
 		"CreateBlob",
 		"POST",
 		"/upload/blobstore/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(CreateBlob).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole, models.BlobstoreRole}), middleware.IdentificationMiddleware).ThenFunc(CreateBlob).ServeHTTP,
 	},
 	arbor.Route{
 		"UpdateBlob",
 		"PUT",
 		"/upload/blobstore/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateBlob).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole, models.BlobstoreRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateBlob).ServeHTTP,
 	},
 	arbor.Route{
 		"GetBlob",

--- a/services/auth/models/roles.go
+++ b/services/auth/models/roles.go
@@ -10,6 +10,7 @@ const (
 	AttendeeRole  = "Attendee"
 	UserRole      = "User"
 	SponsorRole   = "Sponsor"
+	BlobstoreRole = "Blobstore"
 )
 
-var Roles []Role = []Role{AdminRole, StaffRole, MentorRole, ApplicantRole, AttendeeRole, UserRole, SponsorRole}
+var Roles []Role = []Role{AdminRole, StaffRole, MentorRole, ApplicantRole, AttendeeRole, UserRole, SponsorRole, BlobstoreRole}


### PR DESCRIPTION
JWT containing role string "Blobstore" should now have access to endpoints POST/PUT /upload/blobstore/ 

