### PR TITLE
Deploy a service manually using Github Actions CI 

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -28,10 +28,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Create new task definition  
-        run: "aws ecs describe-task-definition --task-definition hackillinois-api-profile --query '{  containerDefinitions: taskDefinition.containerDefinitions,family: taskDefinition.family,taskRoleArn: taskDefinition.taskRoleArn,executionRoleArn: taskDefinition.executionRoleArn,networkMode: taskDefinition.networkMode,volumes: taskDefinition.volumes,placementConstraints: taskDefinition.placementConstraints,requiresCompatibilities: taskDefinition.requiresCompatibilities,cpu: taskDefinition.cpu,memory: taskDefinition.memory}' > task_def.json"
+        run: "aws ecs describe-task-definition --task-definition hackillinois-api-${{ github.event.inputs.service-name }} --query '{  containerDefinitions: taskDefinition.containerDefinitions,family: taskDefinition.family,taskRoleArn: taskDefinition.taskRoleArn,executionRoleArn: taskDefinition.executionRoleArn,networkMode: taskDefinition.networkMode,volumes: taskDefinition.volumes,placementConstraints: taskDefinition.placementConstraints,requiresCompatibilities: taskDefinition.requiresCompatibilities,cpu: taskDefinition.cpu,memory: taskDefinition.memory}' > task_def.json"
 
       - name: Register new task definition
         run: aws ecs register-task-definition --cli-input-json file://task_def.json
 
       - name: Redeploy service with new task definition
-        run: aws ecs update-service --cluster hackillinois-api --service hackillinois-api-profile --force-new-deployment --task-definition hackillinois-api-profile
+        run: aws ecs update-service --cluster hackillinois-api --service hackillinois-api-${{ github.event.inputs.service-name }} --force-new-deployment --task-definition hackillinois-api-${{ github.event.inputs.service-name }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,10 +32,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Create new task definition  
-        run: "NEW_TASK_DEFINTION=$(aws ecs describe-task-definition --task-definition hackillinois-api-profile --query '{  containerDefinitions: taskDefinition.containerDefinitions,family: taskDefinition.family,taskRoleArn: taskDefinition.taskRoleArn,executionRoleArn: taskDefinition.executionRoleArn,networkMode: taskDefinition.networkMode,volumes: taskDefinition.volumes,placementConstraints: taskDefinition.placementConstraints,requiresCompatibilities: taskDefinition.requiresCompatibilities,cpu: taskDefinition.cpu,memory: taskDefinition.memory}')"
+        run: "aws ecs describe-task-definition --task-definition hackillinois-api-profile --query '{  containerDefinitions: taskDefinition.containerDefinitions,family: taskDefinition.family,taskRoleArn: taskDefinition.taskRoleArn,executionRoleArn: taskDefinition.executionRoleArn,networkMode: taskDefinition.networkMode,volumes: taskDefinition.volumes,placementConstraints: taskDefinition.placementConstraints,requiresCompatibilities: taskDefinition.requiresCompatibilities,cpu: taskDefinition.cpu,memory: taskDefinition.memory}' > task_def.json"
 
       - name: Register new task definition
-        run: aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEFINTION"
+        run: aws ecs register-task-definition --cli-input-json task_def.json
 
       - name: Redeploy service with new task definition
         run: aws ecs update-service --cluster hackillinois-api --service hackillinois-api-profile --force-new-deployment --task-definition hackillinois-api-profile

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,10 +2,6 @@ name: deployment
 
 
 on:
-  push:
-    branches:
-      - "master"
-      - "**"
   workflow_dispatch:
     inputs:
       service-name:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -35,7 +35,7 @@ jobs:
         run: "aws ecs describe-task-definition --task-definition hackillinois-api-profile --query '{  containerDefinitions: taskDefinition.containerDefinitions,family: taskDefinition.family,taskRoleArn: taskDefinition.taskRoleArn,executionRoleArn: taskDefinition.executionRoleArn,networkMode: taskDefinition.networkMode,volumes: taskDefinition.volumes,placementConstraints: taskDefinition.placementConstraints,requiresCompatibilities: taskDefinition.requiresCompatibilities,cpu: taskDefinition.cpu,memory: taskDefinition.memory}' > task_def.json"
 
       - name: Register new task definition
-        run: aws ecs register-task-definition --cli-input-json task_def.json
+        run: aws ecs register-task-definition --cli-input-json file://task_def.json
 
       - name: Redeploy service with new task definition
         run: aws ecs update-service --cluster hackillinois-api --service hackillinois-api-profile --force-new-deployment --task-definition hackillinois-api-profile

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,41 @@
+name: deployment
+
+
+on:
+  push:
+    branches:
+      - "master"
+      - "**"
+  workflow_dispatch:
+    inputs:
+      service-name:
+        description: 'Service name, e.g. "auth", "checkin", "decision", "event", "gateway", "mail", "notifications", "profile", "project", "registration", "rsvp", "stat", "upload", "user"'     
+        required: true 
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2    
+
+      - name: Configure AWS credentials from ECS account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECS_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Create new task definition  
+        run: "NEW_TASK_DEFINTION=$(aws ecs describe-task-definition --task-definition hackillinois-api-profile --query '{  containerDefinitions: taskDefinition.containerDefinitions,family: taskDefinition.family,taskRoleArn: taskDefinition.taskRoleArn,executionRoleArn: taskDefinition.executionRoleArn,networkMode: taskDefinition.networkMode,volumes: taskDefinition.volumes,placementConstraints: taskDefinition.placementConstraints,requiresCompatibilities: taskDefinition.requiresCompatibilities,cpu: taskDefinition.cpu,memory: taskDefinition.memory}')"
+
+      - name: Register new task definition
+        run: aws ecs register-task-definition --cli-input-json "$NEW_TASK_DEFINTION"
+
+      - name: Redeploy service with new task definition
+        run: aws ecs update-service --cluster hackillinois-api --service hackillinois-api-profile --force-new-deployment --task-definition hackillinois-api-profile


### PR DESCRIPTION
* Updates with new task definition
* Redeploys service

* Must specify which service to redeploy (does not deploy docker containers)

Successful run updating profile service: https://github.com/HackIllinois/api/runs/1977358099?check_suite_focus=true

Workflow dispatch 
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
