### PR TITLE
Change teamStatus fields to UPPER_SNAKE_CASE and fix a broken test

### DIFF
--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -6,6 +6,8 @@ GET /profile/
 
 Returns the profile stored for the current user.
 
+Valid values for ``teamStatus`` are ``LOOKING_FOR_MEMBERS``, ``LOOKING_FOR_TEAM``, and ``NOT_LOOKING``.
+
 Response format:
 ```
 {
@@ -16,7 +18,7 @@ Response format:
     "timezone": "Americas UTC+8",
     "avatarUrl": "https://github.com/.../profile.jpg",
     "discord": "patrick#1234",
-    "teamStatus": "looking",
+    "teamStatus": "LOOKING_FOR_TEAM",
     "description": "Lorem Ipsum…",
     "interests": ["C++", "Machine Learning"]
 }
@@ -38,7 +40,7 @@ Response format:
     "timezone": "Americas UTC+8",
     "avatarUrl": "https://github.com/.../profile.jpg",
     "discord": "patrick#1234",
-    "teamStatus": "looking",
+    "teamStatus": "LOOKING_FOR_TEAM",
     "description": "Lorem Ipsum…",
     "interests": ["C++", "Machine Learning"]
 }
@@ -61,7 +63,7 @@ Response format:
             "timezone": "Americas UTC+8",
             "avatarUrl": "https://github.com/.../profile.jpg",
             "discord": "patrick#1234",
-            "teamStatus": "looking",
+            "teamStatus": "LOOKING_FOR_TEAM",
             "description": "Lorem Ipsum…",
             "interests": ["C++", "Machine Learning"]
         },
@@ -73,7 +75,7 @@ Response format:
             "timezone": "Americas UTC+8",
             "avatarUrl": "https://github.com/.../profile.jpg",
             "discord": "patrick#1234",
-            "teamStatus": "looking",
+            "teamStatus": "LOOKING_FOR_MEMBERS",
             "description": "Lorem Ipsum…",
             "interests": ["C++", "Machine Learning"]
         },
@@ -95,7 +97,7 @@ Request format:
     "timezone": "Americas UTC+8",
     "avatarUrl": "https://github.com/.../profile.jpg",
     "discord": "patrick#1234",
-    "teamStatus": "looking",
+    "teamStatus": "LOOKING_FOR_TEAM",
     "description": "Lorem Ipsum…",
     "interests": ["C++", "Machine Learning"]
 }
@@ -111,7 +113,7 @@ Response format:
     "timezone": "Americas UTC+8",
     "avatarUrl": "https://github.com/.../profile.jpg",
     "discord": "patrick#1234",
-    "teamStatus": "looking",
+    "teamStatus": "LOOKING_FOR_TEAM",
     "description": "Lorem Ipsum…",
     "interests": ["C++", "Machine Learning"]
 }
@@ -131,7 +133,7 @@ Request format:
     "timezone": "Americas UTC+8",
     "avatarUrl": "https://github.com/.../profile.jpg",
     "discord": "patrick#1234",
-    "teamStatus": "looking",
+    "teamStatus": "LOOKING_FOR_TEAM",
     "description": "Lorem Ipsum…",
     "interests": ["C++", "Machine Learning"]
 }
@@ -147,7 +149,7 @@ Response format:
     "timezone": "Americas UTC+8",
     "avatarUrl": "https://github.com/.../profile.jpg",
     "discord": "patrick#1234",
-    "teamStatus": "looking",
+    "teamStatus": "LOOKING_FOR_TEAM",
     "description": "Lorem Ipsum…",
     "interests": ["C++", "Machine Learning"]
 }
@@ -170,7 +172,7 @@ Response format:
     "timezone": "Americas UTC+8",
     "avatarUrl": "https://github.com/.../profile.jpg",
     "discord": "patrick#1234",
-    "teamStatus": "looking",
+    "teamStatus": "LOOKING_FOR_TEAM",
     "description": "Lorem Ipsum…",
     "interests": ["C++", "Machine Learning"]
 }
@@ -208,7 +210,7 @@ GET /profile/search/?teamStatus=value&interests=value,value,value&limit=value
 
 Returns a list of profiles matching the filter conditions. 
 
-teamStatus is a string matching the user's team status.
+``teamStatus`` is a string matching the user's team status. Valid values for ``teamStatus`` are ``LOOKING_FOR_MEMBERS``, ``LOOKING_FOR_TEAM``, and ``NOT_LOOKING``.
 
 interests is a comma-separated string representing the user's interests.
 
@@ -216,7 +218,7 @@ interests is a comma-separated string representing the user's interests.
 
 If a ``limit`` parameter is provided, it will return the first matching ``limit`` profiles. Otherwise, it will return all of the matched profiles.
 
-Any users with the TeamStatus "Not Looking" will be removed.
+Any users with the TeamStatus "NOT_LOOKING" will be removed.
 
 Response format:
 ```
