### PR TITLE
Event point system

### DIFF
--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -23,7 +23,10 @@ Response format:
 		}
 	],
 	"sponsor": "Example sponsor",
-	"eventType": "WORKSHOP"
+	"eventType": "WORKSHOP",
+	"inPersonPoints": 10,
+	"inPersonVirtPoints": 5,
+	"virtualPoints": 3
 }
 ```
 
@@ -51,7 +54,10 @@ Response format:
 				}
 			],
 			"sponsor": "Example sponsor",
-			"eventType": "WORKSHOP"
+			"eventType": "WORKSHOP",
+			"inPersonPoints": 10,
+			"inPersonVirtPoints": 5,
+			"virtualPoints": 3
 		},
 		{
 			"id": "52fdfcab71282654f163f5f0f9a621d72",
@@ -68,7 +74,10 @@ Response format:
 				}
 			],
 			"sponsor": "Example sponsor",
-			"eventType": "WORKSHOP"
+			"eventType": "WORKSHOP",
+			"inPersonPoints": 20,
+			"inPersonVirtPoints": 10,
+			"virtualPoints": 5
 		}
 	]
 }
@@ -98,11 +107,14 @@ Response format:
                 }
             ],
             "sponsor": "Example sponsor",
-            "eventType": "WORKSHOP"
+            "eventType": "WORKSHOP",
+			"inPersonPoints": 10,
+			"inPersonVirtPoints": 5,
+			"virtualPoints": 3
         },
         {
             "id": "9566c74d10037c4d7bbb0407d1e2c649",
-            "name": "Example Event 10",
+            "name": "Example Event 11",
             "description": "This is a description",
             "startTime": 1532202702,
             "endTime": 1532212702,
@@ -115,7 +127,10 @@ Response format:
                 }
             ],
             "sponsor": "Example sponsor",
-            "eventType": "WORKSHOP"
+            "eventType": "WORKSHOP",
+			"inPersonPoints": 20,
+			"inPersonVirtPoints": 10,
+			"virtualPoints": 5
         }
     ]
 }
@@ -144,7 +159,10 @@ Request format:
 			"latitude": 40.1138,
 			"longitude": -88.2249
 		}
-	]
+	],
+	"inPersonPoints": 10,
+	"inPersonVirtPoints": 5,
+	"virtualPoints": 3
 }
 ```
 
@@ -165,7 +183,10 @@ Response format:
 		}
 	],
 	"sponsor": "Example sponsor",
-	"eventType": "WORKSHOP"
+	"eventType": "WORKSHOP",
+	"inPersonPoints": 10,
+	"inPersonVirtPoints": 5,
+	"virtualPoints": 3
 }
 ```
 
@@ -191,7 +212,10 @@ Response format:
 		}
 	],
 	"sponsor": "Example sponsor",
-	"eventType": "WORKSHOP"
+	"eventType": "WORKSHOP",
+	"inPersonPoints": 10,
+	"inPersonVirtPoints": 7,
+	"virtualPoints": 3
 }
 ```
 
@@ -217,7 +241,10 @@ Request format:
 			"latitude": 40.1138,
 			"longitude": -88.2249
 		}
-	]
+	],
+	"inPersonPoints": 20,
+	"inPersonVirtPoints": 10,
+	"virtualPoints": 5
 }
 ```
 
@@ -238,7 +265,10 @@ Response format:
 		}
 	],
 	"sponsor": "Example sponsor",
-	"eventType": "WORKSHOP"
+	"eventType": "WORKSHOP",
+	"inPersonPoints": 20,
+	"inPersonVirtPoints": 10,
+	"virtualPoints": 5
 }
 ```
 
@@ -367,28 +397,38 @@ Response format:
 GET /event/code/{id}/
 ----------------------------
 
-Gets a struct that contains information about the event code (generated upon event creation) and expiration time.
+Gets an array of structs that contains information about the event codes (generated upon event creation) and expiration times.
 By convention, event checkin codes will be 6 bytes long.
 
 Response format:
 ```
-{
-    "id": "52fdfc072182654f163f5f0f9a621d72",
-    "code": "sample_code",
-    "expiration": 1521388800
-}
-
+[
+	{
+		"id": "52fdfc072182654f163f5f0f9a621d72",
+		"code": "sample_code_1",
+		"isVirtual": false,
+		"expiration": 1521388800
+	},
+	{
+		"id": "52fdfc072182654f163f5f0f9a621d72",
+		"code": "sample_code_2",
+		"isVirtual": true,
+		"expiration": 1521388800
+	}
+]
 ```
 
-PUT /event/code/{id}/
+POST /event/code/
 ----------------------------
 
-Updates a struct that contains information about the event code (generated upon event creation) and expiration time.
+Creates/updates a struct that contains information about the event code (generated upon event creation) and expiration time.
 
 Request format:
 ```
 {
+	"id": "52fdfc072182654f163f5f0f9a621d72",
     "code": "new_code",
+	"isVirtual": true,
     "expiration": 1521388800
 }
 
@@ -397,8 +437,9 @@ Request format:
 Response format:
 ```
 {
-    "id": "52fdfc072182654f163f5f0f9a621d72",
+	"id": "52fdfc072182654f163f5f0f9a621d72",
     "code": "new_code",
+	"isVirtual": true,
     "expiration": 1521388800
 }
 ```
@@ -408,6 +449,8 @@ POST /event/checkin/
 
 Retrieves a struct that contains information about the event checkin status, point increment value, and total point number.
 Takes in a struct that contains an event checkin code.
+
+The endpoint will check the use HackIllinois-Identity field to determine if the user redeeming the points registered for virtual or in-person. It will compare this to the scanned code and will award points accordingly. (e.g. If registered for virtual, give `virtualPoints`. If registered for in-person but attended virtually, give `inPersonVirtPoints`. If registered for in-person and attended in-person, give `inPersonPoints`.)
 
 Valid values for `status` are `Success`, `InvalidCode`, `InvalidTime`, `AlreadyCheckedIn`. When `status != Success`, the `newPoints` and `totalPoints` fields will equal `-1` and should be ignored.
 

--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -6,8 +6,6 @@ GET /profile/
 
 Returns the profile stored for the current user.
 
-Valid values for ``teamStatus`` are ``LOOKING_FOR_MEMBERS``, ``LOOKING_FOR_TEAM``, and ``NOT_LOOKING``.
-
 ***The `id` in the profile service refers to a separate, randomly-generated, profile-only id. This is different from the (user) `id` used in other services. When a profile is created, a mapping from the user `id` to the profile `id` is stored in the database.***
 
 We will distinguish user id and profile id by using `github123456` and `profileid123456` for each, respectively, in the examples below.
@@ -19,12 +17,7 @@ Response format:
     "firstName": "John",
     "lastName": "Doe",
     "points": 2021,
-    "timezone": "Americas UTC+8",
-    "avatarUrl": "https://github.com/.../profile.jpg",
-    "discord": "patrick#1234",
-    "teamStatus": "LOOKING_FOR_TEAM",
-    "description": "Lorem Ipsum…",
-    "interests": ["C++", "Machine Learning"]
+    "isVirtual": false
 }
 
 ```
