### PR TITLE
Profile-Service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 # SERVICES is the list services to test, services are located at $(REPO_ROOT)/service/<service_name>
 # GATEWAYS is the list of top level directories to test, gateways are located at $(REPO_ROOT)/<gateway_name>
 # Add new services or top level directories to test here
-SERVICES := auth user registration decision rsvp checkin upload mail event stat notifications project
+SERVICES := auth user registration decision rsvp checkin upload mail event stat notifications project profile
 GATEWAYS := gateway common
 
 # UTILITIES is the list of utilities to build, utilities are located at $(REPO_ROOT)/utilities/<utility_name>

--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -11,6 +11,7 @@
 	"STAT_SERVICE": "http://localhost:8011",
 	"NOTIFICATIONS_SERVICE": "http://localhost:8012",
 	"PROJECT_SERVICE": "http://localhost:8013",
+	"PROFILE_SERVICE": "http://localhost:8014",
 
 	"GATEWAY_PORT": "8000",
 	"AUTH_PORT": ":8002",
@@ -25,6 +26,7 @@
 	"STAT_PORT": ":8011",
 	"NOTIFICATIONS_PORT": ":8012",
 	"PROJECT_PORT": ":8013",
+	"PROFILE_PORT": ":8014",
 
 	"AUTH_DB_HOST": "localhost",
 	"USER_DB_HOST": "localhost",
@@ -38,6 +40,7 @@
 	"STAT_DB_HOST": "localhost",
 	"NOTIFICATIONS_DB_HOST": "localhost",
 	"PROJECT_DB_HOST": "localhost",
+	"PROFILE_DB_HOST": "localhost",
 
 	"AUTH_DB_NAME": "auth",
 	"USER_DB_NAME": "user",
@@ -51,6 +54,7 @@
 	"STAT_DB_NAME": "stat",
 	"NOTIFICATIONS_DB_NAME": "notifications",
 	"PROJECT_DB_NAME": "project",
+	"PROFILE_DB_NAME": "profile",
 
 	"S3_REGION": "us-east-1",
 	"S3_BUCKET": "hackillinois-upload-2019",

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -11,6 +11,7 @@
 	"STAT_SERVICE": "http://localhost:8011",
 	"NOTIFICATIONS_SERVICE": "http://localhost:8012",
 	"PROJECT_SERVICE": "http://localhost:8013",
+	"PROFILE_SERVICE": "http://localhost:8014",
 
 	"GATEWAY_PORT": "8000",
 	"AUTH_PORT": ":8002",
@@ -25,6 +26,7 @@
 	"STAT_PORT": ":8011",
 	"NOTIFICATIONS_PORT": ":8012",
 	"PROJECT_PORT": ":8013",
+	"PROFILE_PORT": ":8014",
 
 	"AUTH_DB_HOST": "localhost",
 	"USER_DB_HOST": "localhost",
@@ -38,6 +40,7 @@
 	"STAT_DB_HOST": "localhost",
 	"NOTIFICATIONS_DB_HOST": "localhost",
 	"PROJECT_DB_HOST": "localhost",
+	"PROFILE_DB_HOST": "localhost",
 
 	"AUTH_DB_NAME": "test-auth",
 	"USER_DB_NAME": "test-user",
@@ -51,6 +54,7 @@
 	"STAT_DB_NAME": "test-stat",
 	"NOTIFICATIONS_DB_NAME": "test-notifications",
 	"PROJECT_DB_NAME": "test-project",
+	"PROFILE_DB_NAME": "test-profile",
 
 	"S3_REGION": "us-east-1",
 	"S3_BUCKET": "hackillinois-upload-2019",

--- a/container/env.template
+++ b/container/env.template
@@ -21,6 +21,8 @@ MAIL_DB_HOST=
 EVENT_DB_HOST=
 STAT_DB_HOST=
 NOTIFICATIONS_DB_HOST=
+PROJECT_DB_HOST=
+PROFILE_DB_HOST=
 
 # Set the oauth client id and secret for your GitHub, Google, and Linkedin applications
 GITHUB_CLIENT_ID=

--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -16,10 +16,45 @@ Response format:
     "github": "JSmith",
     "linkedin": "john-smith",
     "interests": [
-        "python",
-        "deepLearning"
+        "deep learning",
+        "python"
     ]
 }
