### PR TITLE
Profile service docs format fix

### DIFF
--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -1,7 +1,6 @@
 Profile
 ============
 
-
 GET /profile/
 -------------------------
 
@@ -24,7 +23,7 @@ Response format:
 
 ```
 
-GET /profile/{id}
+GET /profile/{id}/
 -------------------------
 
 Returns the profile stored for user that has the ID ``{id}``.
@@ -179,6 +178,8 @@ Response format:
 
 GET /profile/leaderboard/?limit=
 -------------------------
+
+**Public endpoint.**
 
 Returns a list of profiles sorted by points descending. If a ``limit`` parameter is provided, it will return the first ``limit`` profiles. Otherwise, it will return all of the profiles.
 

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - 'Event': 'reference/services/Event.md'
       - 'Mail': 'reference/services/Mail.md'
       - 'Notifications': 'reference/services/Notifications.md'
+      - 'Profile': 'reference/services/Profile.md'
       - 'Project': 'reference/services/Project.md'
       - 'RSVP': 'reference/services/RSVP.md'
       - 'Registration': 'reference/services/Registration.md'


### PR DESCRIPTION
- Add trailing slash to GET /profile/{id}/ endpoint
- Add Profile to the site's navigation bar