### PR TITLE
Feat/user filtering sortby

### DIFF
--- a/documentation/docs/reference/services/User.md
+++ b/documentation/docs/reference/services/User.md
@@ -65,6 +65,15 @@ GET /user/filter/?key=value
 
 Returns the basic user information, filtered with the given key-value pairs.
 
+To sort the users, provide a **comma-separated** "sortby" parameter. For example, the following request:  
+``
+/user/filter/?key=value&sortby=FirstName,LastName
+``
+
+will return a list of filtered users sorted by first name, using the last name as a tie breaker.
+
+To reverse the sort, add a minus (-) to the desired sort field. For example, "FirstName" would become "-FirstName".
+
 Response format:
 ```
 {

--- a/services/user/service/user_service.go
+++ b/services/user/service/user_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"net/url"
+	"strings"
 
 	"github.com/HackIllinois/api/common/database"
 	"github.com/HackIllinois/api/services/user/config"
@@ -67,6 +68,10 @@ func SetUserInfo(id string, user_info models.UserInfo) error {
 	Returns the users associated with the given parameters
 */
 func GetFilteredUserInfo(parameters map[string][]string) (*models.FilteredUsers, error) {
+	// Grab the sortby parameter and delete it to prevent the CreateFilterQuery from using it
+	sort_parameters := parameters["sortby"]
+	delete(parameters, "sortby")
+
 	query, err := database.CreateFilterQuery(parameters, models.UserInfo{})
 
 	if err != nil {
@@ -74,7 +79,34 @@ func GetFilteredUserInfo(parameters map[string][]string) (*models.FilteredUsers,
 	}
 
 	var filtered_users models.FilteredUsers
-	err = db.FindAll("info", query, &filtered_users.Users)
+
+	if len(sort_parameters) == 1 {
+		// Split by comma to get a slice of sorting parameters
+		// i.e FirstName, LastName --> ["FirstName", "LastName"]
+		sort_parameters = strings.Split(sort_parameters[0], ",")
+
+		// Create and fill the sort fields
+		var sort_fields []database.SortField
+
+		for _, field := range sort_parameters {
+			// Push to lowercase because MongoDB columns are all lowercase
+			field = strings.ToLower(field)
+			field = strings.TrimSpace(field)
+
+			// TODO Add a check here to make sure the requested sort field is actually a field in the model.
+
+			sort_fields = append(sort_fields,
+				database.SortField{
+					Name:     field,
+					Reversed: false,
+				})
+		}
+
+		// Fetch and Sort
+		err = db.FindAllSorted("info", query, sort_fields, &filtered_users.Users)
+	} else {
+		err = db.FindAll("info", query, &filtered_users.Users)
+	}
 
 	if err != nil {
 		return nil, err

--- a/services/user/tests/user_test.go
+++ b/services/user/tests/user_test.go
@@ -228,6 +228,8 @@ func TestGetFilteredUserInfoWithSortingService(t *testing.T) {
 	user_info_2, err := service.GetUserInfo("testid2")
 	user_info_3, err := service.GetUserInfo("testid3")
 
+	// Sort by first name and expect: Alex, Bobby, Charlie
+
 	parameters := map[string][]string{
 		"username": {"testusername"},
 		"sortby":   {"FiRsTNAmE"},
@@ -249,6 +251,32 @@ func TestGetFilteredUserInfoWithSortingService(t *testing.T) {
 	if !reflect.DeepEqual(filtered_info, expected_info) {
 		t.Errorf("Wrong user info. Expected %v, got %v", expected_info, filtered_info)
 	}
+
+	// Reverse the sort and expect: Charlie, Bobby, Alex.
+
+	parameters = map[string][]string{
+		"username": {"testusername"},
+		"sortby":   {"-FiRsTNAmE"},
+	}
+
+	filtered_info, err = service.GetFilteredUserInfo(parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_info = &models.FilteredUsers{
+		[]models.UserInfo{
+			*user_info_2, // Charlie
+			*user_info_3, // Bobby
+			*user_info_1, // Alex
+		},
+	}
+
+	if !reflect.DeepEqual(filtered_info, expected_info) {
+		t.Errorf("Wrong user info. Expected %v, got %v", expected_info, filtered_info)
+	}
+
+	// Sort by two parameters and expect: Bobby Adamson, Bobby Zulu
 
 	user_info_1, err = service.GetUserInfo("testid5")
 	user_info_2, err = service.GetUserInfo("testid4")


### PR DESCRIPTION
#261 

Adds sorting functionality to the /user/filter/ service.

To use it, provide a comma-separated "sortby" parameter.

`/user/filter/?key=value&sortby=FirstName,LastName`

To reverse the sort, add a minus (-) to the desired field. An example is provided in the service documentation.

`/user/filter/?key=value&sortby=-FirstName,LastName`