### PR TITLE
Added rsvp data into response from `POST /event/staff/checkin/`

### DIFF
--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -487,7 +487,7 @@ Valid values for `status` are `Success`, `InvalidEventId`, `BadUserToken`, `Alre
 {
     "newPoints": 10,
     "totalPoints": 10,
-    "status": "Success"
+    "status": "Success",
     "rsvpData": {
         "id": "github0123456",
         "isAttending": true,

--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -469,7 +469,12 @@ Valid values for `status` are `Success`, `InvalidEventId`, `BadUserToken`, `Alre
 	When `status != Success`, the `newPoints` and `totalPoints` fields will equal `-1` and should be ignored.
 
 !!! note
-	The `userToken` should be retrieved from the `userToken` field of a user QR code URI (`hackillinois://user?userToken=some_token`)
+    On status `Sucess` and `AlreadyCheckedIn`, the field `rsvpData` will be populated with the
+    user's RSVP data and registration data.
+
+!!! note
+	The user token `some_token` should be retrieved from the `userToken` field of a user QR code URI
+    (`hackillinois://user?userToken=some_token`)
 
 ```json title="Example request"
 {
@@ -483,6 +488,11 @@ Valid values for `status` are `Success`, `InvalidEventId`, `BadUserToken`, `Alre
     "newPoints": 10,
     "totalPoints": 10,
     "status": "Success"
+    "rsvpData": {
+        "id": "github0123456",
+        "isAttending": true,
+        "registrationData": {}
+    }
 }
 ```
 

--- a/documentation/docs/reference/services/Event.md
+++ b/documentation/docs/reference/services/Event.md
@@ -491,7 +491,7 @@ Valid values for `status` are `Success`, `InvalidEventId`, `BadUserToken`, `Alre
     "rsvpData": {
         "id": "github0123456",
         "isAttending": true,
-        "registrationData": {}
+        "registrationData": { ... }
     }
 }
 ```

--- a/services/event/config/config.go
+++ b/services/event/config/config.go
@@ -17,6 +17,8 @@ var CHECKIN_SERVICE string
 
 var PROFILE_SERVICE string
 
+var RSVP_SERVICE string
+
 var EVENT_CHECKIN_TIME_RESTRICTED bool
 
 func Initialize() error {
@@ -50,6 +52,12 @@ func Initialize() error {
 	}
 
 	PROFILE_SERVICE, err = cfg_loader.Get("PROFILE_SERVICE")
+
+	if err != nil {
+		return err
+	}
+
+	RSVP_SERVICE, err = cfg_loader.Get("RSVP_SERVICE")
 
 	if err != nil {
 		return err

--- a/services/event/models/checkin.go
+++ b/services/event/models/checkin.go
@@ -9,9 +9,10 @@ type CheckinRequest struct {
 }
 
 type CheckinResponse struct {
-	NewPoints   int    `default:"-1" json:"newPoints"`
-	TotalPoints int    `default:"-1" json:"totalPoints"`
-	Status      string `json:"status"`
+	NewPoints   int                    `default:"-1" json:"newPoints"`
+	TotalPoints int                    `default:"-1" json:"totalPoints"`
+	Status      string                 `             json:"status"`
+	RsvpData    map[string]interface{} `             json:"rsvpData,omitempty"`
 }
 
 type RedeemEventRequest struct {

--- a/services/event/service/event_service.go
+++ b/services/event/service/event_service.go
@@ -618,5 +618,17 @@ func CheckinUserTokenToEvent(user_token string, event_id string) (*models.Checki
 		return NewCheckinResponseFailed("InvalidEventId"), nil
 	}
 
-	return PerformCheckin(user_id, event_id)
+	rsvp_data, err := GetRsvpData(user_id)
+	if err != nil {
+		return nil, errors.New("Failed to fetch RSVP data")
+	}
+
+	status, err := PerformCheckin(user_id, event_id)
+	if err != nil {
+		return nil, err
+	}
+
+	status.RsvpData = rsvp_data
+
+	return status, nil
 }

--- a/services/event/service/rsvp_service.go
+++ b/services/event/service/rsvp_service.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/HackIllinois/api/common/apirequest"
+	"github.com/HackIllinois/api/services/event/config"
+)
+
+func GetRsvpData(id string) (map[string]interface{}, error) {
+	var rsvp_data map[string]interface{}
+	status, err := apirequest.Get(config.RSVP_SERVICE+"/rsvp/"+id+"/", &rsvp_data)
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, errors.New("Getting RSVP data failed")
+	}
+
+	return rsvp_data, nil
+}

--- a/tests/e2e/events_test/events_test.go
+++ b/tests/e2e/events_test/events_test.go
@@ -31,6 +31,7 @@ var (
 	events_db_name  string
 	profile_db_name string
 	checkin_db_name string
+	rsvp_db_name    string
 )
 
 var TOKEN_SECRET []byte
@@ -77,6 +78,11 @@ func TestMain(m *testing.M) {
 		fmt.Printf("ERROR: %v\n", err)
 		os.Exit(1)
 	}
+	rsvp_db_name, err = cfg.Get("RSVP_DB_NAME")
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
 	ResetDatabase()
 
 	token_secret_string, err := cfg.Get("TOKEN_SECRET")
@@ -96,6 +102,7 @@ func ResetDatabase() {
 	client.Database(events_db_name).Drop(context.Background())
 	client.Database(profile_db_name).Drop(context.Background())
 	client.Database(checkin_db_name).Drop(context.Background())
+	client.Database(rsvp_db_name).Drop(context.Background())
 
 	{
 		// establishes unique id indexes to prevent duplicate documents


### PR DESCRIPTION
I never realized that this was a thing until I realized that `POST /checkin/` did this, and since mobile needs registration data, this allows them to access it without having to request via `GET /registration/USERID/` (which would require to decode the JWT user token)