### PR TITLE
Fix decision/filter/ unable to filter by wave

### DIFF
--- a/common/database/filter.go
+++ b/common/database/filter.go
@@ -149,7 +149,7 @@ func CreateFilterQuery(
 		case "string":
 			qs, err = UpdateQuerySelectorString(qs, query_type, values)
 			query[key] = qs
-		case "int64":
+		case "int", "int64":
 			cast_values := make([]int64, len(values))
 			for i, value := range values {
 				value_int, err := strconv.ParseInt(value, 10, 64)


### PR DESCRIPTION
Previously, POST /decision/filter/ by wave did not work, and the entire decision list was returned regardless of the filter value. This is because the wave field in the request model is encoded as an int, and there is only database query filter generation logic (in filter.go.CreateFilterQuery) for int64. 

This PR fixes this by adding a case for int data types in the filtering logic. It is handled exactly like how int64s data types are handled. 