### PR TITLE
Event display staff checkin

### DIFF
--- a/services/event/models/event.go
+++ b/services/event/models/event.go
@@ -5,22 +5,23 @@ type Event interface {
 }
 
 type EventPublic struct {
-	ID          string          `json:"id"                  validate:"required"`
-	Name        string          `json:"name"                validate:"required"`
-	Description string          `json:"description"         validate:"required"`
-	StartTime   int64           `json:"startTime"           validate:"required_if=IsAsync False"`
-	EndTime     int64           `json:"endTime"             validate:"required_if=IsAsync False"`
-	Locations   []EventLocation `json:"locations"           validate:"required,dive,required"`
+	ID          string          `json:"id"          validate:"required"`
+	Name        string          `json:"name"        validate:"required"`
+	Description string          `json:"description" validate:"required"`
+	StartTime   int64           `json:"startTime"   validate:"required_if=IsAsync False"`
+	EndTime     int64           `json:"endTime"     validate:"required_if=IsAsync False"`
+	Locations   []EventLocation `json:"locations"   validate:"required,dive,required"`
 	Sponsor     string          `json:"sponsor"`
-	EventType   string          `json:"eventType"           validate:"required,oneof=MEAL SPEAKER WORKSHOP MINIEVENT QNA OTHER"`
+	EventType   string          `json:"eventType"   validate:"required,oneof=MEAL SPEAKER WORKSHOP MINIEVENT QNA OTHER"`
 	Points      int             `json:"points"`
 	IsAsync     bool            `json:"isAsync"`
 }
 
 // Struct to encapsulate hidden fields
 type EventDB struct {
-	EventPublic `bson:",inline"`
-	IsPrivate   bool `json:"isPrivate"`
+	EventPublic           `     bson:",inline"`
+	IsPrivate             bool `               json:"isPrivate"`
+	DisplayOnStaffCheckin bool `               json:"displayOnStaffCheckin"`
 }
 
 type EventLocation struct {

--- a/services/event/tests/event_test.go
+++ b/services/event/tests/event_test.go
@@ -69,7 +69,8 @@ func SetupTestDB(t *testing.T) {
 			},
 			Points: 10,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	err := db.Insert("events", &event, nil)
@@ -124,7 +125,8 @@ func TestGetAllEventsService(t *testing.T) {
 				},
 			},
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	event2 := models.EventDB{
@@ -139,7 +141,8 @@ func TestGetAllEventsService(t *testing.T) {
 			Locations:   []models.EventLocation{},
 			Points:      100,
 		},
-		IsPrivate: true,
+		IsPrivate:             true,
+		DisplayOnStaffCheckin: true,
 	}
 
 	err := db.Insert("events", &event, nil)
@@ -180,7 +183,8 @@ func TestGetAllEventsService(t *testing.T) {
 					},
 					Points: 10,
 				},
-				IsPrivate: false,
+				IsPrivate:             false,
+				DisplayOnStaffCheckin: false,
 			},
 			{
 				EventPublic: models.EventPublic{
@@ -202,7 +206,8 @@ func TestGetAllEventsService(t *testing.T) {
 					},
 					Points: 0,
 				},
-				IsPrivate: false,
+				IsPrivate:             false,
+				DisplayOnStaffCheckin: false,
 			},
 			{
 				EventPublic: models.EventPublic{
@@ -216,7 +221,8 @@ func TestGetAllEventsService(t *testing.T) {
 					Locations:   []models.EventLocation{},
 					Points:      100,
 				},
-				IsPrivate: true,
+				IsPrivate:             true,
+				DisplayOnStaffCheckin: true,
 			},
 		},
 	}
@@ -321,7 +327,8 @@ func TestGetFilteredEventsService(t *testing.T) {
 			},
 			Points: 0,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	err := db.Insert("events", &event, nil)
@@ -341,7 +348,8 @@ func TestGetFilteredEventsService(t *testing.T) {
 			Locations:   []models.EventLocation{},
 			Points:      100,
 		},
-		IsPrivate: true,
+		IsPrivate:             true,
+		DisplayOnStaffCheckin: true,
 	}
 
 	err = db.Insert("events", &event2, nil)
@@ -381,7 +389,8 @@ func TestGetFilteredEventsService(t *testing.T) {
 					},
 					Points: 0,
 				},
-				IsPrivate: false,
+				IsPrivate:             false,
+				DisplayOnStaffCheckin: false,
 			},
 		},
 	}
@@ -501,7 +510,8 @@ func TestGetEventService(t *testing.T) {
 			Locations:   []models.EventLocation{},
 			Points:      1337,
 		},
-		IsPrivate: true,
+		IsPrivate:             true,
+		DisplayOnStaffCheckin: true,
 	}
 
 	err := db.Insert("events", hidden_event, nil)
@@ -533,7 +543,8 @@ func TestGetEventService(t *testing.T) {
 			},
 			Points: 10,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	if !reflect.DeepEqual(event, &expected_event) {
@@ -572,7 +583,8 @@ func TestCreateEventService(t *testing.T) {
 				},
 			},
 		},
