### PR TITLE
Add missing endpoint for auth service

### DIFF
--- a/services/auth/controller/controller.go
+++ b/services/auth/controller/controller.go
@@ -18,6 +18,7 @@ func SetupController(route *mux.Route) {
 
 	router.Handle("/internal/metrics/", promhttp.Handler()).Methods("GET")
 
+	metrics.RegisterHandler("/roles/", GetCurrentUserRoles, "GET", router)
 	metrics.RegisterHandler("/roles/list/", GetRolesLists, "GET", router)
 	metrics.RegisterHandler("/roles/list/{role}/", GetUserListByRole, "GET", router)
 	metrics.RegisterHandler("/{provider}/", Authorize, "GET", router)


### PR DESCRIPTION
In the process of adding metrics, the `GET /roles/` auth endpoint was removed. This is fixed in this PR.