### PR TITLE
Add discord name for leaderboard endpoint

### DIFF
--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -212,12 +212,14 @@ Response format:
             "firstName": "John",
             "lastName": "Doe",
             "points": 2021,
+            "discord": "patrick#1234"
         },
         {
             "id": "profileid123456",
             "firstName": "John",
             "lastName": "Doe",
             "points": 2021,
+            "discord": "patrick#1234"
         },
     ]
 }

--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -209,15 +209,11 @@ Response format:
     profiles: [
         {
             "id": "profileid123456",
-            "firstName": "John",
-            "lastName": "Doe",
             "points": 2021,
             "discord": "patrick#1234"
         },
         {
             "id": "profileid123456",
-            "firstName": "John",
-            "lastName": "Doe",
             "points": 2021,
             "discord": "patrick#1234"
         },

--- a/services/profile/models/leaderboard_entry.go
+++ b/services/profile/models/leaderboard_entry.go
@@ -5,4 +5,5 @@ type LeaderboardEntry struct {
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
 	Points    int    `json:"points"`
+	Discord   string `json:"discord"`
 }

--- a/services/profile/models/leaderboard_entry.go
+++ b/services/profile/models/leaderboard_entry.go
@@ -1,9 +1,7 @@
 package models
 
 type LeaderboardEntry struct {
-	ID        string `json:"id"`
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
-	Points    int    `json:"points"`
-	Discord   string `json:"discord"`
+	ID      string `json:"id"`
+	Points  int    `json:"points"`
+	Discord string `json:"discord"`
 }

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -620,12 +620,14 @@ func TestGetProfileLeaderboard(t *testing.T) {
 				FirstName: "testfirstname2",
 				LastName:  "testlastname2",
 				Points:    340,
+				Discord:   "testdiscordusername2",
 			},
 			{
 				ID:        "testid",
 				FirstName: "testfirstname",
 				LastName:  "testlastname",
 				Points:    0,
+				Discord:   "testdiscordusername",
 			},
 		},
 	}
@@ -671,18 +673,21 @@ func TestGetProfileLeaderboard(t *testing.T) {
 				FirstName: "testfirstname3",
 				LastName:  "testlastname3",
 				Points:    999,
+				Discord:   "testdiscordusername3",
 			},
 			{
 				ID:        "testid2",
 				FirstName: "testfirstname2",
 				LastName:  "testlastname2",
 				Points:    340,
+				Discord:   "testdiscordusername2",
 			},
 			{
 				ID:        "testid",
 				FirstName: "testfirstname",
 				LastName:  "testlastname",
 				Points:    0,
+				Discord:   "testdiscordusername",
 			},
 		},
 	}
@@ -708,12 +713,14 @@ func TestGetProfileLeaderboard(t *testing.T) {
 				FirstName: "testfirstname3",
 				LastName:  "testlastname3",
 				Points:    999,
+				Discord:   "testdiscordusername3",
 			},
 			{
 				ID:        "testid2",
 				FirstName: "testfirstname2",
 				LastName:  "testlastname2",
 				Points:    340,
+				Discord:   "testdiscordusername2",
 			},
 		},
 	}

--- a/services/profile/tests/profile_test.go
+++ b/services/profile/tests/profile_test.go
@@ -616,18 +616,14 @@ func TestGetProfileLeaderboard(t *testing.T) {
 	expected_leaderboard := models.LeaderboardEntryList{
 		LeaderboardEntries: []models.LeaderboardEntry{
 			{
-				ID:        "testid2",
-				FirstName: "testfirstname2",
-				LastName:  "testlastname2",
-				Points:    340,
-				Discord:   "testdiscordusername2",
+				ID:      "testid2",
+				Points:  340,
+				Discord: "testdiscordusername2",
 			},
 			{
-				ID:        "testid",
-				FirstName: "testfirstname",
-				LastName:  "testlastname",
-				Points:    0,
-				Discord:   "testdiscordusername",
+				ID:      "testid",
+				Points:  0,
+				Discord: "testdiscordusername",
 			},
 		},
 	}
@@ -669,25 +665,19 @@ func TestGetProfileLeaderboard(t *testing.T) {
 	expected_leaderboard = models.LeaderboardEntryList{
 		LeaderboardEntries: []models.LeaderboardEntry{
 			{
-				ID:        "testid3",
-				FirstName: "testfirstname3",
-				LastName:  "testlastname3",
-				Points:    999,
-				Discord:   "testdiscordusername3",
+				ID:      "testid3",
+				Points:  999,
+				Discord: "testdiscordusername3",
 			},
 			{
-				ID:        "testid2",
-				FirstName: "testfirstname2",
-				LastName:  "testlastname2",
-				Points:    340,
-				Discord:   "testdiscordusername2",
+				ID:      "testid2",
+				Points:  340,
+				Discord: "testdiscordusername2",
 			},
 			{
-				ID:        "testid",
-				FirstName: "testfirstname",
-				LastName:  "testlastname",
-				Points:    0,
-				Discord:   "testdiscordusername",
+				ID:      "testid",
+				Points:  0,
+				Discord: "testdiscordusername",
 			},
 		},
 	}
@@ -709,18 +699,14 @@ func TestGetProfileLeaderboard(t *testing.T) {
 	expected_leaderboard = models.LeaderboardEntryList{
 		LeaderboardEntries: []models.LeaderboardEntry{
 			{
-				ID:        "testid3",
-				FirstName: "testfirstname3",
-				LastName:  "testlastname3",
-				Points:    999,
-				Discord:   "testdiscordusername3",
+				ID:      "testid3",
+				Points:  999,
+				Discord: "testdiscordusername3",
 			},
 			{
-				ID:        "testid2",
-				FirstName: "testfirstname2",
-				LastName:  "testlastname2",
-				Points:    340,
-				Discord:   "testdiscordusername2",
+				ID:      "testid2",
+				Points:  340,
+				Discord: "testdiscordusername2",
 			},
 		},
 	}


### PR DESCRIPTION
- Update leaderboard endpoint to return discord name alongside existing information.
- Update relevant documentation and tests