### PR TITLE
Use status field instead of http error to indicate incorrect event checkin code

### DIFF
--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -407,7 +407,7 @@ POST /event/checkin/
 Retrieves a struct that contains information about the event checkin status, point increment value, and total point number.
 Takes in a struct that contains an event checkin code.
 
-Valid values for `status` are `Success`, `InvalidTime`, `AlreadyCheckedIn`. When `status != Success`, the `newPoints` and `totalPoints` fields will be -1 and should be ignored.
+Valid values for `status` are `Success`, `InvalidCode`, `InvalidTime`, `AlreadyCheckedIn`. When `status != Success`, the `newPoints` and `totalPoints` fields will equal `-1` and should be ignored.
 
 Request format:
 ```

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -486,9 +486,7 @@ func CanRedeemPoints(event_code string) (bool, string, error) {
 	var eventCode models.EventCode
 	err := db.FindOne("eventcodes", query, &eventCode)
 
-	if err == database.ErrNotFound {
-		return false, "invalid", errors.New("No event has that code")
-	} else if err != nil {
+	if err != nil {
 		return false, "invalid", err
 	}
 


### PR DESCRIPTION
Before, we were returning an http 500 with a raw error message string indicating that the provided code was invalid (nonexistent code). We should instead return a response and populate the `status` field of the response so that front-end can more gracefully handle this expected case.