### PR TITLE
Add registration metrics

### DIFF
--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -1,0 +1,22 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func metricsWrapper(next http.HandlerFunc, endpoint string) http.Handler {
+	labels := map[string]string{
+		"endpoint": endpoint,
+	}
+	return promhttp.InstrumentHandlerDuration(Duration.MustCurryWith(labels),
+		promhttp.InstrumentHandlerCounter(TotalRequests.MustCurryWith(labels),
+			next))
+}
+
+func RegisterHandler(endpoint string, f func(http.ResponseWriter, *http.Request), method string, router *mux.Router) {
+	chain := metricsWrapper(http.HandlerFunc(f), endpoint)
+	router.Handle(endpoint, chain).Methods(method)
+}

--- a/common/metrics/metrics_counter.go
+++ b/common/metrics/metrics_counter.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var TotalRequests = *promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Number of requests.",
+	},
+	[]string{"code", "endpoint", "method"},
+)
+
+var Duration = *promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "http_request_duration_seconds",
+		Help:    "A histogram of latencies for requests.",
+		Buckets: []float64{.25, .5, 1, 2.5, 5, 10},
+	},
+	[]string{"endpoint", "method"},
+)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/levigross/grequests v0.0.0-20181123014746-f3f67e7783bb
+	github.com/prometheus/client_golang v1.11.0
 	github.com/thoas/stats v0.0.0-20181218120333-e97827ebd7ca
 	gopkg.in/go-playground/validator.v9 v9.25.0
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce

--- a/services/registration/controller/controller.go
+++ b/services/registration/controller/controller.go
@@ -7,32 +7,38 @@ import (
 
 	"github.com/HackIllinois/api/common/datastore"
 	"github.com/HackIllinois/api/common/errors"
+	"github.com/HackIllinois/api/common/metrics"
 	"github.com/HackIllinois/api/services/registration/config"
 	"github.com/HackIllinois/api/services/registration/models"
 	"github.com/HackIllinois/api/services/registration/service"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
-	router.HandleFunc("/", GetAllCurrentRegistrations).Methods("GET")
+	router.Handle("/metrics/", promhttp.Handler()).Methods("GET")
 
-	router.HandleFunc("/attendee/", GetCurrentUserRegistration).Methods("GET")
-	router.HandleFunc("/attendee/", CreateCurrentUserRegistration).Methods("POST")
-	router.HandleFunc("/attendee/", UpdateCurrentUserRegistration).Methods("PUT")
-	router.HandleFunc("/attendee/list/", GetFilteredUserRegistrations).Methods("GET")
+	metrics.RegisterHandler("/", GetAllCurrentRegistrations, "GET", router)
 
-	router.HandleFunc("/mentor/", GetCurrentMentorRegistration).Methods("GET")
-	router.HandleFunc("/mentor/", CreateCurrentMentorRegistration).Methods("POST")
-	router.HandleFunc("/mentor/", UpdateCurrentMentorRegistration).Methods("PUT")
-	router.HandleFunc("/mentor/list/", GetFilteredMentorRegistrations).Methods("GET")
+	metrics.RegisterHandler("/attendee/", GetCurrentUserRegistration, "GET", router)
+	metrics.RegisterHandler("/attendee/", CreateCurrentUserRegistration, "POST", router)
+	metrics.RegisterHandler("/attendee/", UpdateCurrentUserRegistration, "PUT", router)
 
-	router.HandleFunc("/{id}/", GetAllRegistrations).Methods("GET")
-	router.HandleFunc("/attendee/{id}/", GetUserRegistration).Methods("GET")
-	router.HandleFunc("/mentor/{id}/", GetMentorRegistration).Methods("GET")
+	metrics.RegisterHandler("/attendee/list/", GetFilteredUserRegistrations, "GET", router)
 
-	router.HandleFunc("/internal/stats/", GetStats).Methods("GET")
+	metrics.RegisterHandler("/mentor/", GetFilteredUserRegistrations, "GET", router)
+	metrics.RegisterHandler("/mentor/", CreateCurrentMentorRegistration, "POST", router)
+	metrics.RegisterHandler("/mentor/", UpdateCurrentMentorRegistration, "PUT", router)
+
+	metrics.RegisterHandler("/mentor/list/", GetFilteredMentorRegistrations, "GET", router)
+
+	metrics.RegisterHandler("/{id}/", GetAllRegistrations, "GET", router)
+	metrics.RegisterHandler("/attendee/{id}/", GetUserRegistration, "GET", router)
+	metrics.RegisterHandler("/mentor/{id}/", GetMentorRegistration, "GET", router)
+
+	metrics.RegisterHandler("/internal/stats/", GetStats, "GET", router)
 }
 
 /*


### PR DESCRIPTION
This commit adds metric collection functionality to the registration endpoint. This is meant to be a test before adding it to the rest of the endpoints. Specifically, this commit will:

- Change `HandleFunc` in the endpoint controller router to use `RegisterHandler`, a wrapper that passes the request through metrics collection middleware before moving to specific service level functionality
-  Add two metrics defined in `common/metrics/metrics_counter.go`
    -  `http_requests_total` collecting the number of http requests by endpoint and its result status code
    - `http_request_duration_seconds` collecting the duration of each http request