### PR TITLE
Add profile tier to min point threshold endpoint

### DIFF
--- a/config/dev_config.json
+++ b/config/dev_config.json
@@ -428,5 +428,16 @@
 				"fields": []
 			}
 		]
-	}
+	},
+
+	"TIER_THRESHOLDS": [
+		{
+			"name": "cookie",
+			"threshold": 0
+		},
+		{
+			"name": "cupcake",
+			"threshold": 50
+		}
+	]
 }

--- a/config/production_config.json
+++ b/config/production_config.json
@@ -458,5 +458,16 @@
 				"fields": []
 			}
 		]
-	}
+	},
+
+	"TIER_THRESHOLDS": [
+		{
+			"name": "cookie",
+			"threshold": 0
+		},
+		{
+			"name": "cupcake",
+			"threshold": 50
+		}
+	]
 }

--- a/config/test_config.json
+++ b/config/test_config.json
@@ -256,5 +256,16 @@
 				"fields": []
 			}
 		]
-	}
+	},
+
+	"TIER_THRESHOLDS": [
+		{
+			"name": "cookie",
+			"threshold": 0
+		},
+		{
+			"name": "cupcake",
+			"threshold": 50
+		}
+	]
 }

--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -376,3 +376,21 @@ Response format:
     ]
 }
 ```
+
+GET /profile/tier/threshold/
+-------------------------
+Returns the profile tier name to minimum point threshold mapping.
+
+Response format:
+```
+[
+  {
+    "name": "cookie",
+    "threshold": 0
+  },
+  {
+    "name": "cupcake",
+    "threshold": 50
+  }
+]
+```

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -85,6 +85,12 @@ var ProfileRoutes = arbor.RouteCollection{
 		"/profile/favorite/",
 		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole, models.AttendeeRole, models.ApplicantRole, models.StaffRole, models.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveProfileFavorite).ServeHTTP,
 	},
+	arbor.Route{
+		"GetTierThresholds",
+		"GET",
+		"/profile/tier/threshold/",
+		alice.New(middleware.AuthMiddleware([]models.Role{models.AdminRole})).ThenFunc(RemoveProfileFavorite).ServeHTTP,
+	},
 	// This needs to be the last route in order to prevent endpoints like "search", "leaderboard" from accidentally being routed as the {id} variable.
 	arbor.Route{
 		"GetUserProfileById",
@@ -144,4 +150,8 @@ func AddProfileFavorite(w http.ResponseWriter, r *http.Request) {
 
 func RemoveProfileFavorite(w http.ResponseWriter, r *http.Request) {
 	arbor.DELETE(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func GetTierThresholds(w http.ResponseWriter, r *http.Request) {
+	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
 }

--- a/services/profile/config/config.go
+++ b/services/profile/config/config.go
@@ -4,12 +4,15 @@ import (
 	"os"
 
 	"github.com/HackIllinois/api/common/configloader"
+	"github.com/HackIllinois/api/services/profile/models"
 )
 
 var PROFILE_DB_HOST string
 var PROFILE_DB_NAME string
 
 var PROFILE_PORT string
+
+var TIER_THRESHOLDS []models.TierThreshold
 
 func Initialize() error {
 	cfg_loader, err := configloader.Load(os.Getenv("HI_CONFIG"))
@@ -31,6 +34,12 @@ func Initialize() error {
 	}
 
 	PROFILE_PORT, err = cfg_loader.Get("PROFILE_PORT")
+
+	if err != nil {
+		return err
+	}
+
+	err = cfg_loader.ParseInto("TIER_THRESHOLDS", &TIER_THRESHOLDS)
 
 	if err != nil {
 		return err

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/HackIllinois/api/common/errors"
 	"github.com/HackIllinois/api/common/utils"
+	"github.com/HackIllinois/api/services/profile/config"
 	"github.com/HackIllinois/api/services/profile/models"
 	"github.com/HackIllinois/api/services/profile/service"
 	"github.com/gorilla/mux"
@@ -31,6 +32,8 @@ func SetupController(route *mux.Route) {
 	router.HandleFunc("/favorite/", RemoveProfileFavorite).Methods("DELETE")
 
 	router.HandleFunc("/{id}/", GetProfileById).Methods("GET")
+
+	router.HandleFunc("/tier/threshold/", GetTierThresholds).Methods("GET")
 }
 
 /*
@@ -406,4 +409,11 @@ func RemoveProfileFavorite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(favorites)
+}
+
+/*
+	Returns the tier name to threshold mapping
+*/
+func GetTierThresholds(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(config.TIER_THRESHOLDS)
 }

--- a/services/profile/models/tier.go
+++ b/services/profile/models/tier.go
@@ -1,0 +1,6 @@
+package models
+
+type TierThreshold struct {
+	Name      string `json:"name"`
+	Threshold int    `json:"threshold"`
+}


### PR DESCRIPTION
- Add a new endpoint in the profile service, GET /profile/tier/threshold/, which will return the profile tier (represented in a string) to minimum point threshold mapping. The values are configured from the respective env config files.