@@ -230,7 +232,7 @@ Response format:
             "timezone": "Americas UTC+8",
             "avatarUrl": "https://github.com/.../profile.jpg",
             "discord": "patrick#1234",
-            "teamStatus": "looking",
+            "teamStatus": "LOOKING_FOR_TEAM",
             "description": "Lorem Ipsum…",
             "interests": ["C++", "Machine Learning"]
         },
@@ -242,7 +244,7 @@ Response format:
             "timezone": "Americas UTC+8",
             "avatarUrl": "https://github.com/.../profile.jpg",
             "discord": "patrick#1234",
-            "teamStatus": "looking",
+            "teamStatus": "LOOKING_FOR_TEAM",
             "description": "Lorem Ipsum…",
             "interests": ["C++", "Machine Learning"]
         },
@@ -277,7 +279,7 @@ Response format:
             "timezone": "Americas UTC+8",
             "avatarUrl": "https://github.com/.../profile.jpg",
             "discord": "patrick#1234",
-            "teamStatus": "looking",
+            "teamStatus": "LOOKING_FOR_TEAM",
             "description": "Lorem Ipsum…",
             "interests": ["C++", "Machine Learning"]
         },
@@ -289,7 +291,7 @@ Response format:
             "timezone": "Americas UTC+8",
             "avatarUrl": "https://github.com/.../profile.jpg",
             "discord": "patrick#1234",
-            "teamStatus": "Not Looking",
+            "teamStatus": "NOT_LOOKING",
             "description": "Lorem Ipsum…",
             "interests": ["C++", "Machine Learning"]
         },

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -183,7 +183,7 @@ func GetFilteredProfiles(w http.ResponseWriter, r *http.Request) {
 }
 
 /*
-	Filters the profiles by TeamStatus and Interests. Additionally filters out profiles that have the TeamStatus "Not Looking".
+	Filters the profiles by TeamStatus and Interests. Additionally filters out profiles that have the TeamStatus "NOT_LOOKING".
 */
 func GetValidFilteredProfiles(w http.ResponseWriter, r *http.Request) {
 	parameters := r.URL.Query()

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -234,7 +234,7 @@ func GetFilteredProfiles(parameters map[string][]string) (*models.ProfileList, e
 }
 
 func GetValidFilteredProfiles(parameters map[string][]string) (*models.ProfileList, error) {
-	parameters["teamStatusNot"] = append(parameters["teamStatusNot"], "Not Looking")
+	parameters["teamStatusNot"] = append(parameters["teamStatusNot"], "NOT_LOOKING")
 	filtered_profile_list, err := GetFilteredProfiles(parameters)
 
 	if err != nil {

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -58,7 +58,7 @@ func SetupTestDB(t *testing.T) {
 		Description: "Hi",
 		Discord:     "testdiscordusername",
 		AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-		TeamStatus:  "Looking For Team",
+		TeamStatus:  "LOOKING_FOR_TEAM",
 		Interests:   []string{"testinterest1", "testinterest2"},
 	}
 
@@ -95,7 +95,7 @@ func TestGetAllProfilesService(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername2",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"testinterest2"},
 	}
 
@@ -122,7 +122,7 @@ func TestGetAllProfilesService(t *testing.T) {
 				Description: "Hi",
 				Discord:     "testdiscordusername",
 				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-				TeamStatus:  "Looking For Team",
+				TeamStatus:  "LOOKING_FOR_TEAM",
 				Interests:   []string{"testinterest1", "testinterest2"},
 			},
 			{
@@ -134,7 +134,7 @@ func TestGetAllProfilesService(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername2",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"testinterest2"},
 			},
 		},
@@ -185,7 +185,7 @@ func TestGetProfileService(t *testing.T) {
 		Description: "Hi",
 		Discord:     "testdiscordusername",
 		AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-		TeamStatus:  "Looking For Team",
+		TeamStatus:  "LOOKING_FOR_TEAM",
 		Interests:   []string{"testinterest1", "testinterest2"},
 	}
 
@@ -211,7 +211,7 @@ func TestCreateProfileService(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername2",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"testinterest2"},
 	}
 
@@ -236,7 +236,7 @@ func TestCreateProfileService(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername2",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"testinterest2"},
 	}
 
@@ -288,7 +288,7 @@ func TestUpdateProfileService(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername2",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"testinterest2"},
 	}
 
@@ -313,7 +313,7 @@ func TestUpdateProfileService(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername2",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"testinterest2"},
 	}
 
@@ -336,7 +336,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername2",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
 	}
 
@@ -351,13 +351,13 @@ func TestGetFilteredProfiles(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername3",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"Cpp", "Machine Learning"},
 	}
 	err = db.Insert("profiles", &profile)
 
 	parameters := map[string][]string{
-		"teamStatus": {"Found Team"},
+		"teamStatus": {"NOT_LOOKING"},
 		"interests":  {"Cpp,Machine Learning"},
 		"limit":      {"0"},
 	}
@@ -379,7 +379,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername2",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
 			},
 			{
@@ -391,7 +391,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername3",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"Cpp", "Machine Learning"},
 			},
 		},
