### PR TITLE
Fix registration service stats

### DIFF
--- a/common/database/stats.go
+++ b/common/database/stats.go
@@ -47,6 +47,9 @@ func AddEntryToStats(stats map[string]interface{}, entry map[string]interface{},
 			AddEntryToStats(mapped_stats, value, stripped_fields)
 		default:
 			reflect_type := reflect.TypeOf(value)
+			if reflect_type == nil {
+				return nil
+			}
 			switch reflect_type.Kind() {
 			case reflect.Array:
 				fallthrough


### PR DESCRIPTION
The registration service stats were broken because some of the fields that it uses are optional (eg race). Since the stats are collected by iterating through and summing all db registration entries, when one of these optional entries was not provided (when it was nil in the db), a nil pointer exception was thrown. I fixed this so that nil values are silently ignored when calculating stats.