@@ -32,7 +25,7 @@ Response format:
 GET /profile/{id}/
 -------------------------
 
-Returns the profile stored for user that has the ID ``{id}``.
+Returns the profile stored for user that has the profile ID ``{id}``.
 
 Response format:
 ```
@@ -41,16 +34,29 @@ Response format:
     "firstName": "John",
     "lastName": "Doe",
     "points": 2021,
-    "timezone": "Americas UTC+8",
-    "avatarUrl": "https://github.com/.../profile.jpg",
-    "discord": "patrick#1234",
-    "teamStatus": "LOOKING_FOR_TEAM",
-    "description": "Lorem Ipsum…",
-    "interests": ["C++", "Machine Learning"]
+    "isVirtual": false
 }
 ```
 
-GET /profile/list/?teamStatus=value&interests=value,value,value&limit=value
+GET /profile/user/{id}/
+-------------------------
+
+**Internal use only.**
+
+Returns the profile stored for user that has the user ID ``{id}``.
+
+Response format:
+```
+{
+    "id": "profileid123456",
+    "firstName": "John",
+    "lastName": "Doe",
+    "points": 2021,
+    "isVirtual": false
+}
+```
+
+GET /profile/list/?isVirtual=value&interests=value,value,value&limit=value
 -------------------------
 
 **Internal use only.**
@@ -60,8 +66,6 @@ Returns a list of profiles matching the filter conditions.
 teamStatus is a string matching the user's team status.
 
 interests is a comma-separated string representing the user's interests.
-
-- i.e if the user's interests are ["C++", "Machine Learning"], you can filter on this by sending ``interests="C++,Machine Learning"``
 
 If a ``limit`` parameter is provided, it will return the first matching ``limit`` profiles. Otherwise, it will return all of the matched profiles.
 
@@ -76,24 +80,14 @@ Response format:
             "firstName": "John",
             "lastName": "Doe",
             "points": 2021,
-            "timezone": "Americas UTC+8",
-            "avatarUrl": "https://github.com/.../profile.jpg",
-            "discord": "patrick#1234",
-            "teamStatus": "LOOKING_FOR_TEAM",
-            "description": "Lorem Ipsum…",
-            "interests": ["C++", "Machine Learning"]
+            "isVirtual": false
         },
         {
             "id": "profileid123456",
             "firstName": "John",
             "lastName": "Doe",
             "points": 2021,
-            "timezone": "Americas UTC+8",
-            "avatarUrl": "https://github.com/.../profile.jpg",
-            "discord": "patrick#1234",
-            "teamStatus": "LOOKING_FOR_MEMBERS",
-            "description": "Lorem Ipsum…",
-            "interests": ["C++", "Machine Learning"]
+            "isVirtual": false
         },
     ]
 }
@@ -109,12 +103,7 @@ Request format:
 {
     "firstName": "John",
     "lastName": "Doe",
-    "timezone": "Americas UTC+8",
-    "avatarUrl": "https://github.com/.../profile.jpg",
-    "discord": "patrick#1234",
-    "teamStatus": "LOOKING_FOR_TEAM",
-    "description": "Lorem Ipsum…",
-    "interests": ["C++", "Machine Learning"]
+    "isVirtual": false
 }
 ```
 
@@ -124,13 +113,8 @@ Response format:
     "id": "profileid123456",
     "firstName": "John",
     "lastName": "Doe",
-    "points": 2021,
-    "timezone": "Americas UTC+8",
-    "avatarUrl": "https://github.com/.../profile.jpg",
-    "discord": "patrick#1234",
-    "teamStatus": "LOOKING_FOR_TEAM",
-    "description": "Lorem Ipsum…",
-    "interests": ["C++", "Machine Learning"]
+    "points": 0,
+    "isVirtual": false
 }
 ```
 
@@ -144,14 +128,10 @@ Note you can not edit the ``points`` field through this.
 Request format:
 ```
 {
+    "id": "profileid123456",
     "firstName": "John",
     "lastName": "Doe",
-    "timezone": "Americas UTC+8",
-    "avatarUrl": "https://github.com/.../profile.jpg",
-    "discord": "patrick#1234",
-    "teamStatus": "LOOKING_FOR_TEAM",
-    "description": "Lorem Ipsum…",
-    "interests": ["C++", "Machine Learning"]
+    "isVirtual": true
 }
 ```
 
@@ -161,13 +141,8 @@ Response format:
     "id": "profileid123456",
     "firstName": "John",
     "lastName": "Doe",
-    "points": 2021,
-    "timezone": "Americas UTC+8",
-    "avatarUrl": "https://github.com/.../profile.jpg",
-    "discord": "patrick#1234",
-    "teamStatus": "LOOKING_FOR_TEAM",
-    "description": "Lorem Ipsum…",
-    "interests": ["C++", "Machine Learning"]
+    "points": 0,
+    "isVirtual": true
 }
 ```
 
@@ -186,13 +161,8 @@ Response format:
     "id": "profileid123456",
     "firstName": "John",
     "lastName": "Doe",
-    "points": 2021,
-    "timezone": "Americas UTC+8",
-    "avatarUrl": "https://github.com/.../profile.jpg",
-    "discord": "patrick#1234",
-    "teamStatus": "LOOKING_FOR_TEAM",
-    "description": "Lorem Ipsum…",
-    "interests": ["C++", "Machine Learning"]
+    "points": 0,
+    "isVirtual": false
 }
 ```
 
@@ -223,20 +193,12 @@ Response format:
 }
 ```
 
-GET /profile/search/?teamStatus=value&interests=value,value,value&limit=value
+GET /profile/search/?isVirtual=value&interests=value,value,value&limit=value
 -------------------------
 
-Returns a list of profiles matching the filter conditions. 
-
-``teamStatus`` is a string matching the user's team status. Valid values for ``teamStatus`` are ``LOOKING_FOR_MEMBERS``, ``LOOKING_FOR_TEAM``, and ``NOT_LOOKING``.
-
-interests is a comma-separated string representing the user's interests.
-
-- i.e if the user's interests are ["C++", "Machine Learning"], you can filter on this by sending ``interests="C++,Machine Learning"``
+Returns a list of profiles matching the filter conditions.
 
 If a ``limit`` parameter is provided, it will return the first matching ``limit`` profiles. Otherwise, it will return all of the matched profiles.
-
-Any users with the TeamStatus "NOT_LOOKING" will be removed.
 
 Response format:
 ```
@@ -247,12 +209,14 @@ Response format:
             "firstName": "John",
             "lastName": "Doe",
             "points": 2021,