+```
+
+GET /profile/list/
+-------------------------
+
+Returns all profiles that are in the database.
+
+Response format:
+```
+{
+    profiles: [
+        {
+            "id": "github0000001"
+            "name": "John Smith",
+            "email": "john@gmail.com",
+            "github": "JSmith",
+            "linkedin": "john-smith",
+            "interests": [
+                "deep learning",
+                "ice skating",
+                "python"
+            ]
+        },
+        {
+            "id": "github0000002"
+            "name": "Smith John",
+            "email": "smith@gmail.com",
+            "github": "SJohn",
+            "linkedin": "smith-john",
+            "interests": [
+                "classical music",
+                "deep learning",
+                "python"
+            ]
+        }
 ```
 
 
@@ -51,8 +86,8 @@ Response format:
     "github": "JSmith",
     "linkedin": "john-smith",
     "interests": [
-        "python",
-        "deepLearning"
+        "deep learning",
+        "python"
     ]
 }
 ```
@@ -71,8 +106,8 @@ Request format:
     "github": "JSmith",
     "linkedin": "john-smith",
     "interests": [
-        "python",
-        "deepLearning"
+        "deep learning",
+        "python"
     ]
 }
 ```
@@ -86,8 +121,8 @@ Response format:
     "github": "JSmith",
     "linkedin": "john-smith",
     "interests": [
-        "python",
-        "deepLearning"
+        "deep learning",
+        "python"
     ]
 }
 ```
@@ -108,8 +143,8 @@ Response format:
     "github": "JSmith",
     "linkedin": "john-smith",
     "interests": [
-        "python",
-        "deepLearning"
+        "deep learning",
+        "python"
     ]
 }
 ```

--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -1,0 +1,115 @@
+Profile
+============
+
+
+GET /profile/
+-------------------------
+
+Returns the profile stored for the current user.
+
+Response format:
+```
+{
+    "id": "github0000001"
+    "name": "John Smith",
+    "email": "john@gmail.com",
+    "github": "JSmith",
+    "linkedin": "john-smith",
+    "interests": [
+        "python",
+        "deepLearning"
+    ]
+}
+```
+
+
+POST /profile/
+-------------------
+
+Creates a profile for the user with the `id` in the JWT token provided in the Authorization header.
+
+Request format:
+```
+{
+    "name": "John Smith",
+    "email": "john@gmail.com",
+    "github": "JSmith",
+    "linkedin": "john-smith",
+    "interests": [
+        "python",
+        "deepLearning"
+    ]
+}
+```
+
+Response format:
+```
+{
+    "id": "github0000001"
+    "name": "John Smith",
+    "email": "john@gmail.com",
+    "github": "JSmith",
+    "linkedin": "john-smith",
+    "interests": [
+        "python",
+        "deepLearning"
+    ]
+}
+```
+
+PUT /profile/
+------------------
+
+Updates the profile for the user with the `id` in the JWT token provided in the Authorization header.
+This returns the updated profile information.
+
+Request format:
+```
+{
+    "name": "John Smith",
+    "email": "john@gmail.com",
+    "github": "JSmith",
+    "linkedin": "john-smith",
+    "interests": [
+        "python",
+        "deepLearning"
+    ]
+}
+```
+
+Response format:
+```
+{
+    "id": "github0000001"
+    "name": "John Smith",
+    "email": "john@gmail.com",
+    "github": "JSmith",
+    "linkedin": "john-smith",
+    "interests": [
+        "python",
+        "deepLearning"
+    ]
+}
+```
+
+
+DELETE /profile/
+------------------
+
+Deletes the profile for the user with the `id` in the JWT token provided in the Authorization header.
+This returns the deleted profile information.
+
+Response format:
+```
+{
+    "id": "github0000001"
+    "name": "John Smith",
+    "email": "john@gmail.com",
+    "github": "JSmith",
+    "linkedin": "john-smith",
+    "interests": [
+        "python",
+        "deepLearning"
+    ]
+}
+```

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -1,11 +1,12 @@
 package config
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/HackIllinois/api/common/configloader"
 	"github.com/arbor-dev/arbor/proxy"
 	"github.com/arbor-dev/arbor/security"
-	"os"
-	"strconv"
 )
 
 var GATEWAY_PORT uint16
@@ -24,6 +25,7 @@ var EVENT_SERVICE string
 var STAT_SERVICE string
 var NOTIFICATIONS_SERVICE string
 var PROJECT_SERVICE string
+var PROFILE_SERVICE string
 
 func Initialize() error {
 
@@ -106,6 +108,12 @@ func Initialize() error {
 	}
 
 	PROJECT_SERVICE, err = cfg_loader.Get("PROJECT_SERVICE")
+
+	if err != nil {
+		return err
+	}
+
+	PROFILE_SERVICE, err = cfg_loader.Get("PROFILE_SERVICE")
 
 	if err != nil {
 		return err

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -1,0 +1,56 @@
+package services
+
+import (
+	"net/http"
+
+	"github.com/HackIllinois/api/gateway/config"
+	"github.com/HackIllinois/api/gateway/middleware"
+	"github.com/HackIllinois/api/gateway/models"
+	"github.com/arbor-dev/arbor"
+	"github.com/justinas/alice"
+)
+
+const ProfileFormat string = "JSON"
+
+var ProfileRoutes = arbor.RouteCollection{
+	arbor.Route{
+		"GetCurrentUserProfile",
+		"GET",
+		"/profile/",
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetProfile).ServeHTTP,
+	},
+	arbor.Route{
+		"CreateCurrentUserProfile",
+		"POST",
+		"/profile/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(CreateProfile).ServeHTTP,
+	},
+	arbor.Route{
+		"UpdateCurrentUserProfile",
+		"PUT",
+		"/profile/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.ApplicantRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateProfile).ServeHTTP,
+	},
+	arbor.Route{
+		"DeleteCurrentUserProfile",
+		"DELETE",
+		"/profile/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.ApplicantRole}), middleware.IdentificationMiddleware).ThenFunc(DeleteProfile).ServeHTTP,
+	},
+}
+
+func GetProfile(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func CreateProfile(w http.ResponseWriter, r *http.Request) {
+	arbor.POST(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func UpdateProfile(w http.ResponseWriter, r *http.Request) {
+	arbor.PUT(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func DeleteProfile(w http.ResponseWriter, r *http.Request) {
+	arbor.PUT(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -17,19 +17,19 @@ var ProfileRoutes = arbor.RouteCollection{
 		"GetCurrentUserProfile",
 		"GET",
 		"/profile/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole})).ThenFunc(GetProfile).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole, models.ApplicantRole})).ThenFunc(GetProfile).ServeHTTP,
 	},
 	arbor.Route{
 		"CreateCurrentUserProfile",
 		"POST",
 		"/profile/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole})).ThenFunc(CreateProfile).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole, models.ApplicantRole})).ThenFunc(CreateProfile).ServeHTTP,
 	},
 	arbor.Route{
 		"UpdateCurrentUserProfile",
 		"PUT",
 		"/profile/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateProfile).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.ApplicantRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateProfile).ServeHTTP,
 	},
 	arbor.Route{
 		"DeleteCurrentUserProfile",
@@ -41,7 +41,7 @@ var ProfileRoutes = arbor.RouteCollection{
 		"GetAllProfiles",
 		"GET",
 		"/profile/list/",
-		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetAllProfiles).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(GetAllProfiles).ServeHTTP,
 	},
 }
 

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -37,6 +37,12 @@ var ProfileRoutes = arbor.RouteCollection{
 		"/profile/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.ApplicantRole}), middleware.IdentificationMiddleware).ThenFunc(DeleteProfile).ServeHTTP,
 	},
+	arbor.Route{
+		"GetAllProfiles",
+		"Get",
+		"/profile/list/",
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetAllProfiles).ServeHTTP,
+	},
 }
 
 func GetProfile(w http.ResponseWriter, r *http.Request) {
@@ -53,4 +59,8 @@ func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 
 func DeleteProfile(w http.ResponseWriter, r *http.Request) {
 	arbor.PUT(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func GetAllProfiles(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
 }

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -17,35 +17,39 @@ var ProfileRoutes = arbor.RouteCollection{
 		"GetCurrentUserProfile",
 		"GET",
 		"/profile/",
-		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetProfile).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole})).ThenFunc(GetProfile).ServeHTTP,
 	},
 	arbor.Route{
 		"CreateCurrentUserProfile",
 		"POST",
 		"/profile/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(CreateProfile).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]models.Role{models.AdminRole})).ThenFunc(CreateProfile).ServeHTTP,
 	},
 	arbor.Route{
 		"UpdateCurrentUserProfile",
 		"PUT",
 		"/profile/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.ApplicantRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateProfile).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateProfile).ServeHTTP,
 	},
 	arbor.Route{
 		"DeleteCurrentUserProfile",
 		"DELETE",
 		"/profile/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.ApplicantRole}), middleware.IdentificationMiddleware).ThenFunc(DeleteProfile).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(DeleteProfile).ServeHTTP,
 	},
 	arbor.Route{
 		"GetAllProfiles",
-		"Get",
+		"GET",
 		"/profile/list/",
 		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetAllProfiles).ServeHTTP,
 	},
 }
 
 func GetProfile(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func GetAllProfiles(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
 }
 
@@ -58,9 +62,5 @@ func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 }
 
 func DeleteProfile(w http.ResponseWriter, r *http.Request) {
-	arbor.PUT(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
-}
-
-func GetAllProfiles(w http.ResponseWriter, r *http.Request) {
-	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+	arbor.DELETE(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
 }

--- a/gateway/services/services.go
+++ b/gateway/services/services.go
@@ -2,10 +2,11 @@ package services
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/HackIllinois/api/gateway/config"
 	"github.com/arbor-dev/arbor"
 	"github.com/justinas/alice"
-	"net/http"
 )
 
 var ServiceLocations map[string]string
@@ -24,6 +25,7 @@ func Initialize() error {
 		"stat":          config.STAT_SERVICE,
 		"notifications": config.NOTIFICATIONS_SERVICE,
 		"project":       config.PROJECT_SERVICE,
+		"profile":       config.PROFILE_SERVICE,
 	}
 
 	return nil
@@ -65,6 +67,7 @@ func RegisterAPIs() arbor.RouteCollection {
 	Routes = append(Routes, StatRoutes...)
 	Routes = append(Routes, NotificationsRoutes...)
 	Routes = append(Routes, ProjectRoutes...)
+	Routes = append(Routes, ProfileRoutes...)
 	Routes = append(Routes, HealthRoutes...)
 	Routes = append(Routes, ReloadRoutes...)
 	return Routes

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DevSatpathy/api v0.4.0 h1:8mFNRQ45ERbfab9HelG4hNjH5uJBJJzxRdRR5x+OIYU=
+github.com/Hackillinois/api v0.4.0 h1:C3iDueAQvAZFBa5eipbDV1oGJxbc6yg6FTNb5MvsuGM=
 github.com/arbor-dev/arbor v0.3.0 h1:/OHWRz78JkQ0ZQwF63Zvtv+1mwWSFEjYbR8gbey7Vyw=
 github.com/arbor-dev/arbor v0.3.0/go.mod h1:V480ScRb7VBbCUxKmRqfs4dFuhj6oDhqVePeJ4OQ8pE=
 github.com/aws/aws-sdk-go v1.16.18 h1:ZXmG9Uexu2f2kKK0Onlod3Hl4X77qQvCGx2725fSubI=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/DevSatpathy/api/services/profile"
 	"github.com/HackIllinois/api/gateway"
 	"github.com/HackIllinois/api/services/auth"
 	"github.com/HackIllinois/api/services/checkin"
@@ -34,6 +35,7 @@ var SERVICE_ENTRYPOINTS = map[string](func()){
 	"stat":          stat.Entry,
 	"notifications": notifications.Entry,
 	"project":       project.Entry,
+	"profile":       profile.Entry,
 }
 
 func StartAll() {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DevSatpathy/api/services/profile"
 	"github.com/HackIllinois/api/gateway"
 	"github.com/HackIllinois/api/services/auth"
 	"github.com/HackIllinois/api/services/checkin"
@@ -13,6 +12,7 @@ import (
 	"github.com/HackIllinois/api/services/event"
 	"github.com/HackIllinois/api/services/mail"
 	"github.com/HackIllinois/api/services/notifications"
+	"github.com/HackIllinois/api/services/profile"
 	"github.com/HackIllinois/api/services/project"
 	"github.com/HackIllinois/api/services/registration"
 	"github.com/HackIllinois/api/services/rsvp"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -28,6 +28,7 @@ $REPO_ROOT/bin/hackillinois-api --service event &
 $REPO_ROOT/bin/hackillinois-api --service stat &
 $REPO_ROOT/bin/hackillinois-api --service notifications &
 $REPO_ROOT/bin/hackillinois-api --service project &
+$REPO_ROOT/bin/hackillinois-api --service profile &
 
 $REPO_ROOT/bin/hackillinois-api --service gateway &
 

--- a/services/profile/README.md
+++ b/services/profile/README.md
@@ -1,0 +1,4 @@
+Profile
+=====
+
+This is the profile microservice supporting hackillinois. This service allows users to display and update a publically viewable social profile.

--- a/services/profile/config/config.go
+++ b/services/profile/config/config.go
@@ -6,10 +6,10 @@ import (
 	"github.com/HackIllinois/api/common/configloader"
 )
 
-var PROJECT_DB_HOST string
-var PROJECT_DB_NAME string
+var PROFILE_DB_HOST string
+var PROFILE_DB_NAME string
 
-var PROJECT_PORT string
+var PROFILE_PORT string
 
 func Initialize() error {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
@@ -18,19 +18,19 @@ func Initialize() error {
 		return err
 	}
 
-	PROJECT_DB_HOST, err = cfg_loader.Get("PROJECT_DB_HOST")
+	PROFILE_DB_HOST, err = cfg_loader.Get("PROFILE_DB_HOST")
 
 	if err != nil {
 		return err
 	}
 
-	PROJECT_DB_NAME, err = cfg_loader.Get("PROJECT_DB_NAME")
+	PROFILE_DB_NAME, err = cfg_loader.Get("PROFILE_DB_NAME")
 
 	if err != nil {
 		return err
 	}
 
-	PROJECT_PORT, err = cfg_loader.Get("PROJECT_PORT")
+	PROFILE_PORT, err = cfg_loader.Get("PROFILE_PORT")
 
 	if err != nil {
 		return err

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -21,15 +21,9 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/list/", GetAllProfiles).Methods("GET")
 }
 
-/*
-	Endpoint to get the profile for the current user
-*/
+// GetProfile is the endpoint to get the profile for the current user
 func GetProfile(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")
-	if id == "" {
-		errors.WriteError(w, r, errors.MalformedRequestError("Must provide id in request.", "Must provide id in request."))
-		return
-	}
 
 	user_profile, err := service.GetProfile(id)
 
@@ -41,9 +35,7 @@ func GetProfile(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(user_profile)
 }
 
-/*
-	Endpoint to create the profile for the current user.
-*/
+// CreateProfile is the endpoint to create the profile for the current user.
 func CreateProfile(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")
 
@@ -61,19 +53,17 @@ func CreateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updated_profile, err := service.GetProfile(id)
+	created_profile, err := service.GetProfile(id)
 
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated profile."))
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get created profile."))
 		return
 	}
 
-	json.NewEncoder(w).Encode(updated_profile)
+	json.NewEncoder(w).Encode(created_profile)
 }
 
-/*
-	Endpoint to update the profile for the current user
-*/
+// UpdateProfile is the endpoint to update the profile for the current user
 func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")
 	if id == "" {
@@ -100,9 +90,7 @@ func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(updated_profile)
 }
 
-/*
-	Endpoint to delete the profile for the current user
-*/
+// DeleteProfile is the endpoint to delete the profile for the current user
 func DeleteProfile(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")
 	if id == "" {
@@ -120,9 +108,7 @@ func DeleteProfile(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(deleted_profile)
 }
 
-/*
-	Endpoint to get all active user profiles
-*/
+// GetAllProfiles is the endpoint to get all active user profiles
 func GetAllProfiles(w http.ResponseWriter, r *http.Request) {
 
 	user_profile_list, err := service.GetAllProfiles()

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -17,10 +17,12 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/", CreateProfile).Methods("POST")
 	router.HandleFunc("/", UpdateProfile).Methods("PUT")
 	router.HandleFunc("/", DeleteProfile).Methods("DELETE")
+
+	router.HandleFunc("/list/", GetAllProfiles).Methods("GET")
 }
 
 /*
-	Endpoint to get the registration for the current user
+	Endpoint to get the profile for the current user
 */
 func GetProfile(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")
@@ -69,6 +71,9 @@ func CreateProfile(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(updated_profile)
 }
 
+/*
+	Endpoint to update the profile for the current user
+*/
 func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")
 	if id == "" {
@@ -95,6 +100,9 @@ func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(updated_profile)
 }
 
+/*
+	Endpoint to delete the profile for the current user
+*/
 func DeleteProfile(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")
 	if id == "" {
@@ -110,4 +118,19 @@ func DeleteProfile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(deleted_profile)
+}
+
+/*
+	Endpoint to get all active user profiles
+*/
+func GetAllProfiles(w http.ResponseWriter, r *http.Request) {
+
+	user_profile_list, err := service.GetAllProfiles()
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not list all user profiles."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(user_profile_list)
 }

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -1,0 +1,113 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/HackIllinois/api/common/errors"
+	"github.com/HackIllinois/api/services/profile/models"
+	"github.com/HackIllinois/api/services/profile/service"
+	"github.com/gorilla/mux"
+)
+
+func SetupController(route *mux.Route) {
+	router := route.Subrouter()
+
+	router.HandleFunc("/", GetProfile).Methods("GET")
+	router.HandleFunc("/", CreateProfile).Methods("POST")
+	router.HandleFunc("/", UpdateProfile).Methods("PUT")
+	router.HandleFunc("/", DeleteProfile).Methods("DELETE")
+}
+
+/*
+	Endpoint to get the registration for the current user
+*/
+func GetProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+	if id == "" {
+		errors.WriteError(w, r, errors.MalformedRequestError("Must provide id in request.", "Must provide id in request."))
+		return
+	}
+
+	user_profile, err := service.GetProfile(id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get current user's profile."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(user_profile)
+}
+
+/*
+	Endpoint to create the profile for the current user.
+*/
+func CreateProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+
+	if id == "" {
+		errors.WriteError(w, r, errors.MalformedRequestError("Must provide id in request.", "Must provide id in request."))
+		return
+	}
+
+	var profile models.Profile
+	json.NewDecoder(r.Body).Decode(&profile)
+	err := service.CreateProfile(id, profile)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not create new profile."))
+		return
+	}
+
+	updated_profile, err := service.GetProfile(id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated profile."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(updated_profile)
+}
+
+func UpdateProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+	if id == "" {
+		errors.WriteError(w, r, errors.MalformedRequestError("Must provide id in request.", "Must provide id in request."))
+		return
+	}
+	var profile models.Profile
+	json.NewDecoder(r.Body).Decode(&profile)
+
+	err := service.UpdateProfile(id, profile)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not update the profile."))
+		return
+	}
+
+	updated_profile, err := service.GetProfile(id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated profile details."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(updated_profile)
+}
+
+func DeleteProfile(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get("HackIllinois-Identity")
+	if id == "" {
+		errors.WriteError(w, r, errors.MalformedRequestError("Must provide id in request.", "Must provide id in request."))
+		return
+	}
+
+	deleted_profile, err := service.DeleteProfile(id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not delete the profile."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(deleted_profile)
+}

--- a/services/profile/main.go
+++ b/services/profile/main.go
@@ -1,0 +1,41 @@
+package profile
+
+import (
+	"log"
+
+	"github.com/HackIllinois/api/common/apiserver"
+	"github.com/HackIllinois/api/services/profile/config"
+	"github.com/HackIllinois/api/services/profile/controller"
+	"github.com/HackIllinois/api/services/profile/service"
+	"github.com/gorilla/mux"
+)
+
+func Initialize() error {
+	err := config.Initialize()
+
+	if err != nil {
+		return err
+
+	}
+
+	err = service.Initialize()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Entry() {
+	err := Initialize()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	router := mux.NewRouter()
+	controller.SetupController(router.PathPrefix("/profile"))
+
+	log.Fatal(apiserver.StartServer(config.PROFILE_PORT, router, "profile", Initialize))
+}

--- a/services/profile/models/profile.go
+++ b/services/profile/models/profile.go
@@ -1,10 +1,14 @@
 package models
 
 type Profile struct {
-	ID        string   `json:"id"`
-	Name      string   `json:"name"`
-	Email     string   `json:"email"`
-	Github    string   `json:"github"`
-	Linkedin  string   `json:"linkedin"`
-	Interests []string `json:"interests"`
+	ID        	string   `json:"id"`
+	FirstName 	string   `json:"firstName"`
+	LastName  	string   `json:"lastName"`
+	Points	  	int	     `json:"points"`
+	Timezone  	string   `json:"timezone"`
+	Description string	 `json:"description`
+	Discord   	string   `json:"discord"`
+	AvatarUrl	string   `json:"avatarUrl"`
+	TeamStatus  string	 `json:"teamStatus"`
+	Interests 	[]string `json:"interests"`
 }