-		IsPrivate: true,
+		IsPrivate:             true,
+		DisplayOnStaffCheckin: false,
 	}
 
 	err := service.CreateEvent("testid2", "testcode2", new_event)
@@ -604,7 +616,8 @@ func TestCreateEventService(t *testing.T) {
 			},
 			Points: 0,
 		},
-		IsPrivate: true,
+		IsPrivate:             true,
+		DisplayOnStaffCheckin: false,
 	}
 
 	if !reflect.DeepEqual(event, &expected_event) {
@@ -632,7 +645,8 @@ func TestCreateEventService(t *testing.T) {
 			},
 			IsAsync: true,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	err = service.CreateEvent("testid2", "testcode2", new_event_async)
@@ -664,7 +678,8 @@ func TestCreateEventService(t *testing.T) {
 			IsAsync: true,
 			Points:  0,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	if !reflect.DeepEqual(event_async, &expected_event_async) {
@@ -761,7 +776,8 @@ func TestUpdateEventService(t *testing.T) {
 			},
 			Points: 100,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	err := service.UpdateEvent("testid", event)
@@ -793,7 +809,8 @@ func TestUpdateEventService(t *testing.T) {
 			},
 			Points: 100,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	if !reflect.DeepEqual(updated_event, &expected_event) {
@@ -916,7 +933,8 @@ func TestIsEventActive(t *testing.T) {
 				},
 			},
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	service.CreateEvent(new_event.ID, "testcode3", new_event)

--- a/tests/e2e/events_test/create_event_test.go
+++ b/tests/e2e/events_test/create_event_test.go
@@ -30,7 +30,8 @@ func TestCreateEventNormal(t *testing.T) {
 			},
 			Points: 50,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: true,
 	}
 	received_event := models.EventDB{}
 	response, err := staff_client.New().Post("/event/").BodyJSON(event_info).ReceiveSuccess(&received_event)
@@ -87,7 +88,8 @@ func TestCreateEventForbidden(t *testing.T) {
 			},
 			Points: 50,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: true,
 	}
 
 	response, err := user_client.New().Post("/event/").BodyJSON(event_info).Receive(nil, nil)

--- a/tests/e2e/events_test/delete_event_test.go
+++ b/tests/e2e/events_test/delete_event_test.go
@@ -47,7 +47,8 @@ func TestDeleteEventNormal(t *testing.T) {
 			},
 			Points: 50,
 		},
-		IsPrivate: true,
+		IsPrivate:             true,
+		DisplayOnStaffCheckin: false,
 	}
 
 	if !reflect.DeepEqual(received_event, expected_event) {
@@ -83,7 +84,8 @@ func TestDeleteEventNormal(t *testing.T) {
 				},
 				Points: 0,
 			},
-			IsPrivate: false,
+			IsPrivate:             false,
+			DisplayOnStaffCheckin: true,
 		},
 	}
 
@@ -148,7 +150,8 @@ func TestDeleteEventNotExist(t *testing.T) {
 				},
 				Points: 50,
 			},
-			IsPrivate: true,
+			IsPrivate:             true,
+			DisplayOnStaffCheckin: false,
 		},
 		{
 			EventPublic: models.EventPublic{
@@ -169,7 +172,8 @@ func TestDeleteEventNotExist(t *testing.T) {
 				},
 				Points: 0,
 			},
-			IsPrivate: false,
+			IsPrivate:             false,
+			DisplayOnStaffCheckin: true,
 		},
 	}
 
@@ -222,7 +226,8 @@ func TestDeleteEventForbidden(t *testing.T) {
 				},
 				Points: 50,
 			},
-			IsPrivate: true,
+			IsPrivate:             true,
+			DisplayOnStaffCheckin: false,
 		},
 		{
 			EventPublic: models.EventPublic{
@@ -243,7 +248,8 @@ func TestDeleteEventForbidden(t *testing.T) {
 				},
 				Points: 0,
 			},
-			IsPrivate: false,
+			IsPrivate:             false,
+			DisplayOnStaffCheckin: true,
 		},
 	}
 

--- a/tests/e2e/events_test/events_test.go
+++ b/tests/e2e/events_test/events_test.go
@@ -148,7 +148,8 @@ func CreateEvents() {
 			},
 			Points: 50,
 		},
-		IsPrivate: true,
+		IsPrivate:             true,
+		DisplayOnStaffCheckin: false,
 	}
 
 	event2 := event_models.EventDB{
@@ -170,7 +171,8 @@ func CreateEvents() {
 			},
 			Points: 0,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: true,
 	}
 
 	client.Database(events_db_name).Collection("events").InsertOne(context.Background(), event1)

--- a/tests/e2e/events_test/get_all_events_test.go
+++ b/tests/e2e/events_test/get_all_events_test.go
@@ -87,7 +87,8 @@ func TestGetAllEventsNormal(t *testing.T) {
 					},
 					Points: 50,
 				},