+            "isVirtual": false
         },
         {
             "id": "profileid123456",
             "firstName": "John",
             "lastName": "Doe",
             "points": 2021,
+            "isVirtual": false
         },
     ]
 }
@@ -308,14 +272,8 @@ Response format:
     "id": "profileid123456",
     "firstName": "John",
     "lastName": "Doe",
-    "points": 2021,
-    "timezone": "Americas UTC+8",
-    "avatarUrl": "https://github.com/.../profile.jpg",
-    "discord": "patrick#1234",
-    "teamStatus": "LOOKING_FOR_TEAM",
-    "description": "Lorem Ipsum…",
-    "interests": ["C++", "Machine Learning"]
-    "points": 10
+    "points": 10,
+    "isVirtual": false
 }
 ```
 

--- a/gateway/services/event.go
+++ b/gateway/services/event.go
@@ -93,8 +93,8 @@ var EventRoutes = arbor.RouteCollection{
 	},
 	arbor.Route{
 		"UpdateEventCode",
-		"PUT",
-		"/event/code/{id}/",
+		"POST",
+		"/event/code/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(PutEventCode).ServeHTTP,
 	},
 	arbor.Route{
@@ -122,7 +122,7 @@ func CreateEvent(w http.ResponseWriter, r *http.Request) {
 }
 
 func UpdateEvent(w http.ResponseWriter, r *http.Request) {
-	arbor.PUT(w, config.EVENT_SERVICE+r.URL.String(), EventFormat, "", r)
+	arbor.POST(w, config.EVENT_SERVICE+r.URL.String(), EventFormat, "", r)
 }
 
 func GetEventCode(w http.ResponseWriter, r *http.Request) {

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -85,6 +85,12 @@ var ProfileRoutes = arbor.RouteCollection{
 		"/profile/favorite/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.AttendeeRole, models.ApplicantRole, models.StaffRole, models.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveProfileFavorite).ServeHTTP,
 	},
+	arbor.Route{
+		"GetUserProfileByUserId",
+		"GET",
+		"/profile/user/{id}/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(GetProfileByUserId).ServeHTTP,
+	},
 	// This needs to be the last route in order to prevent endpoints like "search", "leaderboard" from accidentally being routed as the {id} variable.
 	arbor.Route{
 		"GetUserProfileById",
@@ -99,6 +105,10 @@ func GetProfile(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetProfileById(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func GetProfileByUserId(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
 }
 

--- a/services/event/controller/controller.go
+++ b/services/event/controller/controller.go
@@ -26,7 +26,7 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/", UpdateEvent).Methods("PUT")
 	router.HandleFunc("/", GetAllEvents).Methods("GET")
 	router.HandleFunc("/code/{id}/", GetEventCode).Methods("GET")
-	router.HandleFunc("/code/{id}/", UpdateEventCode).Methods("PUT")
+	router.HandleFunc("/code/", UpdateEventCode).Methods("POST")
 
 	router.HandleFunc("/checkin/", Checkin).Methods("POST")
 
@@ -162,47 +162,38 @@ func GetEventCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	code, err := service.GetEventCode(id)
+	codes, err := service.GetEventCode(id)
 
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Failed to receive event code information from database"))
 		return
 	}
 
-	json.NewEncoder(w).Encode(code)
+	json.NewEncoder(w).Encode(codes)
 }
 
 /*
 	Endpoint to update an event code and end time
 */
 func UpdateEventCode(w http.ResponseWriter, r *http.Request) {
-	id := mux.Vars(r)["id"]
-
-	if id == "" {
-		errors.WriteError(w, r, errors.MalformedRequestError("Must provide event id in request url.", "Must provide event id in request url."))
-		return
-	}
-
 	var eventCode models.EventCode
 	json.NewDecoder(r.Body).Decode(&eventCode)
 
-	eventCode.ID = id
-
-	err := service.UpdateEventCode(id, eventCode)
+	err := service.UpdateEventCode(eventCode.Code, eventCode)
 
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not update the code and timestamp of the event."))
 		return
 	}
 
-	updated_event, err := service.GetEventCode(id)
+	updated_codes, err := service.GetEventCode(eventCode.ID)
 
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated event code and timestamp details."))
 		return
 	}
 
-	json.NewEncoder(w).Encode(updated_event)
+	json.NewEncoder(w).Encode(updated_codes)
 }
 
 /*

--- a/services/event/models/event.go
+++ b/services/event/models/event.go
@@ -1,16 +1,17 @@
 package models
 
 type Event struct {
-	ID             string          `json:"id"                  validate:"required"`
-	Name           string          `json:"name"                validate:"required"`
-	Description    string          `json:"description"         validate:"required"`
-	StartTime      int64           `json:"startTime"           validate:"required"`
-	EndTime        int64           `json:"endTime"             validate:"required"`
-	Locations      []EventLocation `json:"locations"           validate:"required,dive,required"`
-	Sponsor        string          `json:"sponsor"`
-	EventType      string          `json:"eventType"           validate:"required,oneof=MEAL SPEAKER WORKSHOP MINIEVENT QNA OTHER"`
-	InPersonPoints int             `json:"inPersonPoints"`
-	VirtualPoints  int             `json:"virtualPoints"`
+	ID                 string          `json:"id"                  validate:"required"`
+	Name               string          `json:"name"                validate:"required"`
+	Description        string          `json:"description"         validate:"required"`
+	StartTime          int64           `json:"startTime"           validate:"required"`
+	EndTime            int64           `json:"endTime"             validate:"required"`
+	Locations          []EventLocation `json:"locations"           validate:"required,dive,required"`
+	Sponsor            string          `json:"sponsor"`
+	EventType          string          `json:"eventType"           validate:"required,oneof=MEAL SPEAKER WORKSHOP MINIEVENT QNA OTHER"`
+	InPersonPoints     int             `json:"inPersonPoints"`
+	InPersonVirtPoints int             `json:"inPersonVirtPoints"`
+	VirtualPoints      int             `json:"virtualPoints"`
 }
 
 type EventLocation struct {

--- a/services/event/models/event.go
+++ b/services/event/models/event.go
@@ -1,15 +1,16 @@
 package models
 
 type Event struct {
-	ID          string          `json:"id"                  validate:"required"`
-	Name        string          `json:"name"                validate:"required"`
-	Description string          `json:"description"         validate:"required"`
-	StartTime   int64           `json:"startTime"           validate:"required"`
-	EndTime     int64           `json:"endTime"             validate:"required"`
-	Locations   []EventLocation `json:"locations"           validate:"required,dive,required"`
-	Sponsor     string          `json:"sponsor"`
-	EventType   string          `json:"eventType"           validate:"required,oneof=MEAL SPEAKER WORKSHOP MINIEVENT QNA OTHER"`
-	Points      int             `json:"points"`
+	ID             string          `json:"id"                  validate:"required"`
+	Name           string          `json:"name"                validate:"required"`
+	Description    string          `json:"description"         validate:"required"`
+	StartTime      int64           `json:"startTime"           validate:"required"`
+	EndTime        int64           `json:"endTime"             validate:"required"`
+	Locations      []EventLocation `json:"locations"           validate:"required,dive,required"`
+	Sponsor        string          `json:"sponsor"`
+	EventType      string          `json:"eventType"           validate:"required,oneof=MEAL SPEAKER WORKSHOP MINIEVENT QNA OTHER"`
+	InPersonPoints int             `json:"inPersonPoints"`
+	VirtualPoints  int             `json:"virtualPoints"`
 }
 
 type EventLocation struct {

--- a/services/event/models/event_code.go
+++ b/services/event/models/event_code.go
@@ -3,5 +3,6 @@ package models
 type EventCode struct {
 	ID         string `json:"id"`
 	Code       string `json:"code"`
+	IsVirtual  bool   `json:"isVirtual"`
 	Expiration int64  `json:"expiration"`
 }

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -499,30 +499,32 @@ func CanRedeemPoints(event_code string) (bool, bool, string, error) {
 /*
 	Returns the eventcode struct for the event with the given id
 */
-func GetEventCode(id string) (*models.EventCode, error) {
+func GetEventCode(id string) (*[]models.EventCode, error) {
 	query := database.QuerySelector{
 		"id": id,
 	}
 
-	var eventCode models.EventCode
-	err := db.FindOne("eventcodes", query, &eventCode)
+	eventCodes := []models.EventCode{}
+
+	err := db.FindAll("eventcodes", query, &eventCodes)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &eventCode, nil
+	return &eventCodes, nil
 }
 
 /*
 	Updates the event code and end time with the given id
+	If no matching code is not found, then it is a new code and add it
 */
-func UpdateEventCode(id string, eventCode models.EventCode) error {
+func UpdateEventCode(code string, eventCode models.EventCode) error {
 	selector := database.QuerySelector{
-		"id": id,
+		"code": code,
 	}
 
-	err := db.Update("eventcodes", selector, &eventCode)
+	_, err := db.Upsert("eventcodes", selector, &eventCode)
 
 	return err
 }

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -478,7 +478,7 @@ func GetStats() (map[string]interface{}, error) {
 	Check if an event can be redeemed for points, i.e., that the point timeout has not been reached
 	Returns true if the current time is between `PreEventCheckinIntervalInMinutes` number of minutes before the event, and the end of event.
 */
-func CanRedeemPoints(event_code string) (bool, string, error) {
+func CanRedeemPoints(event_code string) (bool, bool, string, error) {
 	query := database.QuerySelector{
 		"code": event_code,
 	}
@@ -487,13 +487,13 @@ func CanRedeemPoints(event_code string) (bool, string, error) {
 	err := db.FindOne("eventcodes", query, &eventCode)
 
 	if err != nil {
-		return false, "invalid", err
+		return false, false, "invalid", err
 	}
 
 	expiration_time := eventCode.Expiration
 	current_time := time.Now().Unix()
 
-	return current_time < expiration_time, eventCode.ID, nil
+	return current_time < expiration_time, eventCode.IsVirtual, eventCode.ID, nil
 }
 
 /*

--- a/services/event/service/profile_service.go
+++ b/services/event/service/profile_service.go
@@ -53,3 +53,19 @@ func AwardPoints(id string, points int) (*models.Profile, error) {
 
 	return &profile, nil
 }
+
+func GetIsUserVirtual(id string) (bool, error) {
+	var profile models.Profile
+
+	status, err := apirequest.Get(config.PROFILE_SERVICE+"/profile/user/"+id+"/", &profile)
+
+	if err != nil {
+		return false, err
+	}
+
+	if status != http.StatusOK {
+		return false, errors.New("Unable to retrieve if user is virtual or in-person")
+	}
+
+	return profile.IsVirtual, nil
+}

--- a/services/event/tests/event_test.go
+++ b/services/event/tests/event_test.go
@@ -66,7 +66,8 @@ func SetupTestDB(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		Points: 10,
+		InPersonPoints: 10,
+		VirtualPoints:  5,
 	}
 
 	err := db.Insert("events", &event)
@@ -153,7 +154,8 @@ func TestGetAllEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				Points: 10,
+				InPersonPoints: 10,
+				VirtualPoints:  5,
 			},
 			{
 				ID:          "testid2",
@@ -172,7 +174,8 @@ func TestGetAllEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				Points: 0,
+				InPersonPoints: 0,
+				VirtualPoints:  0,
 			},
 		},
 	}
@@ -224,7 +227,8 @@ func TestGetFilteredEventsService(t *testing.T) {
 				Longitude: 123.456,
 			},
 		},
-		Points: 0,
+		InPersonPoints: 0,
+		VirtualPoints:  0,
 	}
 
 	err := db.Insert("events", &event)
@@ -262,7 +266,8 @@ func TestGetFilteredEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				Points: 0,
+				InPersonPoints: 0,
+				VirtualPoints:  0,
 			},
 		},
 	}
@@ -300,7 +305,8 @@ func TestGetFilteredEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				Points: 10,
+				InPersonPoints: 0,
+				VirtualPoints:  0,
 			},
 			{
 				ID:          "testid2",
@@ -319,7 +325,8 @@ func TestGetFilteredEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				Points: 0,
+				InPersonPoints: 0,
+				VirtualPoints:  0,
 			},
 		},
 	}
@@ -377,7 +384,8 @@ func TestGetEventService(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		Points: 10,
+		InPersonPoints: 10,
+		VirtualPoints:  5,
 	}
 
 	if !reflect.DeepEqual(event, &expected_event) {
@@ -439,7 +447,8 @@ func TestCreateEventService(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		Points: 0,
+		InPersonPoints: 0,
+		VirtualPoints:  0,
 	}
 
 	if !reflect.DeepEqual(event, &expected_event) {
@@ -536,7 +545,8 @@ func TestUpdateEventService(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		Points: 100,
+		InPersonPoints: 100,
+		VirtualPoints:  50,
 	}
 
 	err := service.UpdateEvent("testid", event)
@@ -567,7 +577,8 @@ func TestUpdateEventService(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		Points: 100,
+		InPersonPoints: 100,
+		VirtualPoints:  50,
 	}
 
 	if !reflect.DeepEqual(updated_event, &expected_event) {

--- a/services/event/tests/event_test.go
+++ b/services/event/tests/event_test.go
@@ -66,8 +66,9 @@ func SetupTestDB(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		InPersonPoints: 10,
-		VirtualPoints:  5,
+		InPersonPoints:     10,
+		InPersonVirtPoints: 7,
+		VirtualPoints:      5,
 	}
 
 	err := db.Insert("events", &event)
@@ -154,8 +155,9 @@ func TestGetAllEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				InPersonPoints: 10,
-				VirtualPoints:  5,
+				InPersonPoints:     10,
+				InPersonVirtPoints: 7,
+				VirtualPoints:      5,
 			},
 			{
 				ID:          "testid2",
@@ -174,8 +176,9 @@ func TestGetAllEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				InPersonPoints: 0,
-				VirtualPoints:  0,
+				InPersonPoints:     0,
+				InPersonVirtPoints: 0,
+				VirtualPoints:      0,
 			},
 		},
 	}
@@ -227,8 +230,9 @@ func TestGetFilteredEventsService(t *testing.T) {
 				Longitude: 123.456,
 			},
 		},
-		InPersonPoints: 0,
-		VirtualPoints:  0,
+		InPersonPoints:     0,
+		InPersonVirtPoints: 0,
+		VirtualPoints:      0,
 	}
 
 	err := db.Insert("events", &event)
@@ -266,8 +270,9 @@ func TestGetFilteredEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				InPersonPoints: 0,
-				VirtualPoints:  0,
+				InPersonPoints:     0,
+				InPersonVirtPoints: 0,
+				VirtualPoints:      0,
 			},
 		},
 	}
@@ -305,8 +310,9 @@ func TestGetFilteredEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				InPersonPoints: 0,
-				VirtualPoints:  0,
+				InPersonPoints:     10,
+				InPersonVirtPoints: 7,
+				VirtualPoints:      5,
 			},
 			{
 				ID:          "testid2",
@@ -325,8 +331,9 @@ func TestGetFilteredEventsService(t *testing.T) {
 						Longitude: 123.456,
 					},
 				},
-				InPersonPoints: 0,
-				VirtualPoints:  0,
+				InPersonPoints:     0,
+				InPersonVirtPoints: 0,
+				VirtualPoints:      0,
 			},
 		},
 	}
@@ -384,8 +391,9 @@ func TestGetEventService(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		InPersonPoints: 10,
-		VirtualPoints:  5,
+		InPersonPoints:     10,
+		InPersonVirtPoints: 7,
+		VirtualPoints:      5,
 	}
 
 	if !reflect.DeepEqual(event, &expected_event) {
@@ -447,8 +455,9 @@ func TestCreateEventService(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		InPersonPoints: 0,
-		VirtualPoints:  0,
+		InPersonPoints:     0,
+		InPersonVirtPoints: 0,
+		VirtualPoints:      0,
 	}
 
 	if !reflect.DeepEqual(event, &expected_event) {
@@ -545,8 +554,9 @@ func TestUpdateEventService(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		InPersonPoints: 100,
-		VirtualPoints:  50,
+		InPersonPoints:     100,
+		InPersonVirtPoints: 70,
+		VirtualPoints:      50,
 	}
 
 	err := service.UpdateEvent("testid", event)
@@ -577,8 +587,9 @@ func TestUpdateEventService(t *testing.T) {
 				Longitude:   123.456,
 			},
 		},
-		InPersonPoints: 100,
-		VirtualPoints:  50,
+		InPersonPoints:     100,
+		InPersonVirtPoints: 70,
+		VirtualPoints:      50,
 	}
 
 	if !reflect.DeepEqual(updated_event, &expected_event) {

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -30,6 +30,8 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/favorite/", AddProfileFavorite).Methods("POST")
 	router.HandleFunc("/favorite/", RemoveProfileFavorite).Methods("DELETE")
 
+	router.HandleFunc("/user/{id}/", GetProfileByUserId).Methods("GET")
+
 	router.HandleFunc("/{id}/", GetProfileById).Methods("GET")
 }
 
@@ -66,6 +68,29 @@ func GetProfileById(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile for profile id "+profile_id))
+		return
+	}
+
+	json.NewEncoder(w).Encode(user_profile)
+}
+
+/*
+	GetProfileByUserId is used to get a profile for a provided user id.
+*/
+func GetProfileByUserId(w http.ResponseWriter, r *http.Request) {
+	user_id := mux.Vars(r)["id"]
+
+	profile_id, err := service.GetProfileIdFromUserId(user_id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile id associated with the user"))
+		return
+	}
+
+	user_profile, err := service.GetProfile(profile_id)
+
+	if err != nil {
+		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile for user id "+user_id))
 		return
 	}
 

--- a/services/profile/models/profile.go
+++ b/services/profile/models/profile.go
@@ -1,14 +1,9 @@
 package models
 
 type Profile struct {
-	ID          string   `json:"id"`
-	FirstName   string   `json:"firstName"`
-	LastName    string   `json:"lastName"`
-	Points      int      `json:"points"`
-	Timezone    string   `json:"timezone"`
-	Description string   `json:"description"`
-	Discord     string   `json:"discord"`
-	AvatarUrl   string   `json:"avatarUrl"`
-	TeamStatus  string   `json:"teamStatus"`
-	Interests   []string `json:"interests"`
+	ID        string `json:"id"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Points    int    `json:"points"`
+	IsVirtual bool   `json:"isVirtual"`
 }

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -295,9 +295,10 @@ func GetFilteredProfiles(parameters map[string][]string) (*models.ProfileList, e
 /*
 	Returns a list of profiles filtered upon teamStatus and interests. Will be limited to only include the first "limit" results.
 	Will also remove profiles with a TeamStatus set to "NOT_LOOKING"
+
+	Sorta redundant since the Profile model doesn't have team status or interest fields anymore
 */
 func GetValidFilteredProfiles(parameters map[string][]string) (*models.ProfileList, error) {
-	parameters["teamStatusNot"] = append(parameters["teamStatusNot"], "NOT_LOOKING")
 	filtered_profile_list, err := GetFilteredProfiles(parameters)
 
 	if err != nil {

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -323,10 +323,11 @@ func RedeemEvent(profile_id string, event_id string) (*models.RedeemEventRespons
 
 	if err != nil {
 		if err == database.ErrNotFound {
-			err = db.Insert("profileattendance", &models.AttendanceTracker{
+			attended_events = models.AttendanceTracker{
 				ID:     profile_id,
 				Events: []string{},
-			})
+			}
+			err = db.Insert("profileattendance", &attended_events)
 
 			if err != nil {
 				redemption_status.Status = "Could not add tracker to db"

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -53,16 +53,11 @@ func SetupTestDB(t *testing.T) {
 	profile_id := "testid"
 
 	profile := models.Profile{
-		ID:          profile_id,
-		FirstName:   "testfirstname",
-		LastName:    "testlastname",
-		Points:      0,
-		Timezone:    "America/Chicago",
-		Description: "Hi",
-		Discord:     "testdiscordusername",
-		AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-		TeamStatus:  "LOOKING_FOR_TEAM",
-		Interests:   []string{"testinterest1", "testinterest2"},
+		ID:        profile_id,
+		FirstName: "testfirstname",
+		LastName:  "testlastname",
+		Points:    0,
+		IsVirtual: false,
 	}
 
 	id_map := models.IdMap{
@@ -121,18 +116,14 @@ func CleanupTestDB(t *testing.T) {
 */
 func TestGetAllProfilesService(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	profile := models.Profile{
-		ID:          "testid2",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"testinterest2"},
+		ID:        "testid2",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: true,
 	}
 
 	err := db.Insert("profiles", &profile)
@@ -152,28 +143,18 @@ func TestGetAllProfilesService(t *testing.T) {
 	expected_profile_list := models.ProfileList{
 		Profiles: []models.Profile{
 			{
-				ID:          "testid",
-				FirstName:   "testfirstname",
-				LastName:    "testlastname",
-				Points:      0,
-				Timezone:    "America/Chicago",
-				Description: "Hi",
-				Discord:     "testdiscordusername",
-				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-				TeamStatus:  "LOOKING_FOR_TEAM",
-				Interests:   []string{"testinterest1", "testinterest2"},
+				ID:        "testid",
+				FirstName: "testfirstname",
+				LastName:  "testlastname",
+				Points:    0,
+				IsVirtual: false,
 			},
 			{
-				ID:          "testid2",
-				FirstName:   "testfirstname2",
-				LastName:    "testlastname2",
-				Points:      340,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername2",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"testinterest2"},
+				ID:        "testid2",
+				FirstName: "testfirstname2",
+				LastName:  "testlastname2",
+				Points:    340,
+				IsVirtual: true,
 			},
 		},
 	}
@@ -197,9 +178,6 @@ func TestGetAllProfilesService(t *testing.T) {
 	if !reflect.DeepEqual(actual_profile_list, &expected_profile_list) {
 		t.Errorf("Wrong profile list. Expected %v, got %v", expected_profile_list, actual_profile_list)
 	}
-
-	CleanupTestDB(t)
-
 }
 
 /*
@@ -207,6 +185,7 @@ func TestGetAllProfilesService(t *testing.T) {
 */
 func TestGetProfileService(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	profile, err := service.GetProfile("testid")
 
@@ -215,23 +194,16 @@ func TestGetProfileService(t *testing.T) {
 	}
 
 	expected_profile := models.Profile{
-		ID:          "testid",
-		FirstName:   "testfirstname",
-		LastName:    "testlastname",
-		Points:      0,
-		Timezone:    "America/Chicago",
-		Description: "Hi",
-		Discord:     "testdiscordusername",
-		AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-		TeamStatus:  "LOOKING_FOR_TEAM",
-		Interests:   []string{"testinterest1", "testinterest2"},
+		ID:        "testid",
+		FirstName: "testfirstname",
+		LastName:  "testlastname",
+		Points:    0,
+		IsVirtual: false,
 	}
 
 	if !reflect.DeepEqual(profile, &expected_profile) {
 		t.Errorf("Wrong profile info. Expected %v, got %v", &expected_profile, profile)
 	}
-
-	CleanupTestDB(t)
 }
 
 /*
@@ -239,18 +211,14 @@ func TestGetProfileService(t *testing.T) {
 */
 func TestCreateProfileService(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	new_profile := models.Profile{
-		ID:          "testid2",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"testinterest2"},
+		ID:        "testid2",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: true,
 	}
 
 	err := service.CreateProfile("testuserid2", "testid2", new_profile)
@@ -266,16 +234,11 @@ func TestCreateProfileService(t *testing.T) {
 	}
 
 	expected_profile := models.Profile{
-		ID:          "testid2",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"testinterest2"},
+		ID:        "testid2",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: true,
 	}
 
 	if !reflect.DeepEqual(profile, &expected_profile) {
@@ -292,8 +255,6 @@ func TestCreateProfileService(t *testing.T) {
 	if profile_id1 != "testid2" {
 		t.Errorf("Wrong profile mapping found for user %s. Expected %s but got %s", "testuserid2", "testid2", profile_id1)
 	}
-
-	CleanupTestDB(t)
 }
 
 /*
@@ -301,6 +262,7 @@ func TestCreateProfileService(t *testing.T) {
 */
 func TestDeleteProfileService(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	profile_id := "testid"
 
@@ -318,8 +280,6 @@ func TestDeleteProfileService(t *testing.T) {
 	if err == nil {
 		t.Errorf("Found profile %v in profiles database.", profile)
 	}
-
-	CleanupTestDB(t)
 }
 
 /*
@@ -327,18 +287,14 @@ func TestDeleteProfileService(t *testing.T) {
 */
 func TestUpdateProfileService(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	profile := models.Profile{
-		ID:          "testid",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"testinterest2"},
+		ID:        "testid",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: true,
 	}
 
 	err := service.UpdateProfile("testid", profile)
@@ -354,61 +310,44 @@ func TestUpdateProfileService(t *testing.T) {
 	}
 
 	expected_profile := models.Profile{
-		ID:          "testid",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"testinterest2"},
+		ID:        "testid",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: true,
 	}
 
 	if !reflect.DeepEqual(updated_profile, &expected_profile) {
 		t.Errorf("Wrong profile info. Expected %v, got %v", expected_profile, updated_profile)
 	}
-
-	CleanupTestDB(t)
 }
 
 func TestGetFilteredProfiles(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	profile := models.Profile{
-		ID:          "testid2",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
+		ID:        "testid2",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: true,
 	}
 
 	err := db.Insert("profiles", &profile)
 
 	profile = models.Profile{
-		ID:          "testid3",
-		FirstName:   "testfirstname3",
-		LastName:    "testlastname3",
-		Points:      342,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername3",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"Cpp", "Machine Learning"},
+		ID:        "testid3",
+		FirstName: "testfirstname3",
+		LastName:  "testlastname3",
+		Points:    342,
+		IsVirtual: true,
 	}
 	err = db.Insert("profiles", &profile)
 
 	parameters := map[string][]string{
-		"teamStatus": {"NOT_LOOKING"},
-		"interests":  {"Cpp,Machine Learning"},
-		"limit":      {"0"},
+		"IsVirtual": {"true"},
+		"limit":     {"0"},
 	}
 
 	filtered_profile_list, err := service.GetFilteredProfiles(parameters)
@@ -420,28 +359,18 @@ func TestGetFilteredProfiles(t *testing.T) {
 	expected_filtered_profile_list := models.ProfileList{
 		Profiles: []models.Profile{
 			{
-				ID:          "testid2",
-				FirstName:   "testfirstname2",
-				LastName:    "testlastname2",
-				Points:      340,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername2",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
+				ID:        "testid2",
+				FirstName: "testfirstname2",
+				LastName:  "testlastname2",
+				Points:    340,
+				IsVirtual: true,
 			},
 			{
-				ID:          "testid3",
-				FirstName:   "testfirstname3",
-				LastName:    "testlastname3",
-				Points:      342,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername3",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"Cpp", "Machine Learning"},
+				ID:        "testid3",
+				FirstName: "testfirstname3",
+				LastName:  "testlastname3",
+				Points:    342,
+				IsVirtual: true,
 			},
 		},
 	}
@@ -452,9 +381,8 @@ func TestGetFilteredProfiles(t *testing.T) {
 
 	// Add a limit and test that
 	parameters = map[string][]string{
-		"teamStatus": {"NOT_LOOKING"},
-		"interests":  {"Cpp,Machine Learning"},
-		"limit":      {"1"},
+		"IsVirtual": {"true"},
+		"limit":     {"1"},
 	}
 
 	filtered_profile_list, err = service.GetFilteredProfiles(parameters)
@@ -462,16 +390,11 @@ func TestGetFilteredProfiles(t *testing.T) {
 	expected_filtered_profile_list = models.ProfileList{
 		Profiles: []models.Profile{
 			{
-				ID:          "testid2",
-				FirstName:   "testfirstname2",
-				LastName:    "testlastname2",
-				Points:      340,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername2",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
+				ID:        "testid2",
+				FirstName: "testfirstname2",
+				LastName:  "testlastname2",
+				Points:    340,
+				IsVirtual: true,
 			},
 		},
 	}
@@ -480,11 +403,9 @@ func TestGetFilteredProfiles(t *testing.T) {
 		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
 	}
 
-	// Change the interests to be off by one
+	// Remove filter by virtual status
 	parameters = map[string][]string{
-		"teamStatus": {"NOT_LOOKING"},
-		"interests":  {"Cpp,Machine Learning,Additional Interest"},
-		"limit":      {"0"},
+		"limit": {"0"},
 	}
 
 	filtered_profile_list, err = service.GetFilteredProfiles(parameters)
@@ -492,16 +413,25 @@ func TestGetFilteredProfiles(t *testing.T) {
 	expected_filtered_profile_list = models.ProfileList{
 		Profiles: []models.Profile{
 			{
-				ID:          "testid2",
-				FirstName:   "testfirstname2",
-				LastName:    "testlastname2",
-				Points:      340,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername2",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
+				ID:        "testid",
+				FirstName: "testfirstname",
+				LastName:  "testlastname",
+				Points:    0,
+				IsVirtual: false,
+			},
+			{
+				ID:        "testid2",
+				FirstName: "testfirstname2",
+				LastName:  "testlastname2",
+				Points:    340,
+				IsVirtual: true,
+			},
+			{
+				ID:        "testid3",
+				FirstName: "testfirstname3",
+				LastName:  "testlastname3",
+				Points:    342,
+				IsVirtual: true,
 			},
 		},
 	}
@@ -509,94 +439,18 @@ func TestGetFilteredProfiles(t *testing.T) {
 	if !reflect.DeepEqual(filtered_profile_list, &expected_filtered_profile_list) {
 		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
 	}
-
-	// Remove filter by interests
-	parameters = map[string][]string{
-		"teamStatus": {"NOT_LOOKING"},
-		"limit":      {"0"},
-	}
-
-	filtered_profile_list, err = service.GetFilteredProfiles(parameters)
-
-	expected_filtered_profile_list = models.ProfileList{
-		Profiles: []models.Profile{
-			{
-				ID:          "testid2",
-				FirstName:   "testfirstname2",
-				LastName:    "testlastname2",
-				Points:      340,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername2",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
-			},
-			{
-				ID:          "testid3",
-				FirstName:   "testfirstname3",
-				LastName:    "testlastname3",
-				Points:      342,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername3",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"Cpp", "Machine Learning"},
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(filtered_profile_list, &expected_filtered_profile_list) {
-		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
-	}
-
-	// Remove filter by teamStatus
-	parameters = map[string][]string{
-		"interests": {"Cpp,Machine Learning,Additional Interest"},
-		"limit":     {"0"},
-	}
-
-	filtered_profile_list, err = service.GetFilteredProfiles(parameters)
-
-	expected_filtered_profile_list = models.ProfileList{
-		Profiles: []models.Profile{
-			{
-				ID:          "testid2",
-				FirstName:   "testfirstname2",
-				LastName:    "testlastname2",
-				Points:      340,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername2",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(filtered_profile_list, &expected_filtered_profile_list) {
-		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
-	}
-
-	CleanupTestDB(t)
 }
 
 func TestGetProfileLeaderboard(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	profile := models.Profile{
-		ID:          "testid2",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
+		ID:        "testid2",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: true,
 	}
 
 	err := db.Insert("profiles", &profile)
@@ -636,16 +490,11 @@ func TestGetProfileLeaderboard(t *testing.T) {
 
 	// Insert another profile and test
 	profile = models.Profile{
-		ID:          "testid3",
-		FirstName:   "testfirstname3",
-		LastName:    "testlastname3",
-		Points:      999,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername3",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"Cpp"},
+		ID:        "testid3",
+		FirstName: "testfirstname3",
+		LastName:  "testlastname3",
+		Points:    999,
+		IsVirtual: true,
 	}
 
 	err = db.Insert("profiles", &profile)
@@ -720,44 +569,33 @@ func TestGetProfileLeaderboard(t *testing.T) {
 	if !reflect.DeepEqual(leaderboard, &expected_leaderboard) {
 		t.Errorf("Wrong profile info. Expected %v, got %v", expected_leaderboard, leaderboard)
 	}
-
-	CleanupTestDB(t)
 }
 
 func TestGetValidFilteredProfiles(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	profile := models.Profile{
-		ID:          "testid2",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
+		ID:        "testid2",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: false,
 	}
 
 	err := db.Insert("profiles", &profile)
 
 	profile = models.Profile{
-		ID:          "testid3",
-		FirstName:   "testfirstname3",
-		LastName:    "testlastname3",
-		Points:      342,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername3",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "NOT_LOOKING",
-		Interests:   []string{"Cpp", "Machine Learning"},
+		ID:        "testid3",
+		FirstName: "testfirstname3",
+		LastName:  "testlastname3",
+		Points:    342,
+		IsVirtual: true,
 	}
 	err = db.Insert("profiles", &profile)
 
 	parameters := map[string][]string{
-		"interests": {"Cpp,Machine Learning"},
+		"IsVirtual": {"true"},
 		"limit":     {"0"},
 	}
 
@@ -770,35 +608,29 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 	expected_filtered_profile_list := models.ProfileList{
 		Profiles: []models.Profile{
 			{
-				ID:          "testid3",
-				FirstName:   "testfirstname3",
-				LastName:    "testlastname3",
-				Points:      342,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername3",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "NOT_LOOKING",
-				Interests:   []string{"Cpp", "Machine Learning"},
+				ID:        "testid3",
+				FirstName: "testfirstname3",
+				LastName:  "testlastname3",
+				Points:    342,
+				IsVirtual: true,
 			},
 		},
 	}
 
+	if !reflect.DeepEqual(filtered_profile_list, &expected_filtered_profile_list) {
+		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
+	}
+
 	profile = models.Profile{
-		ID:          "testid4",
-		FirstName:   "testfirstname3",
-		LastName:    "testlastname3",
-		Points:      342,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername3",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "LOOKING_FOR_TEAM",
-		Interests:   []string{},
+		ID:        "testid4",
+		FirstName: "testfirstname4",
+		LastName:  "testlastname4",
+		Points:    342,
+		IsVirtual: false,
 	}
 	err = db.Insert("profiles", &profile)
 
-	// Remove the interests filter. Now every profile should show up except for those that are "NOT_LOOKING" for a team.
+	// Remove the virtual status filter. Now every profile should show up.
 
 	parameters = map[string][]string{
 		"limit": {"0"},
@@ -813,98 +645,50 @@ func TestGetValidFilteredProfiles(t *testing.T) {
 	expected_filtered_profile_list = models.ProfileList{
 		Profiles: []models.Profile{
 			{
-				ID:          "testid",
-				FirstName:   "testfirstname",
-				LastName:    "testlastname",
-				Points:      0,
-				Timezone:    "America/Chicago",
-				Description: "Hi",
-				Discord:     "testdiscordusername",
-				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-				TeamStatus:  "LOOKING_FOR_TEAM",
-				Interests:   []string{"testinterest1", "testinterest2"},
+				ID:        "testid",
+				FirstName: "testfirstname",
+				LastName:  "testlastname",
+				Points:    0,
+				IsVirtual: false,
 			},
 			{
-				ID:          "testid4",
-				FirstName:   "testfirstname3",
-				LastName:    "testlastname3",
-				Points:      342,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername3",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "LOOKING_FOR_TEAM",
-				Interests:   []string{},
+				ID:        "testid2",
+				FirstName: "testfirstname2",
+				LastName:  "testlastname2",
+				Points:    340,
+				IsVirtual: false,
+			},
+			{
+				ID:        "testid3",
+				FirstName: "testfirstname3",
+				LastName:  "testlastname3",
+				Points:    342,
+				IsVirtual: true,
+			},
+			{
+				ID:        "testid4",
+				FirstName: "testfirstname4",
+				LastName:  "testlastname4",
+				Points:    342,
+				IsVirtual: false,
 			},
 		},
 	}
 	if !reflect.DeepEqual(filtered_profile_list, &expected_filtered_profile_list) {
 		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
 	}
-
-	// Add a TeamStatus filter.
-
-	parameters = map[string][]string{
-		"teamStatus": {"LOOKING_FOR_TEAM"},
-		"limit":      {"0"},
-	}
-
-	filtered_profile_list, err = service.GetValidFilteredProfiles(parameters)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected_filtered_profile_list = models.ProfileList{
-		Profiles: []models.Profile{
-			{
-				ID:          "testid",
-				FirstName:   "testfirstname",
-				LastName:    "testlastname",
-				Points:      0,
-				Timezone:    "America/Chicago",
-				Description: "Hi",
-				Discord:     "testdiscordusername",
-				AvatarUrl:   "https://imgs.smoothradio.com/images/191589?crop=16_9&width=660&relax=1&signature=Rz93ikqcAz7BcX6SKiEC94zJnqo=",
-				TeamStatus:  "LOOKING_FOR_TEAM",
-				Interests:   []string{"testinterest1", "testinterest2"},
-			},
-			{
-				ID:          "testid4",
-				FirstName:   "testfirstname3",
-				LastName:    "testlastname3",
-				Points:      342,
-				Timezone:    "America/New York",
-				Description: "Hello",
-				Discord:     "testdiscordusername3",
-				AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-				TeamStatus:  "LOOKING_FOR_TEAM",
-				Interests:   []string{},
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(filtered_profile_list, &expected_filtered_profile_list) {
-		t.Errorf("Wrong profile list. Expected %v, got %v", expected_filtered_profile_list, filtered_profile_list)
-	}
-
-	CleanupTestDB(t)
 }
 
 func TestProfileFavorites(t *testing.T) {
 	SetupTestDB(t)
+	defer CleanupTestDB(t)
 
 	profile := models.Profile{
-		ID:          "testid2",
-		FirstName:   "testfirstname2",
-		LastName:    "testlastname2",
-		Points:      340,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername2",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Not Looking",
-		Interests:   []string{"Cpp", "Machine Learning", "Additional Interest"},
+		ID:        "testid2",
+		FirstName: "testfirstname2",
+		LastName:  "testlastname2",
+		Points:    340,
+		IsVirtual: true,
 	}
 
 	err := db.Insert("profiles", &profile)
@@ -967,16 +751,11 @@ func TestProfileFavorites(t *testing.T) {
 
 	// Favorite another profile
 	profile = models.Profile{
-		ID:          "testid3",
-		FirstName:   "testfirstname3",
-		LastName:    "testlastname3",
-		Points:      342,
-		Timezone:    "America/New York",
-		Description: "Hello",
-		Discord:     "testdiscordusername3",
-		AvatarUrl:   "https://yt3.ggpht.com/ytc/AAUvwniHNhQyp4hWj3nrADnils-6N3jNREP8rWKGDTp0Lg=s900-c-k-c0x00ffffff-no-rj",
-		TeamStatus:  "Found Team",
-		Interests:   []string{"Cpp", "Machine Learning"},
+		ID:        "testid3",
+		FirstName: "testfirstname3",
+		LastName:  "testlastname3",
+		Points:    342,
+		IsVirtual: true,
 	}
 	err = db.Insert("profiles", &profile)
 	if err != nil {
@@ -1013,6 +792,4 @@ func TestProfileFavorites(t *testing.T) {
 	if !reflect.DeepEqual(profile_favorites, &expected_profile_favorites) {
 		t.Errorf("Wrong favorite profile list. Expected %v, got %v", expected_profile_favorites, profile_favorites)
 	}
-
-	CleanupTestDB(t)
 }


### PR DESCRIPTION
- Event model now have 3 fields for points: `InPersonPoints`, `InPersonVirtPoints`, and `VirtualPoints`
- Event code model has an additional field `IsVirtual` to distinguish between code for virtual/in-person use
- Changed `PUT /event/code/{id}` to `POST /event/code/`
- Added an admin-only internal route `GET /profile/user/{id}/` so that we can determine if the user redeeming the event is virtual or in-person
- Fixed a bug where new entries into `profileattendance` were resulting in duplicate rows with empty `id` fields
- Reimplemented `POST /event/checkin` to check the user for virtual status
- Updated tests for profile and event service
- Updated docs for profile and event