@@ -403,7 +403,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 
 	// Add a limit and test that
 	parameters = map[string][]string{
-		"teamStatus": {"Found Team"},
+		"teamStatus": {"NOT_LOOKING"},
 		"interests":  {"Cpp,Machine Learning"},
 		"limit":      {"1"},
 	}
@@ -421,7 +421,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername2",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
 			},
 		},
@@ -433,7 +433,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 
 	// Change the interests to be off by one
 	parameters = map[string][]string{
-		"teamStatus": {"Found Team"},
+		"teamStatus": {"NOT_LOOKING"},
 		"interests":  {"Cpp,Machine Learning,Additional Interest"},
 		"limit":      {"0"},
 	}
@@ -451,7 +451,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername2",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
 			},
 		},
@@ -463,7 +463,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 
 	// Remove filter by interests
 	parameters = map[string][]string{
-		"teamStatus": {"Found Team"},
+		"teamStatus": {"NOT_LOOKING"},
 		"limit":      {"0"},
 	}
 
@@ -480,7 +480,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername2",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
 			},
 			{
@@ -492,7 +492,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername3",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"Cpp", "Machine Learning"},
 			},
 		},
@@ -521,7 +521,7 @@ func TestGetFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername2",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
 			},
 		},
@@ -546,7 +546,7 @@ func TestGetProfileLeaderboard(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername2",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
 	}
 
@@ -595,7 +595,7 @@ func TestGetProfileLeaderboard(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername3",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"Cpp"},
 	}
 
@@ -687,7 +687,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername2",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Not Looking",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
 	}
 
@@ -702,7 +702,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername3",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
+		TeamStatus:  "NOT_LOOKING",
 		Interests:   []string{"Cpp", "Machine Learning"},
 	}
 	err = db.Insert("profiles", &profile)
@@ -729,7 +729,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername3",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
+				TeamStatus:  "NOT_LOOKING",
 				Interests:   []string{"Cpp", "Machine Learning"},
 			},
 		},
@@ -744,12 +744,12 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 		Description: "Hello",
 		Discord:     "testdiscordusername3",
 		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Looking For Team",
+		TeamStatus:  "LOOKING_FOR_TEAM",
 		Interests:   []string{},
 	}
 	err = db.Insert("profiles", &profile)
 
-	// Remove the interests filter. Now every profile should show up except for those that are "Not Looking" for a team.
+	// Remove the interests filter. Now every profile should show up except for those that are "NOT_LOOKING" for a team.
 
 	parameters = map[string][]string{
 		"limit": {"0"},
@@ -772,20 +772,8 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 				Description: "Hi",
 				Discord:     "testdiscordusername",
 				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-				TeamStatus:  "Looking For Team",
+				TeamStatus:  "LOOKING_FOR_TEAM",
 				Interests:   []string{"testinterest1", "testinterest2"},
-			},
-			{
-				ID:          "testid3",
-				FirstName:   "testfirstname3",
-				LastName:    "testlastname3",
-				Points:      342,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername3",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Found Team",
-				Interests:   []string{"Cpp", "Machine Learning"},
 			},
 			{
 				ID:          "testid4",
@@ -796,7 +784,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername3",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Looking For Team",
+				TeamStatus:  "LOOKING_FOR_TEAM",
 				Interests:   []string{},
 			},
 		},
@@ -808,7 +796,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 	// Add a TeamStatus filter.
 
 	parameters = map[string][]string{
-		"teamStatus": {"Looking For Team"},
+		"teamStatus": {"LOOKING_FOR_TEAM"},
 		"limit":      {"0"},
 	}
 
@@ -829,7 +817,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 				Description: "Hi",
 				Discord:     "testdiscordusername",
 				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-				TeamStatus:  "Looking For Team",
+				TeamStatus:  "LOOKING_FOR_TEAM",
 				Interests:   []string{"testinterest1", "testinterest2"},
 			},
 			{
@@ -841,7 +829,7 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 				Description: "Hello",
 				Discord:     "testdiscordusername3",
 				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "Looking For Team",
+				TeamStatus:  "LOOKING_FOR_TEAM",
 				Interests:   []string{},
 			},
 		},


### PR DESCRIPTION
- `teamStatus` should be one of `LOOKING_FOR_MEMBERS` `LOOKING_FOR_TEAM` `NOT_LOOKING`
- Changed relevant tests and docs. One of the tests was not changed in #372  where a profile with `NOT_LOOKING` should have been excluded from the search results. The issue was that the `teamStatus` value used in the test was not the one we are actually excluding for, so it was a bad test that wasn't updated.

TODO
- #382