--- a/services/profile/models/profile.go
+++ b/services/profile/models/profile.go
@@ -1,0 +1,10 @@
+package models
+
+type Profile struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Email     string   `json:"email"`
+	Github    string   `json:"github"`
+	Linkedin  string   `json:"linkedin"`
+	Interests []string `json:"interests"`
+}

--- a/services/profile/models/profile_list.go
+++ b/services/profile/models/profile_list.go
@@ -1,0 +1,5 @@
+package models
+
+type ProfileList struct {
+	Profiles []Profile `json:"profiles"`
+}

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -83,6 +83,7 @@ func DeleteProfile(id string) (*models.Profile, error) {
 	Creates a profile with the given id
 */
 func CreateProfile(id string, profile models.Profile) error {
+	profile.ID = id
 	err := validate.Struct(profile)
 
 	if err != nil {
@@ -107,6 +108,7 @@ func CreateProfile(id string, profile models.Profile) error {
 	Updates the profile with the given id
 */
 func UpdateProfile(id string, profile models.Profile) error {
+	profile.ID = id
 	err := validate.Struct(profile)
 
 	if err != nil {

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -54,7 +54,7 @@ func GetProfile(id string) (*models.Profile, error) {
 	Removes the profile from profile trackers and every user's tracker.
 	Returns the profile that was deleted.
 */
-func DeleteProject(id string) (*models.Profile, error) {
+func DeleteProfile(id string) (*models.Profile, error) {
 
 	// Gets profile to be able to return it later
 

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -68,7 +68,7 @@ func DeleteProfile(id string) (*models.Profile, error) {
 		"id": id,
 	}
 
-	// Remove project from projects database
+	// Remove profile from profile database
 
 	err = db.RemoveOne("profiles", query)
 
@@ -120,4 +120,23 @@ func UpdateProfile(id string, profile models.Profile) error {
 	err = db.Update("profiles", selector, &profile)
 
 	return err
+}
+
+/*
+	Returns the list of all accessible profiles
+*/
+func GetAllProfiles() (*models.ProfileList, error) {
+	profiles := []models.Profile{}
+
+	err := db.FindAll("profiles", nil, &profiles)
+
+	if err != nil {
+		return nil, err
+	}
+
+	profile_list := models.ProfileList{
+		Profiles: profiles,
+	}
+
+	return &profile_list, nil
 }

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/services/profile/config"
+	"github.com/HackIllinois/api/services/profile/models"
+	"gopkg.in/go-playground/validator.v9"
+)
+
+var validate *validator.Validate
+
+var db database.Database
+
+func Initialize() error {
+	if db != nil {
+		db.Close()
+		db = nil
+	}
+
+	var err error
+	db, err = database.InitDatabase(config.PROFILE_DB_HOST, config.PROFILE_DB_NAME)
+
+	if err != nil {
+		return err
+	}
+
+	validate = validator.New()
+
+	return nil
+}
+
+/*
+	Returns the profile with the given id
+*/
+func GetProfile(id string) (*models.Profile, error) {
+	query := database.QuerySelector{
+		"id": id,
+	}
+
+	var profile models.Profile
+	err := db.FindOne("profiles", query, &profile)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &profile, nil
+}
+
+/*
+	Deletes the profile with the given id.
+	Removes the profile from profile trackers and every user's tracker.
+	Returns the profile that was deleted.
+*/
+func DeleteProject(id string) (*models.Profile, error) {
+
+	// Gets profile to be able to return it later
+
+	profile, err := GetProfile(id)
+
+	if err != nil {
+		return nil, err
+	}
+
+	query := database.QuerySelector{
+		"id": id,
+	}
+
+	// Remove project from projects database
+
+	err = db.RemoveOne("profiles", query)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return profile, err
+}
+
+/*
+	Creates a profile with the given id
+*/
+func CreateProfile(id string, profile models.Profile) error {
+	err := validate.Struct(profile)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = GetProfile(id)
+
+	if err != database.ErrNotFound {
+		if err != nil {
+			return err
+		}
+		return errors.New("Profile already exists")
+	}
+
+	err = db.Insert("profiles", &profile)
+
+	return err
+}
+
+/*
+	Updates the profile with the given id
+*/
+func UpdateProfile(id string, profile models.Profile) error {
+	err := validate.Struct(profile)
+
+	if err != nil {
+		return err
+	}
+
+	selector := database.QuerySelector{
+		"id": id,
+	}
+
+	err = db.Update("profiles", selector, &profile)
+
+	return err
+}

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -79,7 +79,7 @@ func CleanupTestDB(t *testing.T) {
 /*
 	Service level test for getting all profiles from db
 */
-func TestGetAllProjectsService(t *testing.T) {
+func TestGetAllProfilesService(t *testing.T) {
 	SetupTestDB(t)
 
 	profile := models.Profile{
@@ -146,4 +146,144 @@ func TestGetAllProjectsService(t *testing.T) {
 
 	CleanupTestDB(t)
 
+}
+
+/*
+	Service level test for getting profile from db
+*/
+func TestGetProfileService(t *testing.T) {
+	SetupTestDB(t)
+
+	profile, err := service.GetProfile("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_profile := models.Profile{
+		ID:        "testid",
+		Name:      "testname",
+		Email:     "testemail",
+		Github:    "testgithub",
+		Linkedin:  "testlinkedin",
+		Interests: []string{"testinterest1", "testinterest2"},
+	}
+
+	if !reflect.DeepEqual(profile, &expected_profile) {
+		t.Errorf("Wrong profile info. Expected %v, got %v", &expected_profile, profile)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for creating a profile in the db
+*/
+func TestCreateProfileService(t *testing.T) {
+	SetupTestDB(t)
+
+	new_profile := models.Profile{
+		ID:        "testid2",
+		Name:      "testname2",
+		Email:     "testemail2",
+		Github:    "testgithub2",
+		Linkedin:  "testlinkedin2",
+		Interests: []string{"testinterest3", "testinterest4"},
+	}
+
+	err := service.CreateProfile("testid2", new_profile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	profile, err := service.GetProfile("testid2")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_profile := models.Profile{
+		ID:        "testid2",
+		Name:      "testname2",
+		Email:     "testemail2",
+		Github:    "testgithub2",
+		Linkedin:  "testlinkedin2",
+		Interests: []string{"testinterest3", "testinterest4"},
+	}
+
+	if !reflect.DeepEqual(profile, &expected_profile) {
+		t.Errorf("Wrong profile info. Expected %v, got %v", expected_profile, profile)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for deleting a profile in the db
+*/
+func TestDeleteProfileService(t *testing.T) {
+	SetupTestDB(t)
+
+	profile_id := "testid"
+
+	// Try to delete the profile
+
+	_, err := service.DeleteProfile(profile_id)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to find the profile in the profiles db
+	profile, err := service.GetProfile(profile_id)
+
+	if err == nil {
+		t.Errorf("Found profile %v in profiles database.", profile)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for updating a profile in the db
+*/
+func TestUpdateProfileService(t *testing.T) {
+	SetupTestDB(t)
+
+	profile := models.Profile{
+		ID:        "testid",
+		Name:      "testname2",
+		Email:     "testemail2",
+		Github:    "testgithub2",
+		Linkedin:  "testlinkedin2",
+		Interests: []string{"testinterest3", "testinterest4"},
+	}
+
+	err := service.UpdateProfile("testid", profile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updated_profile, err := service.GetProfile("testid")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_profile := models.Profile{
+		ID:        "testid",
+		Name:      "testname2",
+		Email:     "testemail2",
+		Github:    "testgithub2",
+		Linkedin:  "testlinkedin2",
+		Interests: []string{"testinterest3", "testinterest4"},
+	}
+
+	if !reflect.DeepEqual(updated_profile, &expected_profile) {
+		t.Errorf("Wrong profile info. Expected %v, got %v", expected_profile, updated_profile)
+	}
+
+	CleanupTestDB(t)
 }

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -50,12 +50,16 @@ var TestTime = time.Now().Unix()
 */
 func SetupTestDB(t *testing.T) {
 	profile := models.Profile{
-		ID:        "testid",
-		Name:      "testname",
-		Email:     "testemail",
-		Github:    "testgithub",
-		Linkedin:  "testlinkedin",
-		Interests: []string{"testinterest1", "testinterest2"},
+		ID:          "testid",
+		FirstName:   "testfirstname",
+		LastName:    "testlastname",
+		Points:      0,
+		Timezone:    "America/Chicago",
+		Description: "Hi",
+		Discord:     "testdiscordusername",
+		AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
+		TeamStatus:  "Looking For Team",
+		Interests:   []string{"testinterest1", "testinterest2"},
 	}
 
 	err := db.Insert("profiles", &profile)
@@ -83,12 +87,16 @@ func TestGetAllProfilesService(t *testing.T) {
 	SetupTestDB(t)
 
 	profile := models.Profile{
-		ID:        "testid2",
-		Name:      "testname2",
-		Email:     "testemail2",
-		Github:    "testgithub2",
-		Linkedin:  "testlinkedin2",
-		Interests: []string{"testinterest3", "testinterest4"},
+		ID:          "testid2",
+		FirstName:   "testfirstname2",
+		LastName:    "testlastname2",
+		Points:      340,
+		Timezone:    "America/New York",
+		Description: "Hello",
+		Discord:     "testdiscordusername2",
+		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+		TeamStatus:  "Found Team",
+		Interests:   []string{"testinterest2"},
 	}
 
 	err := db.Insert("profiles", &profile)
@@ -106,20 +114,28 @@ func TestGetAllProfilesService(t *testing.T) {
 	expected_profile_list := models.ProfileList{
 		Profiles: []models.Profile{
 			{
-				ID:        "testid",
-				Name:      "testname",
-				Email:     "testemail",
-				Github:    "testgithub",
-				Linkedin:  "testlinkedin",
-				Interests: []string{"testinterest1", "testinterest2"},
+				ID:          "testid",
+				FirstName:   "testfirstname",
+				LastName:    "testlastname",
+				Points:      0,
+				Timezone:    "America/Chicago",
+				Description: "Hi",
+				Discord:     "testdiscordusername",
+				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
+				TeamStatus:  "Looking For Team",
+				Interests:   []string{"testinterest1", "testinterest2"},
 			},
 			{
-				ID:        "testid2",
-				Name:      "testname2",
-				Email:     "testemail2",
-				Github:    "testgithub2",
-				Linkedin:  "testlinkedin2",
-				Interests: []string{"testinterest3", "testinterest4"},
+				ID:          "testid2",
+				FirstName:   "testfirstname2",
+				LastName:    "testlastname2",
+				Points:      340,
+				Timezone:    "America/New York",
+				Description: "Hello",
+				Discord:     "testdiscordusername2",
+				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+				TeamStatus:  "Found Team",
+				Interests:   []string{"testinterest2"},
 			},
 		},
 	}
@@ -161,12 +177,16 @@ func TestGetProfileService(t *testing.T) {
 	}
 
 	expected_profile := models.Profile{
-		ID:        "testid",
-		Name:      "testname",
-		Email:     "testemail",
-		Github:    "testgithub",
-		Linkedin:  "testlinkedin",
-		Interests: []string{"testinterest1", "testinterest2"},
+		ID:          "testid",
+		FirstName:   "testfirstname",
+		LastName:    "testlastname",
+		Points:      0,
+		Timezone:    "America/Chicago",
+		Description: "Hi",
+		Discord:     "testdiscordusername",
+		AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
+		TeamStatus:  "Looking For Team",
+		Interests:   []string{"testinterest1", "testinterest2"},
 	}
 
 	if !reflect.DeepEqual(profile, &expected_profile) {
@@ -183,12 +203,16 @@ func TestCreateProfileService(t *testing.T) {
 	SetupTestDB(t)
 
 	new_profile := models.Profile{
-		ID:        "testid2",
-		Name:      "testname2",
-		Email:     "testemail2",
-		Github:    "testgithub2",
-		Linkedin:  "testlinkedin2",
-		Interests: []string{"testinterest3", "testinterest4"},
+		ID:          "testid2",
+		FirstName:   "testfirstname2",
+		LastName:    "testlastname2",
+		Points:      340,
+		Timezone:    "America/New York",
+		Description: "Hello",
+		Discord:     "testdiscordusername2",
+		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+		TeamStatus:  "Found Team",
+		Interests:   []string{"testinterest2"},
 	}
 
 	err := service.CreateProfile("testid2", new_profile)
@@ -204,12 +228,16 @@ func TestCreateProfileService(t *testing.T) {
 	}
 
 	expected_profile := models.Profile{
-		ID:        "testid2",
-		Name:      "testname2",
-		Email:     "testemail2",
-		Github:    "testgithub2",
-		Linkedin:  "testlinkedin2",
-		Interests: []string{"testinterest3", "testinterest4"},
+		ID:          "testid2",
+		FirstName:   "testfirstname2",
+		LastName:    "testlastname2",
+		Points:      340,
+		Timezone:    "America/New York",
+		Description: "Hello",
+		Discord:     "testdiscordusername2",
+		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+		TeamStatus:  "Found Team",
+		Interests:   []string{"testinterest2"},
 	}
 
 	if !reflect.DeepEqual(profile, &expected_profile) {
@@ -252,12 +280,16 @@ func TestUpdateProfileService(t *testing.T) {
 	SetupTestDB(t)
 
 	profile := models.Profile{
-		ID:        "testid",
-		Name:      "testname2",
-		Email:     "testemail2",
-		Github:    "testgithub2",
-		Linkedin:  "testlinkedin2",
-		Interests: []string{"testinterest3", "testinterest4"},
+		ID:          "testid",
+		FirstName:   "testfirstname2",
+		LastName:    "testlastname2",
+		Points:      340,
+		Timezone:    "America/New York",
+		Description: "Hello",
+		Discord:     "testdiscordusername2",
+		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+		TeamStatus:  "Found Team",
+		Interests:   []string{"testinterest2"},
 	}
 
 	err := service.UpdateProfile("testid", profile)
@@ -273,12 +305,16 @@ func TestUpdateProfileService(t *testing.T) {
 	}
 
 	expected_profile := models.Profile{
-		ID:        "testid",
-		Name:      "testname2",
-		Email:     "testemail2",
-		Github:    "testgithub2",
-		Linkedin:  "testlinkedin2",
-		Interests: []string{"testinterest3", "testinterest4"},
+		ID:          "testid",
+		FirstName:   "testfirstname2",
+		LastName:    "testlastname2",
+		Points:      340,
+		Timezone:    "America/New York",
+		Description: "Hello",
+		Discord:     "testdiscordusername2",
+		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+		TeamStatus:  "Found Team",
+		Interests:   []string{"testinterest2"},
 	}
 
 	if !reflect.DeepEqual(updated_profile, &expected_profile) {

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/HackIllinois/api/common/database"
+	"github.com/HackIllinois/api/services/profile/config"
+	"github.com/HackIllinois/api/services/profile/models"
+	"github.com/HackIllinois/api/services/profile/service"
+)
+
+var db database.Database
+
+func TestMain(m *testing.M) {
+	err := config.Initialize()
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+
+	}
+
+	err = service.Initialize()
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	db, err = database.InitDatabase(config.PROFILE_DB_HOST, config.PROFILE_DB_NAME)
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	return_code := m.Run()
+
+	os.Exit(return_code)
+}
+
+var TestTime = time.Now().Unix()
+
+/*
+	Initialize db with a test profile
+*/
+func SetupTestDB(t *testing.T) {
+	profile := models.Profile{
+		ID:        "testid",
+		Name:      "testname",
+		Email:     "testemail",
+		Github:    "testgithub",
+		Linkedin:  "testlinkedin",
+		Interests: []string{"testinterest1", "testinterest2"},
+	}
+
+	err := db.Insert("profiles", &profile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+	Drop test db
+*/
+func CleanupTestDB(t *testing.T) {
+	err := db.DropDatabase()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+	Service level test for getting all profiles from db
+*/
+func TestGetAllProjectsService(t *testing.T) {
+	SetupTestDB(t)
+
+	profile := models.Profile{
+		ID:        "testid2",
+		Name:      "testname2",
+		Email:     "testemail2",
+		Github:    "testgithub2",
+		Linkedin:  "testlinkedin2",
+		Interests: []string{"testinterest3", "testinterest4"},
+	}
+
+	err := db.Insert("profiles", &profile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual_profile_list, err := service.GetAllProfiles()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_profile_list := models.ProfileList{
+		Profiles: []models.Profile{
+			{
+				ID:        "testid",
+				Name:      "testname",
+				Email:     "testemail",
+				Github:    "testgithub",
+				Linkedin:  "testlinkedin",
+				Interests: []string{"testinterest1", "testinterest2"},
+			},
+			{
+				ID:        "testid2",
+				Name:      "testname2",
+				Email:     "testemail2",
+				Github:    "testgithub2",
+				Linkedin:  "testlinkedin2",
+				Interests: []string{"testinterest3", "testinterest4"},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(actual_profile_list, &expected_profile_list) {
+		t.Errorf("Wrong profile list. Expected %v, got %v", expected_profile_list, actual_profile_list)
+	}
+
+	db.RemoveAll("profiles", nil)
+
+	actual_profile_list, err = service.GetAllProfiles()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_profile_list = models.ProfileList{
+		Profiles: []models.Profile{},
+	}
+
+	if !reflect.DeepEqual(actual_profile_list, &expected_profile_list) {
+		t.Errorf("Wrong profile list. Expected %v, got %v", expected_profile_list, actual_profile_list)
+	}
+
+	CleanupTestDB(t)
+
+}

--- a/services/project/tests/project_test.go
+++ b/services/project/tests/project_test.go
@@ -354,7 +354,7 @@ func TestCreateProjectService(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(project, &expected_project) {
-		t.Errorf("Wrong user info. Expected %v, got %v", expected_project, project)
+		t.Errorf("Wrong project info. Expected %v, got %v", expected_project, project)
 	}
 
 	CleanupTestDB(t)
@@ -425,7 +425,7 @@ func TestUpdateProjectService(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(updated_project, &expected_project) {
-		t.Errorf("Wrong user info. Expected %v, got %v", expected_project, updated_project)
+		t.Errorf("Wrong project info. Expected %v, got %v", expected_project, updated_project)
 	}
 
 	CleanupTestDB(t)

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -2,14 +2,15 @@ package controller
 
 import (
 	"encoding/json"
+	"net/http"
+	"time"
+
 	"github.com/HackIllinois/api/common/datastore"
 	"github.com/HackIllinois/api/common/errors"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
 	"github.com/HackIllinois/api/services/registration/service"
 	"github.com/gorilla/mux"
-	"net/http"
-	"time"
 )
 
 func SetupController(route *mux.Route) {


### PR DESCRIPTION
This service emulates some of the social networking and team formation that is normally possible at hackathons. Given a virtual format, attendees will not have badges that identify their basic information, such as . With an event on discord, it can be hard to know someone's real name and identity, so providing a publicly accessible endpoint for a profile allows for users to populate this data if they choose to do so. Including attendees' Linkedin and Github accounts enables for followups and forging relationships and friendships with fellow attendees. Potential expansions to this include:

- Populating data from the user registration, and just enabling users to opt into displaying this information
- Placing user profiles within the project endpoint, so people can easily identify the users that contributed to the profile and make a connection with them or follow up with questions
- Integration with the upload endpoint, enabling attendees to add photos (should limit size for storage costs) to complete this profile