### PR TITLE
Remove All Favorited Events Endpoint

### DIFF
--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -361,3 +361,15 @@ Response format:
 	]
 }
 ```
+
+DELETE /event/favorite/remove/
+----------------------------
+
+Removes all of the events from the favorites for the current user.
+
+Response format:
+```
+{
+	"id": "github001",
+	"events": []
+}

--- a/gateway/services/event.go
+++ b/gateway/services/event.go
@@ -32,6 +32,12 @@ var EventRoutes = arbor.RouteCollection{
 		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveEventFavorite).ServeHTTP,
 	},
 	arbor.Route{
+		"RemoveAllEventFavorites",
+		"DELETE",
+		"/event/favorite/remove/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveAllEventFavorites).ServeHTTP,
+	},
+	arbor.Route{
 		"MarkUserAsAttendingEvent",
 		"POST",
 		"/event/track/",
@@ -129,4 +135,8 @@ func AddEventFavorite(w http.ResponseWriter, r *http.Request) {
 
 func RemoveEventFavorite(w http.ResponseWriter, r *http.Request) {
 	arbor.POST(w, config.EVENT_SERVICE+r.URL.String(), EventFormat, "", r)
+}
+
+func RemoveAllEventFavorites(w http.ResponseWriter, r *http.Request) {
+	arbor.DELETE(w, config.EVENT_SERVICE+r.URL.String(), EventFormat, "", r)
 }

--- a/services/event/controller/controller.go
+++ b/services/event/controller/controller.go
@@ -17,6 +17,7 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/favorite/", GetEventFavorites).Methods("GET")
 	router.HandleFunc("/favorite/add/", AddEventFavorite).Methods("POST")
 	router.HandleFunc("/favorite/remove/", RemoveEventFavorite).Methods("POST")
+	router.HandleFunc("/favorite/remove/", RemoveAllEventFavorites).Methods("DELETE")
 
 	router.HandleFunc("/filter/", GetFilteredEvents).Methods("GET")
 	router.HandleFunc("/{id}/", GetEvent).Methods("GET")
@@ -286,6 +287,29 @@ func RemoveEventFavorite(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not remove an event favorite for the current user."))
+		return
+	}
+
+	favorites, err := service.GetEventFavorites(id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch updated event favourites for the user (post-removal)."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(favorites)
+}
+
+/*
+	Endpoint to remove all of the event favorites for the current user
+*/
+func RemoveAllEventFavorites(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+
+	err := service.RemoveAllEventFavorites(id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not remove all event favorites for the current user."))
 		return
 	}
 

--- a/services/event/controller/controller.go
+++ b/services/event/controller/controller.go
@@ -241,7 +241,7 @@ func GetEventFavorites(w http.ResponseWriter, r *http.Request) {
 	favorites, err := service.GetEventFavorites(id)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get user's event favourites."))
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get user's event favorites."))
 		return
 	}
 
@@ -293,7 +293,7 @@ func RemoveEventFavorite(w http.ResponseWriter, r *http.Request) {
 	favorites, err := service.GetEventFavorites(id)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch updated event favourites for the user (post-removal)."))
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch updated event favorites for the user (post-removal)."))
 		return
 	}
 
@@ -316,7 +316,7 @@ func RemoveAllEventFavorites(w http.ResponseWriter, r *http.Request) {
 	favorites, err := service.GetEventFavorites(id)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch updated event favourites for the user (post-removal)."))
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch updated event favorites for the user (post-removal)."))
 		return
 	}
 

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -416,7 +416,7 @@ func AddEventFavorite(id string, event string) error {
 }
 
 /*
-	Removes the given event to the favorites for the user with the given id
+	Removes the given event from the favorites for the user with the given id
 */
 func RemoveEventFavorite(id string, event string) error {
 	selector := database.QuerySelector{
@@ -437,6 +437,21 @@ func RemoveEventFavorite(id string, event string) error {
 
 	err = db.Update("favorites", selector, event_favorites)
 
+	return err
+}
+
+/*
+	Removes all of the favorite events from the user with the given id
+*/
+func RemoveAllEventFavorites(id string) error {
+	selector := database.QuerySelector{
+		"id": id,
+	}
+
+	_, err := db.RemoveAll("favorites", selector)
+	if err != nil {
+		return errors.New("Failed to delete all of the user's favorite events.")
+	}
 	return err
 }
 

--- a/services/project/controller/controller.go
+++ b/services/project/controller/controller.go
@@ -35,7 +35,7 @@ func GetProjectFavorites(w http.ResponseWriter, r *http.Request) {
 	favorites, err := service.GetProjectFavorites(id)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get user's project favourites."))
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get user's project favorites."))
 		return
 	}
 
@@ -87,7 +87,7 @@ func RemoveProjectFavorite(w http.ResponseWriter, r *http.Request) {
 	favorites, err := service.GetProjectFavorites(id)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch updated project favourites for the user (post-removal)."))
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not fetch updated project favorites for the user (post-removal)."))
 		return
 	}
 


### PR DESCRIPTION
Adds a new method to an existing endpoint, DELETE /event/favorite/remove, which removes all of the user's favorited events.

- Added /event/favorite/remove endpoint, accessed through DELETE method
- Wrote a test for removing all of a user's favorite events
- Changed mixed spelling throughout codebase of "favourite" to "favorite"
- Added this new endpoint to the services documentation