-				IsPrivate: true,
+				IsPrivate:             true,
+				DisplayOnStaffCheckin: false,
 			},
 			{
 				EventPublic: models.EventPublic{
@@ -108,7 +109,8 @@ func TestGetAllEventsNormal(t *testing.T) {
 					},
 					Points: 0,
 				},
-				IsPrivate: false,
+				IsPrivate:             false,
+				DisplayOnStaffCheckin: true,
 			},
 		},
 	}

--- a/tests/e2e/events_test/get_filtered_events_test.go
+++ b/tests/e2e/events_test/get_filtered_events_test.go
@@ -32,7 +32,8 @@ func AddAdditionalEvents() {
 			},
 			Points: 1337,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: false,
 	}
 
 	event4 := models.EventDB{
@@ -54,7 +55,8 @@ func AddAdditionalEvents() {
 			},
 			Points: 0,
 		},
-		IsPrivate: false,
+		IsPrivate:             false,
+		DisplayOnStaffCheckin: true,
 	}
 
 	client.Database(events_db_name).Collection("events").InsertOne(context.Background(), event3)
@@ -164,7 +166,8 @@ func TestGetFilteredAllEventsAsStaff(t *testing.T) {
 					},
 					Points: 50,
 				},
-				IsPrivate: true,
+				IsPrivate:             true,
+				DisplayOnStaffCheckin: false,
 			},
 		},
 	}
@@ -210,7 +213,8 @@ func TestGetFilteredAllEventsNoFilter(t *testing.T) {
 					},
 					Points: 50,
 				},
-				IsPrivate: true,
+				IsPrivate:             true,
+				DisplayOnStaffCheckin: false,
 			},
 			{
 				EventPublic: models.EventPublic{
@@ -231,7 +235,8 @@ func TestGetFilteredAllEventsNoFilter(t *testing.T) {
 					},
 					Points: 0,
 				},
-				IsPrivate: false,
+				IsPrivate:             false,
+				DisplayOnStaffCheckin: true,
 			},
 		},
 	}
@@ -685,6 +690,76 @@ func TestGetFilteredPrivateEventsAsPublic(t *testing.T) {
 	}
 }
 
+func TestGetFilteredDisplayStaffCheckinEventsAsStaff(t *testing.T) {
+	CreateEvents()
+	AddAdditionalEvents()
+	defer ClearEvents()
+
+	received_events := models.EventList[models.EventDB]{}
+	response, err := staff_client.New().Get("/event/filter/?displayOnStaffCheckin=true").ReceiveSuccess(&received_events)
+	if err != nil {
+		t.Fatal("Unable to make request")
+		return
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("Request returned HTTP error %d", response.StatusCode)
+		return
+	}
+
+	expected_events := models.EventList[models.EventDB]{
+		Events: []models.EventDB{
+			{
+				EventPublic: models.EventPublic{
+					ID:          TEST_EVENT_2_ID,
+					Name:        "testevent2",
+					Description: "testdescription2",
+					StartTime:   current_unix_time + 60000,
+					EndTime:     current_unix_time + 120000,
+					Sponsor:     "",
+					EventType:   "FOOD",
+					Locations: []models.EventLocation{
+						{
+							Description: "testlocationdescription2",
+							Tags:        []string{"SIEBEL3", "ECEB2"},
+							Latitude:    123.456,
+							Longitude:   123.456,
+						},
+					},
+					Points: 0,
+				},
+				IsPrivate:             false,
+				DisplayOnStaffCheckin: true,
+			},
+			{
+				EventPublic: models.EventPublic{
+					ID:          "testeventid4",
+					Name:        "eventdinner",
+					Description: "Get your dinner!",
+					StartTime:   current_unix_time + 240000,
+					EndTime:     current_unix_time + 300000,
+					Sponsor:     "",
+					EventType:   "FOOD",
+					Locations: []models.EventLocation{
+						{
+							Description: "testlocationdescription4",
+							Tags:        []string{"SIEBEL3", "ECEB2"},
+							Latitude:    123.456,
+							Longitude:   123.456,
+						},
+					},
+					Points: 0,
+				},
+				IsPrivate:             false,
+				DisplayOnStaffCheckin: true,
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(received_events, expected_events) {
+		t.Fatalf("Wrong event info. Expected %v, got %v", expected_events, received_events)
+	}
+}
+
 func TestGetFilteredPrivateEventsAsStaff(t *testing.T) {
 	CreateEvents()
 	defer ClearEvents()
@@ -721,7 +796,8 @@ func TestGetFilteredPrivateEventsAsStaff(t *testing.T) {
 					},
 					Points: 50,
 				},
-				IsPrivate: true,
+				IsPrivate:             true,
+				DisplayOnStaffCheckin: false,
 			},
 		},
 	}


### PR DESCRIPTION
#503 has been merged YIPPEE.

Adds a private `DisplayOnStaffCheckin` to allow the apps to filter the events that require QR code scanning.