### PR TITLE
Add pool limit for mongodb connection

### DIFF
--- a/common/database/mongo_database.go
+++ b/common/database/mongo_database.go
@@ -54,6 +54,7 @@ func (db *MongoDatabase) Connect(host string) error {
 	}
 
 	session, err := mgo.DialWithInfo(dial_info)
+	session.SetPoolLimit(25)
 
 	if err != nil {
 		return ErrConnection


### PR DESCRIPTION
This PR limits the number of our pooled connections to Mongo.

Testing with calling the `POST /registration/attendee/` endpoint 300 times concurrently:
- No PooLimit - 395 connections to Mongo
- PoolLimit = 50 - 154 connections to Mongo
- PooLimit = 25 - 132 connections to Mongo

Note that this test was done locally.
I chose the value of 25 for now, although suggestions for other pool limit values are welcome 