### PR TITLE
Profile search privacy

### DIFF
--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -50,11 +50,18 @@ var ProfileRoutes = arbor.RouteCollection{
 		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.AttendeeRole, models.StaffRole, models.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(GetProfileLeaderboard).ServeHTTP,
 	},
 	arbor.Route{
-		"GetFilteredProfiles",
+		"GetValidFilteredProfiles",
 		"GET",
 		"/profile/search/",
-		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.AttendeeRole, models.StaffRole, models.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(GetFilteredProfiles).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.AttendeeRole, models.StaffRole, models.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(GetValidFilteredProfiles).ServeHTTP,
 	},
+	arbor.Route{
+		"GetFilteredProfiles",
+		"GET",
+		"/profile/filtered/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(GetFilteredProfiles).ServeHTTP,
+	},
+	// This needs to be the last route in order to prevent endpoints like "search", "leaderboard" from accidentally being routed as the {id} variable.
 	arbor.Route{
 		"GetUserProfileById",
 		"GET",
@@ -72,6 +79,10 @@ func GetProfileById(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetAllProfiles(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func GetValidFilteredProfiles(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
 }
 

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -181,3 +181,18 @@ func GetFilteredProfiles(w http.ResponseWriter, r *http.Request) {
 
 	json.NewEncoder(w).Encode(filtered_profile_list)
 }
+
+/*
+	Filters the profiles by TeamStatus and Interests. Additionally filters out profiles that have the TeamStatus "Not Looking".
+*/
+func GetValidFilteredProfiles(w http.ResponseWriter, r *http.Request) {
+	parameters := r.URL.Query()
+
+	filtered_profile_list, err := service.GetValidFilteredProfiles(parameters)
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get the valid filtered profiles."))
+		return
+	}
+
+	json.NewEncoder(w).Encode(filtered_profile_list)
+}

--- a/services/profile/models/profile.go
+++ b/services/profile/models/profile.go
@@ -6,7 +6,7 @@ type Profile struct {
 	LastName    string   `json:"lastName"`
 	Points      int      `json:"points"`
 	Timezone    string   `json:"timezone"`
-	Description string   `json:"description`
+	Description string   `json:"description"`
 	Discord     string   `json:"discord"`
 	AvatarUrl   string   `json:"avatarUrl"`
 	TeamStatus  string   `json:"teamStatus"`

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -232,3 +232,18 @@ func GetFilteredProfiles(parameters map[string][]string) (*models.ProfileList, e
 
 	return &profile_list, nil
 }
+
+func GetValidFilteredProfiles(parameters map[string][]string) (*models.ProfileList, error) {
+	_, exists := parameters["TeamStatus"]
+	if !exists {
+		parameters["TeamStatusNot"] = append(parameters["TeamStatusNot"], "Not Looking")
+	}
+
+	filtered_profile_list, err := GetFilteredProfiles(parameters)
+
+	if err != nil {
+		return nil, errors.New("Could not get filtered profiles")
+	}
+
+	return filtered_profile_list, nil
+}

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -234,11 +234,7 @@ func GetFilteredProfiles(parameters map[string][]string) (*models.ProfileList, e
 }
 
 func GetValidFilteredProfiles(parameters map[string][]string) (*models.ProfileList, error) {
-	_, exists := parameters["TeamStatus"]
-	if !exists {
-		parameters["TeamStatusNot"] = append(parameters["TeamStatusNot"], "Not Looking")
-	}
-
+	parameters["TeamStatusNot"] = append(parameters["TeamStatusNot"], "Not Looking")
 	filtered_profile_list, err := GetFilteredProfiles(parameters)
 
 	if err != nil {

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -234,7 +234,7 @@ func GetFilteredProfiles(parameters map[string][]string) (*models.ProfileList, e
 }
 
 func GetValidFilteredProfiles(parameters map[string][]string) (*models.ProfileList, error) {
-	parameters["TeamStatusNot"] = append(parameters["TeamStatusNot"], "Not Looking")
+	parameters["teamStatusNot"] = append(parameters["teamStatusNot"], "Not Looking")
 	filtered_profile_list, err := GetFilteredProfiles(parameters)
 
 	if err != nil {

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -850,7 +850,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 	// Add a TeamStatus filter.
 
 	parameters = map[string][]string{
-		"TeamStatus": {"Looking For Team"},
+		"teamStatus": {"Looking For Team"},
 		"limit":      {"0"},
 	}
 

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -716,3 +716,137 @@ func TestGetProfileLeaderboard(t *testing.T) {
 
 	CleanupTestDB(t)
 }
+
+func TestGetValidFilteredProfiles(t *testing.T) {
+	SetupTestDB(t)
+
+	profile := models.Profile{
+		ID:          "testid2",
+		FirstName:   "testfirstname2",
+		LastName:    "testlastname2",
+		Points:      340,
+		Timezone:    "America/New York",
+		Description: "Hello",
+		Discord:     "testdiscordusername2",
+		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+		TeamStatus:  "Not Looking",
+		Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
+	}
+
+	err := db.Insert("profiles", &profile)
+
+	profile = models.Profile{
+		ID:          "testid3",
+		FirstName:   "testfirstname3",
+		LastName:    "testlastname3",
+		Points:      342,
+		Timezone:    "America/New York",
+		Description: "Hello",
+		Discord:     "testdiscordusername3",
+		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+		TeamStatus:  "Found Team",
+		Interests:   []string{"Cpp", "Machine Learning"},
+	}
+	err = db.Insert("profiles", &profile)
+
+	parameters := map[string][]string{
+		"interests": {"Cpp,Machine Learning"},
+		"limit":     {"0"},
+	}
+
+	filtered_profile_list, err := service.GetValidFilteredProfiles(parameters)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_filtered_profile_list := models.ProfileList{
+		Profiles: []models.Profile{
+			{
+				ID:          "testid3",
+				FirstName:   "testfirstname3",
+				LastName:    "testlastname3",
+				Points:      342,
+				Timezone:    "America/New York",
+				Description: "Hello",
+				Discord:     "testdiscordusername3",
+				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+				TeamStatus:  "Found Team",
+				Interests:   []string{"Cpp", "Machine Learning"},
+			},
+		},
+	}
+
+	profile = models.Profile{
+		ID:          "testid4",
+		FirstName:   "testfirstname3",
+		LastName:    "testlastname3",
+		Points:      342,
+		Timezone:    "America/New York",
+		Description: "Hello",
+		Discord:     "testdiscordusername3",
+		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+		TeamStatus:  "Looking for Team",
+		Interests:   []string{},
+	}
+	err = db.Insert("profiles", &profile)
+
+	// Remove the interests filter. Now every profile should show up except for those that are "Not Looking" for a team.
+
+	parameters = map[string][]string{
+		"limit": {"1"},
+	}
+
+	filtered_profile_list, err = service.GetValidFilteredProfiles(parameters)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_filtered_profile_list = models.ProfileList{
+		Profiles: []models.Profile{
+			{
+				ID:          "testid",
+				FirstName:   "testfirstname",
+				LastName:    "testlastname",
+				Points:      0,
+				Timezone:    "America/Chicago",
+				Description: "Hi",
+				Discord:     "testdiscordusername",
+				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
+				TeamStatus:  "Looking For Team",
+				Interests:   []string{"testinterest1", "testinterest2"},
+			},
+			{
+				ID:          "testid3",
+				FirstName:   "testfirstname3",
+				LastName:    "testlastname3",
+				Points:      342,
+				Timezone:    "America/New York",
+				Description: "Hello",
+				Discord:     "testdiscordusername3",
+				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+				TeamStatus:  "Found Team",
+				Interests:   []string{"Cpp", "Machine Learning"},
+			},
+			{
+				ID:          "testid4",
+				FirstName:   "testfirstname3",
+				LastName:    "testlastname3",
+				Points:      342,
+				Timezone:    "America/New York",
+				Description: "Hello",
+				Discord:     "testdiscordusername3",
+				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+				TeamStatus:  "Looking for Team",
+				Interests:   []string{},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(filtered_profile_list, &expected_filtered_profile_list) {
+		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
+	}
+
+	CleanupTestDB(t)
+}

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -786,7 +786,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername3",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Looking for Team",
+		TeamStatus:  "Looking For Team",
 		Interests:   []string{},
 	}
 	err = db.Insert("profiles", &profile)
@@ -838,7 +838,52 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername3",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Looking for Team",
+				TeamStatus:  "Looking For Team",
+				Interests:   []string{},
+			},
+		},
+	}
+	if !reflect.DeepEqual(filtered_profile_list, &expected_filtered_profile_list) {
+		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
+	}
+
+	// Add a TeamStatus filter.
+
+	parameters = map[string][]string{
+		"TeamStatus": {"Looking For Team"},
+		"limit":      {"0"},
+	}
+
+	filtered_profile_list, err = service.GetValidFilteredProfiles(parameters)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_filtered_profile_list = models.ProfileList{
+		Profiles: []models.Profile{
+			{
+				ID:          "testid",
+				FirstName:   "testfirstname",
+				LastName:    "testlastname",
+				Points:      0,
+				Timezone:    "America/Chicago",
+				Description: "Hi",
+				Discord:     "testdiscordusername",
+				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
+				TeamStatus:  "Looking For Team",
+				Interests:   []string{"testinterest1", "testinterest2"},
+			},
+			{
+				ID:          "testid4",
+				FirstName:   "testfirstname3",
+				LastName:    "testlastname3",
+				Points:      342,
+				Timezone:    "America/New York",
+				Description: "Hello",
+				Discord:     "testdiscordusername3",
+				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
+				TeamStatus:  "Looking For Team",
 				Interests:   []string{},
 			},
 		},

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -794,7 +794,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 	// Remove the interests filter. Now every profile should show up except for those that are "Not Looking" for a team.
 
 	parameters = map[string][]string{
-		"limit": {"1"},
+		"limit": {"0"},
 	}
 
 	filtered_profile_list, err = service.GetValidFilteredProfiles(parameters)


### PR DESCRIPTION
- Moved the existing Profile /search/ code to a new endpoint, /filtered/, only accessible by AdminRole and StaffRole
- Made a new endpoint for /search/ which returns the desired parameters, as well as filtering out the Profiles that have the TeamStatus "Not Looking" (this status can be changed to whatever we need it to be)