### PR TITLE
Refactor favorite endpoints

### DIFF
--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -319,7 +319,7 @@ Response format:
 }
 ```
 
-POST /event/favorite/add/
+POST /event/favorite/
 -------------------------
 
 Adds the given event to the favorites for the current user.
@@ -342,7 +342,7 @@ Response format:
 }
 ```
 
-POST /event/favorite/remove/
+DELETE /event/favorite/
 ----------------------------
 
 Removes the given event from the favorites for the current user.

--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -368,7 +368,7 @@ Response format:
 }
 ```
 
-POST /profile/favorite/add/
+POST /profile/favorite/
 -------------------------
 Adds the specified profile to the current user's favorite list, and returns the updated list of favorite profiles.
 
@@ -390,7 +390,7 @@ Response format:
 }
 ```
 
-POST /profile/favorite/remove/
+DELETE /profile/favorite/
 -------------------------
 Removes the specified profile from the current user's favorite list, and returns the updated list of favorite profiles.
 

--- a/documentation/docs/reference/services/Project.md
+++ b/documentation/docs/reference/services/Project.md
@@ -176,7 +176,7 @@ Response format:
 }
 ```
 
-POST /project/favorite/add/
+POST /project/favorite/
 -------------------------
 
 Adds the given project to the favorites for the current user.
@@ -199,7 +199,7 @@ Response format:
 }
 ```
 
-POST /project/favorite/remove/
+DELETE /project/favorite/
 ----------------------------
 
 Removes the given project from the favorites for the current user.

--- a/gateway/services/event.go
+++ b/gateway/services/event.go
@@ -22,13 +22,13 @@ var EventRoutes = arbor.RouteCollection{
 	arbor.Route{
 		"AddEventFavorite",
 		"POST",
-		"/event/favorite/add/",
+		"/event/favorite/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(AddEventFavorite).ServeHTTP,
 	},
 	arbor.Route{
 		"RemoveEventFavorite",
-		"POST",
-		"/event/favorite/remove/",
+		"DELETE",
+		"/event/favorite/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveEventFavorite).ServeHTTP,
 	},
 	arbor.Route{
@@ -158,5 +158,5 @@ func AddEventFavorite(w http.ResponseWriter, r *http.Request) {
 }
 
 func RemoveEventFavorite(w http.ResponseWriter, r *http.Request) {
-	arbor.POST(w, config.EVENT_SERVICE+r.URL.String(), EventFormat, "", r)
+	arbor.DELETE(w, config.EVENT_SERVICE+r.URL.String(), EventFormat, "", r)
 }

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -82,13 +82,13 @@ var ProfileRoutes = arbor.RouteCollection{
 	arbor.Route{
 		"AddProfileFavorite",
 		"POST",
-		"/profile/favorite/add/",
+		"/profile/favorite/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.AttendeeRole, models.ApplicantRole, models.StaffRole, models.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(AddProfileFavorite).ServeHTTP,
 	},
 	arbor.Route{
 		"RemoveProfileFavorite",
-		"POST",
-		"/profile/favorite/remove/",
+		"DELETE",
+		"/profile/favorite/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.AttendeeRole, models.ApplicantRole, models.StaffRole, models.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveProfileFavorite).ServeHTTP,
 	},
 	// This needs to be the last route in order to prevent endpoints like "search", "leaderboard" from accidentally being routed as the {id} variable.
@@ -153,5 +153,5 @@ func AddProfileFavorite(w http.ResponseWriter, r *http.Request) {
 }
 
 func RemoveProfileFavorite(w http.ResponseWriter, r *http.Request) {
-	arbor.POST(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+	arbor.DELETE(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
 }

--- a/gateway/services/project.go
+++ b/gateway/services/project.go
@@ -22,13 +22,13 @@ var ProjectRoutes = arbor.RouteCollection{
 	arbor.Route{
 		"AddProjectFavorite",
 		"POST",
-		"/project/favorite/add/",
+		"/project/favorite/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(AddProjectFavorite).ServeHTTP,
 	},
 	arbor.Route{
 		"RemoveProjectFavorite",
-		"POST",
-		"/project/favorite/remove/",
+		"DELETE",
+		"/project/favorite/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.UserRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveProjectFavorite).ServeHTTP,
 	},
 	arbor.Route{
@@ -98,5 +98,5 @@ func AddProjectFavorite(w http.ResponseWriter, r *http.Request) {
 }
 
 func RemoveProjectFavorite(w http.ResponseWriter, r *http.Request) {
-	arbor.POST(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
+	arbor.DELETE(w, config.PROJECT_SERVICE+r.URL.String(), ProjectFormat, "", r)
 }

--- a/services/event/controller/controller.go
+++ b/services/event/controller/controller.go
@@ -16,8 +16,8 @@ func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
 	router.HandleFunc("/favorite/", GetEventFavorites).Methods("GET")
-	router.HandleFunc("/favorite/add/", AddEventFavorite).Methods("POST")
-	router.HandleFunc("/favorite/remove/", RemoveEventFavorite).Methods("POST")
+	router.HandleFunc("/favorite/", AddEventFavorite).Methods("POST")
+	router.HandleFunc("/favorite/", RemoveEventFavorite).Methods("DELETE")
 
 	router.HandleFunc("/filter/", GetFilteredEvents).Methods("GET")
 	router.HandleFunc("/{id}/", GetEvent).Methods("GET")

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -28,8 +28,8 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/points/award/", AwardPoints).Methods("POST")
 
 	router.HandleFunc("/favorite/", GetProfileFavorites).Methods("GET")
-	router.HandleFunc("/favorite/add/", AddProfileFavorite).Methods("POST")
-	router.HandleFunc("/favorite/remove/", RemoveProfileFavorite).Methods("POST")
+	router.HandleFunc("/favorite/", AddProfileFavorite).Methods("POST")
+	router.HandleFunc("/favorite/", RemoveProfileFavorite).Methods("DELETE")
 
 	router.HandleFunc("/{id}/", GetProfileById).Methods("GET")
 }

--- a/services/project/controller/controller.go
+++ b/services/project/controller/controller.go
@@ -15,8 +15,8 @@ func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
 	router.HandleFunc("/favorite/", GetProjectFavorites).Methods("GET")
-	router.HandleFunc("/favorite/add/", AddProjectFavorite).Methods("POST")
-	router.HandleFunc("/favorite/remove/", RemoveProjectFavorite).Methods("POST")
+	router.HandleFunc("/favorite/", AddProjectFavorite).Methods("POST")
+	router.HandleFunc("/favorite/", RemoveProjectFavorite).Methods("DELETE")
 
 	router.HandleFunc("/filter/", GetFilteredProjects).Methods("GET")
 	router.HandleFunc("/{id}/", GetProject).Methods("GET")


### PR DESCRIPTION
This PR refactors the /favorite/ endpoints for the following services:

- Profile
- Event
- Project

In particular, this PR will refactor the endpoints as follows:

- POST favorite/add/ to POST /favorite/
- POST favorite/remove/ to DELETE /favorite/