### PR TITLE
Add unauthorized action e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,6 @@ docs:
 integration-test:
 	@echo "Beginning integration tests";
 	@echo "Checking if the API is running...";
-	@curl --silent --output /dev/null localhost:8000 || (echo "Failed to connect to the API. Is it running?"; exit 1;)
+	@curl --silent --output /dev/null localhost:8000 || (echo "Failed to connect to the API. Is it running? If it's not, start it with 'make run-test'"; exit 1;)
 	@echo "Running end-to-end tests";
-	@HI_CONFIG=file://$(REPO_ROOT)/config/test_config.json go test -v $(BASE_PACKAGE)/tests || exit 1;	
+	@find $(REPO_ROOT)/tests/e2e/ -maxdepth 1 -type d \( ! -name . \) -exec bash -c "cd '{}' && HI_CONFIG=file://$(REPO_ROOT)/config/test_config.json go test -v " \;

--- a/tests/common/make_client.go
+++ b/tests/common/make_client.go
@@ -1,34 +1,64 @@
-package tests
+package common
 
 import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/dghubble/sling"
+	"gopkg.in/mgo.v2"
 )
 
-func GetAdminClient() *sling.Sling {
-	// First, get an admin authorization token by running `make setup`.
-	path, err := os.Getwd()
-	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-	}
+func formatCommand(command string) *exec.Cmd {
+	split_command := strings.Split(command, " ")
 
-	fmt.Println(filepath.Dir(filepath.Dir(path)))
+	return exec.Command(split_command[0], split_command[1:]...)
+}
 
-	cmd := exec.Command("make", "setup")
-	cmd.Dir = filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(path))))
+// Retrieves the root path of the project
+func getProjectRootPath() string {
+	cmd := formatCommand("git rev-parse --show-toplevel")
+
 	out, err := cmd.Output()
-
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
 	}
 
-	out_lines := strings.Split(string(out[:]), "\n")
-	admin_token := out_lines[len(out_lines)-3]
+	return strings.Trim(string(out), "\n")
+}
 
-	return sling.New().Base("http://localhost:8000").Client(nil).Add("Authorization", admin_token)
+// Returns a Sling client configured with the desired role
+func GetSlingClient(role string) *sling.Sling {
+	root_path := getProjectRootPath()
+
+	// accountgen
+	accountgen_cmd := formatCommand(fmt.Sprintf("bin/hackillinois-utility-accountgen -role %v", role))
+	accountgen_cmd.Dir = root_path
+	_, err := accountgen_cmd.Output()
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+	}
+
+	// tokengen
+	tokengen_cmd := formatCommand(fmt.Sprintf("bin/hackillinois-utility-tokengen -role %v", role))
+	tokengen_cmd.Dir = root_path
+	out, err := tokengen_cmd.Output()
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+	}
+
+	out_lines := string(out)
+	token := strings.Trim(strings.Split(out_lines, "Token:")[1], "\n")
+
+	return sling.New().Base("http://localhost:8000").Client(nil).Add("Authorization", token)
+}
+
+func GetLocalMongoSession() *mgo.Session {
+	session, err := mgo.Dial("localhost")
+	if err != nil {
+		fmt.Println("Failed to connect to database:", err)
+		os.Exit(1)
+	}
+	return session
 }

--- a/tests/e2e/add_accept_finalize_user_test/add_accept_finalize_user_test.go
+++ b/tests/e2e/add_accept_finalize_user_test/add_accept_finalize_user_test.go
@@ -3,52 +3,20 @@ package tests
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/HackIllinois/api/common/configloader"
 	decision_models "github.com/HackIllinois/api/services/decision/models"
 	user_models "github.com/HackIllinois/api/services/user/models"
+	"github.com/HackIllinois/api/tests/common"
 	"github.com/dghubble/sling"
 	"gopkg.in/mgo.v2"
 )
 
 var admin_client *sling.Sling
 var session *mgo.Session
-
-func GetAdminClient() *sling.Sling {
-	// First, get an admin authorization token by running `make setup`.
-	path, err := os.Getwd()
-	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-	}
-
-	cmd := exec.Command("make", "setup")
-	cmd.Dir = filepath.Dir(path)
-	out, err := cmd.Output()
-
-	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-	}
-
-	out_lines := strings.Split(string(out[:]), "\n")
-	admin_token := out_lines[len(out_lines)-3]
-
-	return sling.New().Base("http://localhost:8000").Client(nil).Add("Authorization", admin_token)
-}
-
-func GetLocalMongoSession() *mgo.Session {
-	session, err := mgo.Dial("localhost")
-	if err != nil {
-		fmt.Println("Failed to connect to database:", err)
-		os.Exit(1)
-	}
-	return session
-}
 
 func TestMain(m *testing.M) {
 
@@ -59,9 +27,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	admin_client = GetAdminClient()
+	admin_client = common.GetSlingClient("Admin")
 
-	session = GetLocalMongoSession()
+	session = common.GetLocalMongoSession()
 
 	user_db_name, err := cfg.Get("USER_DB_NAME")
 	if err != nil {

--- a/tests/e2e/unauthorized_actions_test/unauthorized_actions_test.go
+++ b/tests/e2e/unauthorized_actions_test/unauthorized_actions_test.go
@@ -1,0 +1,50 @@
+// // Attendee user attempts admin actions (delete event, etc.) should result in failure
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/HackIllinois/api/common/configloader"
+	"github.com/HackIllinois/api/services/mail/models"
+	"github.com/HackIllinois/api/tests/common"
+	"github.com/dghubble/sling"
+	"gopkg.in/mgo.v2"
+)
+
+var attendee_client *sling.Sling
+var session *mgo.Session
+
+func TestMain(m *testing.M) {
+
+	cfg, err := configloader.Load(os.Getenv("HI_CONFIG"))
+
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	attendee_client = common.GetSlingClient("Attendee")
+
+	session = common.GetLocalMongoSession()
+
+	decision_db_name, err := cfg.Get("MAIL_DB_NAME")
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+	session.DB(decision_db_name).DropDatabase()
+
+	return_code := m.Run()
+	os.Exit(return_code)
+}
+
+func TestAttendeeUnauthorizedCalls(t *testing.T) {
+	received_mail_list := models.MailList{}
+	response, _ := attendee_client.New().Get("/mail/list/").Receive(&received_mail_list, &received_mail_list)
+
+	if response.StatusCode != 403 {
+		t.Errorf("Attendee able to access admin-only endpoints")
+	}
+}


### PR DESCRIPTION
This PR adds a new e2e test that checks if users can perform unauthorized actions. This PR also refactors the existing e2e testing framework. Thus, **please merge this PR first before adding new e2e tests.**

In particular, when merged, this PR will:
- Refactor commonly used test functions to a common file
- Refactor token generation for e2e tests to not use `make setup`. The new token is generated by calling the `accountgen` and `tokengen` binaries directly. This is done for two reasons:
	- Previous `make integration-test` behavior was dependent on the dir which the command is executed from
	- Enable generating tokens with roles other than admin roles (eg. a token with attendee role to test unauthorized endpoint access)
- Refactor each e2e test to have its own `TestMain`
	- `make integration-test` will iterate through all these `TestMain`s, similar to `make test` for the unit tests for the services
- Add e2e test for attendee token performing authorized access