### PR TITLE
Dependency on workflow run to redeploy all 

### DIFF
--- a/.github/workflows/redeploy-all.yml
+++ b/.github/workflows/redeploy-all.yml
@@ -1,9 +1,11 @@
 name: redeploy-all
 
 on:
-  push:
-    branches:
-      - "master"
+  workflow_run:
+    workflows: ["CI"]
+    branches: [master]
+    types: 
+      - completed
 
 defaults:
   run:


### PR DESCRIPTION
Race condition where docker container push and pull from dockerhub happen at the same time, so aws can get outdated version of the api

Solution: Github actions recently released dependency to run a workflow after another one completes