### PR TITLE
Live leaderboard

### DIFF
--- a/documentation/docs/reference/services/Profile.md
+++ b/documentation/docs/reference/services/Profile.md
@@ -203,6 +203,47 @@ Request requires no body.
 }
 ```
 
+WS /profile/live/leaderboard/?limit=
+-------------------------
+
+!!! note
+    This is a public endpoint
+
+This endpoint expects a websocket connection.
+
+Returns a list of profiles sorted by points descending. If a `limit` parameter is provided, it will
+return the first `limit` profiles. Otherwise, it will return all of the profiles.
+
+Once, the connection has been established, `limit` can be easily changed by simply sending the key
+in a JSON.
+
+The API will send back a list of profiles whenever a user gets awarded points (ratelimited to 1
+response per second) or if 5 minutes elapse with no activity (i.e. no point values change). The
+latter is more or less a failsafe in order to ensure the leaderboard is the most up-to-date.
+
+```json title="Exmaple WS message request"
+{
+    "limit": 20
+}
+```
+
+```json title="Example WS response"
+{
+    "profiles": [
+        {
+            "id": "profileid123456",
+            "points": 2021,
+            "discord": "patrick#1234"
+        },
+        {
+            "id": "profileid123456",
+            "points": 2021,
+            "discord": "patrick#1234"
+        },
+    ]
+}
+```
+
 GET /profile/search/?teamStatus=value&interests=value,value,value&limit=value
 -------------------------
 

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -50,6 +50,12 @@ var ProfileRoutes = arbor.RouteCollection{
 		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetProfileLeaderboard).ServeHTTP,
 	},
 	arbor.Route{
+		"GetProfileLeaderboard",
+		"GET",
+		"/profile/live/leaderboard/",
+		alice.New(middleware.IdentificationMiddleware).ThenFunc(GetLiveProfileLeaderboard).ServeHTTP,
+	},
+	arbor.Route{
 		"GetValidFilteredProfiles",
 		"GET",
 		"/profile/search/",
@@ -130,6 +136,10 @@ func DeleteProfile(w http.ResponseWriter, r *http.Request) {
 
 func GetProfileLeaderboard(w http.ResponseWriter, r *http.Request) {
 	arbor.GET(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
+}
+
+func GetLiveProfileLeaderboard(w http.ResponseWriter, r *http.Request) {
+	arbor.ProxyWebsocket(w, config.PROFILE_SERVICE+r.URL.String(), ProfileFormat, "", r)
 }
 
 func RedeemEvent(w http.ResponseWriter, r *http.Request) {

--- a/gateway/services/profile.go
+++ b/gateway/services/profile.go
@@ -17,31 +17,41 @@ var ProfileRoutes = arbor.RouteCollection{
 		"GetCurrentUserProfile",
 		"GET",
 		"/profile/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole})).ThenFunc(GetProfile).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole})).
+			ThenFunc(GetProfile).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"CreateCurrentUserProfile",
 		"POST",
 		"/profile/",
-		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole})).ThenFunc(CreateProfile).ServeHTTP,
+		alice.New(middleware.IdentificationMiddleware, middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole})).
+			ThenFunc(CreateProfile).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"UpdateCurrentUserProfile",
 		"PUT",
 		"/profile/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(UpdateProfile).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).
+			ThenFunc(UpdateProfile).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"DeleteCurrentUserProfile",
 		"DELETE",
 		"/profile/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole}), middleware.IdentificationMiddleware).ThenFunc(DeleteProfile).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole}), middleware.IdentificationMiddleware).
+			ThenFunc(DeleteProfile).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"GetAllProfiles",
 		"GET",
 		"/profile/list/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(GetFilteredProfiles).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.StaffRole}), middleware.IdentificationMiddleware).
+			ThenFunc(GetFilteredProfiles).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"GetProfileLeaderboard",
@@ -59,37 +69,49 @@ var ProfileRoutes = arbor.RouteCollection{
 		"GetValidFilteredProfiles",
 		"GET",
 		"/profile/search/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(GetValidFilteredProfiles).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).
+			ThenFunc(GetValidFilteredProfiles).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"RedeemEvent",
 		"POST",
 		"/profile/event/checkin/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(RedeemEvent).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.StaffRole}), middleware.IdentificationMiddleware).
+			ThenFunc(RedeemEvent).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"AwardPoints",
 		"POST",
 		"/profile/points/award/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.StaffRole}), middleware.IdentificationMiddleware).ThenFunc(AwardPoints).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.StaffRole}), middleware.IdentificationMiddleware).
+			ThenFunc(AwardPoints).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"GetProfileFavorites",
 		"GET",
 		"/profile/favorite/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(GetProfileFavorites).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).
+			ThenFunc(GetProfileFavorites).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"AddProfileFavorite",
 		"POST",
 		"/profile/favorite/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(AddProfileFavorite).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).
+			ThenFunc(AddProfileFavorite).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"RemoveProfileFavorite",
 		"DELETE",
 		"/profile/favorite/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(RemoveProfileFavorite).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).
+			ThenFunc(RemoveProfileFavorite).
+			ServeHTTP,
 	},
 	arbor.Route{
 		"GetTierThresholds",
@@ -102,7 +124,9 @@ var ProfileRoutes = arbor.RouteCollection{
 		"GetUserProfileById",
 		"GET",
 		"/profile/{id}/",
-		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).ThenFunc(GetProfileById).ServeHTTP,
+		alice.New(middleware.AuthMiddleware([]authtoken.Role{authtoken.AdminRole, authtoken.AttendeeRole, authtoken.ApplicantRole, authtoken.StaffRole, authtoken.MentorRole}), middleware.IdentificationMiddleware).
+			ThenFunc(GetProfileById).
+			ServeHTTP,
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/HackIllinois/api
 
-replace github.com/arbor-dev/arbor => github.com/HackIllinois/arbor v0.3.1-0.20220625214746-96b56633f2e3
+replace github.com/arbor-dev/arbor => github.com/HackIllinois/arbor v0.3.1-0.20230201230413-b6f79f9e5736
 
 require (
 	github.com/arbor-dev/arbor v0.3.0
@@ -9,6 +9,7 @@ require (
 	github.com/go-playground/validator/v10 v10.10.0
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/gorilla/mux v1.6.2
+	github.com/gorilla/websocket v1.5.0
 	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da
 	github.com/levigross/grequests v0.0.0-20181123014746-f3f67e7783bb
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/HackIllinois/arbor v0.3.1-0.20220625214746-96b56633f2e3 h1:6OwmTZCWPOFEjRilwzMMD++PwjJfR9+hG3EXWR/EEAc=
-github.com/HackIllinois/arbor v0.3.1-0.20220625214746-96b56633f2e3/go.mod h1:CilbmeWfrwvOtRRxg4oQs5NpGtklqUWCQvW9rxw+Xfk=
+github.com/HackIllinois/arbor v0.3.1-0.20230201230413-b6f79f9e5736 h1:qtfomoIx6ggEIOR5U5zinYMu1ZsueqNYHBRd6pd7ttA=
+github.com/HackIllinois/arbor v0.3.1-0.20230201230413-b6f79f9e5736/go.mod h1:CilbmeWfrwvOtRRxg4oQs5NpGtklqUWCQvW9rxw+Xfk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/services/profile/controller/controller.go
+++ b/services/profile/controller/controller.go
@@ -53,14 +53,12 @@ func GetProfile(w http.ResponseWriter, r *http.Request) {
 	id := r.Header.Get("HackIllinois-Identity")
 
 	profile_id, err := service.GetProfileIdFromUserId(id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile id associated with the user"))
 		return
 	}
 
 	user_profile, err := service.GetProfile(profile_id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get current user's profile."))
 		return
@@ -76,7 +74,6 @@ func GetProfileById(w http.ResponseWriter, r *http.Request) {
 	profile_id := mux.Vars(r)["id"]
 
 	user_profile, err := service.GetProfile(profile_id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile for profile id "+profile_id))
 		return
@@ -116,7 +113,6 @@ func CreateProfile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	created_profile, err := service.GetProfile(profile_id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get created profile."))
 		return
@@ -137,7 +133,6 @@ func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	profile_id, err := service.GetProfileIdFromUserId(id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile id associated with the user"))
 		return
@@ -147,7 +142,6 @@ func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	json.NewDecoder(r.Body).Decode(&profile)
 
 	old_profile, err := service.GetProfile(profile_id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile associated with this profile id."))
 		return
@@ -165,7 +159,6 @@ func UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	updated_profile, err := service.GetProfile(profile_id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated profile details."))
 		return
@@ -281,16 +274,21 @@ func RedeemEvent(w http.ResponseWriter, r *http.Request) {
 	id := request.ID
 
 	profile_id, err := service.GetProfileIdFromUserId(id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile id associated with the user"))
 		return
 	}
 
 	redemption_status, err := service.RedeemEvent(profile_id, request.EventID)
-
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not check if event was redeemed for id "+request.ID+" and event id "+request.EventID+". "+redemption_status.Status))
+		errors.WriteError(
+			w,
+			r,
+			errors.DatabaseError(
+				err.Error(),
+				"Could not check if event was redeemed for id "+request.ID+" and event id "+request.EventID+". "+redemption_status.Status,
+			),
+		)
 		return
 	}
 
@@ -307,16 +305,18 @@ func AwardPoints(w http.ResponseWriter, r *http.Request) {
 	id := request.ID
 
 	profile_id, err := service.GetProfileIdFromUserId(id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile id associated with the user"))
 		return
 	}
 
 	user_profile, err := service.GetProfile(profile_id)
-
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile for id "+request.ID+" when trying to award points."))
+		errors.WriteError(
+			w,
+			r,
+			errors.DatabaseError(err.Error(), "Could not get profile for id "+request.ID+" when trying to award points."),
+		)
 		return
 	}
 
@@ -333,7 +333,11 @@ func AwardPoints(w http.ResponseWriter, r *http.Request) {
 
 	updated_profile, err := service.GetProfile(profile_id)
 	if err != nil {
-		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated profile details after awarding points."))
+		errors.WriteError(
+			w,
+			r,
+			errors.DatabaseError(err.Error(), "Could not get updated profile details after awarding points."),
+		)
 		return
 	}
 
@@ -352,14 +356,12 @@ func GetProfileFavorites(w http.ResponseWriter, r *http.Request) {
 	}
 
 	profile_id, err := service.GetProfileIdFromUserId(id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile id associated with the user"))
 		return
 	}
 
 	favorites, err := service.GetProfileFavorites(profile_id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get user's profile favorites."))
 		return
@@ -380,7 +382,6 @@ func AddProfileFavorite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	profile_id, err := service.GetProfileIdFromUserId(id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile id associated with the user"))
 		return
@@ -397,7 +398,6 @@ func AddProfileFavorite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	favorites, err := service.GetProfileFavorites(profile_id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated user profile favorites."))
 		return
@@ -418,7 +418,6 @@ func RemoveProfileFavorite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	profile_id, err := service.GetProfileIdFromUserId(id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get profile id associated with the user"))
 		return
@@ -435,7 +434,6 @@ func RemoveProfileFavorite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	favorites, err := service.GetProfileFavorites(profile_id)
-
 	if err != nil {
 		errors.WriteError(w, r, errors.DatabaseError(err.Error(), "Could not get updated user profile favorites."))
 		return

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -44,7 +44,6 @@ func GetProfileIdFromUserId(id string) (string, error) {
 
 	var id_map models.IdMap
 	err := db.FindOne("profileids", query, &id_map, nil)
-
 	// Returns error if no mapping was found
 	if err != nil {
 		return "", err
@@ -63,7 +62,6 @@ func GetProfile(profile_id string) (*models.Profile, error) {
 
 	var profile models.Profile
 	err := db.FindOne("profiles", query, &profile, nil)
-
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +77,6 @@ func GetProfile(profile_id string) (*models.Profile, error) {
 func DeleteProfile(profile_id string) (*models.Profile, error) {
 	// Gets profile to be able to return it later
 	profile, err := GetProfile(profile_id)
-
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +124,6 @@ func DeleteProfile(profile_id string) (*models.Profile, error) {
 func CreateProfile(id string, profile_id string, profile models.Profile) error {
 	profile.ID = profile_id
 	err := validate.Struct(profile)
-
 	if err != nil {
 		return err
 	}
@@ -191,7 +187,6 @@ func CreateProfile(id string, profile_id string, profile models.Profile) error {
 func UpdateProfile(profile_id string, profile models.Profile) error {
 	profile.ID = profile_id
 	err := validate.Struct(profile)
-
 	if err != nil {
 		return err
 	}
@@ -262,7 +257,6 @@ func GetFilteredProfiles(parameters map[string][]string) (*models.ProfileList, e
 	}
 
 	limit, err := strconv.Atoi(limit_param[0])
-
 	if err != nil {
 		return nil, errors.New("Could not convert 'limit' to int.")
 	}
@@ -271,7 +265,6 @@ func GetFilteredProfiles(parameters map[string][]string) (*models.ProfileList, e
 	delete(parameters, "limit")
 
 	query, err := database.CreateFilterQuery(parameters, models.Profile{})
-
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +296,6 @@ func GetFilteredProfiles(parameters map[string][]string) (*models.ProfileList, e
 */
 func GetValidFilteredProfiles(parameters map[string][]string) (*models.ProfileList, error) {
 	filtered_profile_list, err := GetFilteredProfiles(parameters)
-
 	if err != nil {
 		return nil, errors.New("Could not get filtered profiles")
 	}
@@ -324,7 +316,6 @@ func RedeemEvent(profile_id string, event_id string) (*models.RedeemEventRespons
 
 	var attended_events models.AttendanceTracker
 	err := db.FindOne("profileattendance", selector, &attended_events, nil)
-
 	if err != nil {
 		if err == database.ErrNotFound {
 			attended_events = models.AttendanceTracker{
@@ -365,7 +356,6 @@ func GetProfileFavorites(profile_id string) (*models.ProfileFavorites, error) {
 
 	var profile_favorites models.ProfileFavorites
 	err := db.FindOne("profilefavorites", query, &profile_favorites, nil)
-
 	if err != nil {
 		return nil, err
 	}
@@ -386,13 +376,11 @@ func AddProfileFavorite(profile_id string, profile string) error {
 	}
 
 	_, err := GetProfile(profile)
-
 	if err != nil {
 		return errors.New("Could not find profile with the given id.")
 	}
 
 	profile_favorites, err := GetProfileFavorites(profile_id)
-
 	if err != nil {
 		return err
 	}
@@ -415,7 +403,6 @@ func RemoveProfileFavorite(profile_id string, profile string) error {
 	}
 
 	profile_favorites, err := GetProfileFavorites(profile_id)
-
 	if err != nil {
 		return err
 	}

--- a/services/profile/service/profile_service.go
+++ b/services/profile/service/profile_service.go
@@ -217,11 +217,14 @@ func GetProfileLeaderboard(parameters map[string][]string) (*models.LeaderboardE
 	}
 
 	limit, err := strconv.Atoi(limit_param[0])
-
 	if err != nil {
 		return nil, errors.New("Could not convert 'limit' to int.")
 	}
 
+	return GetProfileLeaderboardWithLimit(limit)
+}
+
+func GetProfileLeaderboardWithLimit(limit int) (*models.LeaderboardEntryList, error) {
 	leaderboard_entries := []models.LeaderboardEntry{}
 
 	sort_field := bson.D{
@@ -231,8 +234,7 @@ func GetProfileLeaderboard(parameters map[string][]string) (*models.LeaderboardE
 		},
 	}
 
-	err = db.FindAllSorted("profiles", nil, sort_field, &leaderboard_entries, nil)
-
+	err := db.FindAllSorted("profiles", nil, sort_field, &leaderboard_entries, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/services/profile/service/ws_service.go
+++ b/services/profile/service/ws_service.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"log"
+	"time"
+
+	"github.com/HackIllinois/api/services/profile/models"
+	"github.com/gorilla/websocket"
+)
+
+type LiveLeaderboardConnection struct {
+	Conn  *websocket.Conn `json:"-"`
+	Limit int             `json:"limit"`
+}
+
+var (
+	leaderboardConnections map[*websocket.Conn]LiveLeaderboardConnection = make(
+		map[*websocket.Conn]LiveLeaderboardConnection,
+	)
+	leaderboardUpdateCooldown = 1 * time.Second
+	leaderboardInactiveUpdate = 5 * time.Minute
+	ChanUpdateLiveLeaderboard = make(chan struct{}, 32)
+)
+
+func LiveLeaderboardManager() {
+	for {
+		select {
+		case <-ChanUpdateLiveLeaderboard:
+		case <-time.After(leaderboardInactiveUpdate): // failsafe case
+		}
+		// send updated leaderboard to websocket
+		go BroadcastUpdatedLeaderboard()
+
+		// Prevents spamming websockets
+		cooldown_ticker := time.NewTicker(leaderboardUpdateCooldown)
+		reupdate_after_cooldown := false
+	cooldown:
+		for {
+			select {
+			case <-ChanUpdateLiveLeaderboard:
+				reupdate_after_cooldown = true
+			case <-cooldown_ticker.C:
+				break cooldown
+			}
+		}
+		if reupdate_after_cooldown {
+			ChanUpdateLiveLeaderboard <- struct{}{}
+		}
+	}
+}
+
+func BroadcastUpdatedLeaderboard() error {
+	full_leaderboard, err := GetProfileLeaderboard(make(map[string][]string))
+	if err != nil {
+		return err
+	}
+
+	for _, connection_info := range leaderboardConnections {
+		leaderboard_to_send := *full_leaderboard
+		if connection_info.Limit > 0 {
+			leaderboard_to_send.LeaderboardEntries = leaderboard_to_send.LeaderboardEntries[:connection_info.Limit]
+		}
+		go SendUpdatedLeaderboard(connection_info.Conn, leaderboard_to_send)
+	}
+
+	return nil
+}
+
+// The leaderboard size should be no more than the limit that the client wants
+func SendUpdatedLeaderboard(conn *websocket.Conn, leaderboard models.LeaderboardEntryList) {
+	err := conn.WriteJSON(leaderboard)
+	if err != nil {
+		log.Printf("error occurred on writing to ws: %v", err)
+		// Note: We will not close to socket as the read handler (HandleIncomingLeaderboardWS) will
+		// do that for us
+	}
+}
+
+func HandleIncomingLeaderboardWS(conn *websocket.Conn, limit int) {
+	defer conn.Close()
+
+	leaderboardConnections[conn] = LiveLeaderboardConnection{
+		Conn:  conn,
+		Limit: limit,
+	}
+
+	defer delete(leaderboardConnections, conn)
+
+	leaderboard, err := GetProfileLeaderboardWithLimit(limit)
+	if err != nil {
+		conn.WriteMessage(
+			websocket.CloseInternalServerErr,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Could not fetch leaderboard"),
+		)
+		return
+	}
+
+	err = conn.WriteJSON(leaderboard)
+	if err != nil {
+		if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+			log.Printf("Connection failed before we could send back leadderboard", err)
+		}
+		return
+	}
+
+	for {
+		var updated_settings LiveLeaderboardConnection
+		err := conn.ReadJSON(&updated_settings)
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				log.Printf("IsUnexpectedCloseError()", err)
+			}
+			conn.Close()
+			break
+		}
+
+		updated_settings.Conn = conn
+		leaderboardConnections[conn] = updated_settings
+
+		leaderboard, err := GetProfileLeaderboardWithLimit(updated_settings.Limit)
+		if err != nil {
+			conn.WriteMessage(
+				websocket.CloseInternalServerErr,
+				websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Could not fetch leaderboard"),
+			)
+			return
+		}
+
+		err = conn.WriteJSON(leaderboard)
+		if err != nil {
+			return
+		}
+	}
+}


### PR DESCRIPTION
This is mainly for the Siebel dashboard, but this is a new public endpoint: `WS /profile/live/leaderboard/`

Once the connection has been established, the API will send back an initial leaderboard. From then on, the API will send back updated leaderboards whenever it detects updates to player point totals (primarily from `POST /profile/points/award/`). The amount of leaderboards the API can send back due to point value updates is 1 response/second.

The API will also send back an updated leaderboard every 5 minutes of inactivity.